### PR TITLE
Build Crashlytics editor tool

### DIFF
--- a/editor/CMakeLists.txt
+++ b/editor/CMakeLists.txt
@@ -15,7 +15,6 @@
 add_subdirectory(app)
 add_subdirectory(analytics)
 add_subdirectory(auth)
-# TODO(cl/383898177): Waiting for this cl to be synced to Github repo.
-# add_subdirectory(crashlytics)
+add_subdirectory(crashlytics)
 add_subdirectory(dynamic_links)
 add_subdirectory(messaging)


### PR DESCRIPTION
Was disabled due to a bug in code.

Re-enable it after the patch is copied to Github