### PR TITLE
Added user agent string for build source to unity builds.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -52,6 +52,10 @@ option(FIREBASE_INCLUDE_STORAGE
 option(FIREBASE_UNITY_BUILD_TESTS
        "Enable the Firebase Unity Build Tests." OFF)
 
+# This should only be enabled by the GitHub Action build script.
+option(FIREBASE_GITHUB_ACTION_BUILD
+       "Indicates that this build was created from a GitHub Action" OFF)
+
 # These options allow selecting what built outputs go into the CPack zip file
 # as we merge the different platform zip's together for unity package
 # For example: only packing dotnet libraries on linux builds

--- a/app/src/VersionInfoTemplate.cs
+++ b/app/src/VersionInfoTemplate.cs
@@ -22,6 +22,17 @@ internal class VersionInfo {
   /// @brief Retrieves the Firebase Unity SDK version number as a string.
   // "@FIREBASE_UNITY_SDK_VERSION@" is replaced at build time.
   internal static string SdkVersion { get { return "@FIREBASE_UNITY_SDK_VERSION@"; } }
+
+  /// @brief Retrieves a string indicating whether the SDK was built on github.
+  internal static string BuildSource {
+    get {
+#if FIREBASE_GITHUB_ACTION_BUILD
+      return "github_action_built";
+#else
+      return "custom_built";
+#endif
+    }
+  }
 }
 
 }  // namespace Firebase

--- a/app/src/swig/app.i
+++ b/app/src/swig/app.i
@@ -903,6 +903,9 @@ static firebase::AppOptions* AppOptionsLoadFromJsonConfig(const char* config) {
         RegisterLibraryInternal(
             libraryPrefix + "-ver",
             Firebase.Platform.PlatformInformation.RuntimeVersion);
+        // fire-(unity|mono)/<github-action-built|custom_built>
+        RegisterLibraryInternal(
+            libraryPrefix + "-buildsrc", Firebase.VersionInfo.BuildSource);
       }
       // Cache the name so that it can be accessed after the app is disposed.
       newProxy.name = newProxy.NameInternal;


### PR DESCRIPTION
Like the C++ libraries, Unity libraries now have the option to declare
whether they were built from a Github Actions (in other words, whether
they're an official release) or whether they're custom built.