### PR TITLE
Add missing files to Crashlytics CMakeLists.txt

### DIFF
--- a/crashlytics/CMakeLists.txt
+++ b/crashlytics/CMakeLists.txt
@@ -32,6 +32,8 @@ set(firebase_crashlytics_src
   src/ExceptionHandler.cs
   src/Impl.cs
   src/LoggedException.cs
+  src/Metadata.cs
+  src/MetadataBuilder.cs
   src/StackTraceParser.cs
 )
 


### PR DESCRIPTION
Two C# source files are missing from CMakeLists.txt and cause the build failed.