### PR TITLE
Using variable from config script instead of the input

### DIFF
--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -149,7 +149,7 @@ jobs:
         shell: bash
         run: |
           python scripts/gha/unity_installer.py --install \
-            --platforms ${{ github.event.inputs.platforms }} \
+            --platforms ${{ needs.check_and_prepare.outputs.platform }} \
             --version ${{ matrix.unity_version }}
       - name: Activate Unity license
         timeout-minutes: 10
@@ -197,35 +197,35 @@ jobs:
               --version ${{ matrix.unity_version }}
       - name: Upload Android integration tests artifact
         uses: actions/upload-artifact@v2.2.2
-        if: contains(github.event.inputs.platforms, 'Android') && ${{ !cancelled() }}
+        if: contains(needs.check_and_prepare.outputs.platform, 'Android') && ${{ !cancelled() }}
         with:
           name: testapps-${{ matrix.unity_version }}-Android
           path: testapps-${{ matrix.unity_version }}-all/Android
           retention-days: ${{ env.artifactRetentionDays }}
       - name: Upload iOS integration tests artifact
         uses: actions/upload-artifact@v2.2.2
-        if: contains(github.event.inputs.platforms, 'iOS') && ${{ !cancelled() }}
+        if: contains(needs.check_and_prepare.outputs.platform, 'iOS') && ${{ !cancelled() }}
         with:
           name: testapps-${{ matrix.unity_version }}-iOS
           path: testapps-${{ matrix.unity_version }}-all/iOS
           retention-days: ${{ env.artifactRetentionDays }}
       - name: Upload Linux integration tests artifact
         uses: actions/upload-artifact@v2.2.2
-        if: contains(github.event.inputs.platforms, 'Linux') && ${{ !cancelled() }}
+        if: contains(needs.check_and_prepare.outputs.platform, 'Linux') && ${{ !cancelled() }}
         with:
           name: testapps-${{ matrix.unity_version }}-ubuntu-latest
           path: testapps-${{ matrix.unity_version }}-all/Linux
           retention-days: ${{ env.artifactRetentionDays }}
       - name: Upload macOS integration tests artifact
         uses: actions/upload-artifact@v2.2.2
-        if: contains(github.event.inputs.platforms, 'macOS') && ${{ !cancelled() }}
+        if: contains(needs.check_and_prepare.outputs.platform, 'macOS') && ${{ !cancelled() }}
         with:
           name: testapps-${{ matrix.unity_version }}-macos-latest
           path: testapps-${{ matrix.unity_version }}-all/macOS
           retention-days: ${{ env.artifactRetentionDays }}
       - name: Upload Windows integration tests artifact
         uses: actions/upload-artifact@v2.2.2
-        if: contains(github.event.inputs.platforms, 'Windows') && ${{ !cancelled() }}
+        if: contains(needs.check_and_prepare.outputs.platform, 'Windows') && ${{ !cancelled() }}
         with:
           name: testapps-${{ matrix.unity_version }}-windows-latest
           path: testapps-${{ matrix.unity_version }}-all/Windows

--- a/scripts/gha/print_matrix_configuration.py
+++ b/scripts/gha/print_matrix_configuration.py
@@ -62,8 +62,8 @@ PARAMETERS = {
       },
 
       EXPANDED_KEY: {
-        # "2019.2.8f1", "2021.1.9f1" haven't been verified.
-        "unity_version": ["2017.4.37f1", "2019.2.8f1", "2021.1.9f1"],
+        # TODO: add "2019.4.30f1", "2020.3.19f1" later.
+        "unity_version": ["2017.4.37f1"],
         "android_device": ["android_target", "android_latest", "emulator_target", "emulator_latest", "emulator_32bit"],
         "ios_device": ["ios_min", "ios_target", "ios_latest", "simulator_min", "simulator_target", "simulator_latest"],
       }


### PR DESCRIPTION
### Description
> Provide details of the change, and generalize the change in the PR title above.
1. Using variable from config script instead of the input
2. Remove unsupported Unity version for now

### Type of Change
Place an `x` the applicable box:
- [x] Bug fix. Add the issue # below if applicable.
- [ ] New feature. A non-breaking change which adds functionality.
- [ ] Other, such as a build process or documentation change.
***

