### PR TITLE
Bump up EDM4U version to 1.2.167

### DIFF
--- a/cmake/firebase_unity_version.cmake
+++ b/cmake/firebase_unity_version.cmake
@@ -22,7 +22,7 @@ set(FIREBASE_IOS_POD_VERSION "8.3.0"
 
 # https://github.com/googlesamples/unity-jar-resolver
 set(FIREBASE_UNITY_JAR_RESOLVER_VERSION
-  "1.2.166"
+  "1.2.167"
    CACHE STRING
   "Version tag of Play Services Resolver to download and use (no trailing .0)"
 )

--- a/external/CMakeLists.txt
+++ b/external/CMakeLists.txt
@@ -115,40 +115,49 @@ if(FIREBASE_INCLUDE_UNITY)
     "${JAR_RESOLVER_DLL_DIR}/Google.VersionHandler.dll"
   )
 
-  unity_pack_cs(google_version_handler_cs
-    PACK_PATH "ExternalDependencyManager/Editor"
-  )
-
   mono_add_external_dll(google_version_handlerimpl_cs
-    "${JAR_RESOLVER_DLL_DIR}/Google.VersionHandlerImpl_v${FIREBASE_UNITY_JAR_RESOLVER_VERSION}.dll"
-  )
-
-  unity_pack_cs(google_version_handlerimpl_cs
-    PACK_PATH "ExternalDependencyManager/Editor"
+    "${JAR_RESOLVER_DLL_DIR}/${FIREBASE_UNITY_JAR_RESOLVER_VERSION}/Google.VersionHandlerImpl.dll"
   )
 
   mono_add_external_dll(google_jar_resolver_cs
-    "${JAR_RESOLVER_DLL_DIR}/Google.JarResolver_v${FIREBASE_UNITY_JAR_RESOLVER_VERSION}.dll"
-  )
-
-  unity_pack_cs(google_jar_resolver_cs
-    PACK_PATH "ExternalDependencyManager/Editor"
+    "${JAR_RESOLVER_DLL_DIR}/${FIREBASE_UNITY_JAR_RESOLVER_VERSION}/Google.JarResolver.dll"
   )
 
   mono_add_external_dll(google_ios_resolver_cs
-    "${JAR_RESOLVER_DLL_DIR}/Google.IOSResolver_v${FIREBASE_UNITY_JAR_RESOLVER_VERSION}.dll"
-  )
-
-  unity_pack_cs(google_ios_resolver_cs
-    PACK_PATH "ExternalDependencyManager/Editor"
+    "${JAR_RESOLVER_DLL_DIR}/${FIREBASE_UNITY_JAR_RESOLVER_VERSION}/Google.IOSResolver.dll"
   )
 
   mono_add_external_dll(google_package_manager_resolver_cs
-    "${JAR_RESOLVER_DLL_DIR}/Google.PackageManagerResolver_v${FIREBASE_UNITY_JAR_RESOLVER_VERSION}.dll"
+    "${JAR_RESOLVER_DLL_DIR}/${FIREBASE_UNITY_JAR_RESOLVER_VERSION}/Google.PackageManagerResolver.dll"
+  )
+
+  # TODO: Pack everything under ${GOOGLE_UNITY_JAR_RESOLVER_SOURCE_DIR}/exploded/Assets/
+  # Temporarily group these `unity_package_cs` call together before we change to
+  # package the entire folder.
+  unity_pack_cs(google_version_handler_cs
+    PACK_PATH "ExternalDependencyManager/Editor/"
+  )
+
+  unity_pack_cs(google_version_handlerimpl_cs
+    PACK_PATH "ExternalDependencyManager/Editor/${FIREBASE_UNITY_JAR_RESOLVER_VERSION}"
+  )
+
+  unity_pack_cs(google_jar_resolver_cs
+    PACK_PATH "ExternalDependencyManager/Editor/${FIREBASE_UNITY_JAR_RESOLVER_VERSION}"
+  )
+
+  unity_pack_cs(google_ios_resolver_cs
+    PACK_PATH "ExternalDependencyManager/Editor/${FIREBASE_UNITY_JAR_RESOLVER_VERSION}"
   )
 
   unity_pack_cs(google_package_manager_resolver_cs
-    PACK_PATH "ExternalDependencyManager/Editor"
+    PACK_PATH "ExternalDependencyManager/Editor/${FIREBASE_UNITY_JAR_RESOLVER_VERSION}"
+  )
+
+  unity_pack_file(
+    "${JAR_RESOLVER_DLL_DIR}/external-dependency-manager_version-${FIREBASE_UNITY_JAR_RESOLVER_VERSION}_manifest.txt"
+    "${JAR_RESOLVER_DLL_DIR}/external-dependency-manager_version-${FIREBASE_UNITY_JAR_RESOLVER_VERSION}_manifest.txt.meta"
+    PACK_PATH "ExternalDependencyManager/Editor/"
   )
 
   unity_pack_file(

--- a/unity_packer/exports.json
+++ b/unity_packer/exports.json
@@ -187,7 +187,7 @@
         "manifest" : {
           "unity": "2017.1",
           "dependencies": {
-            "com.google.external-dependency-manager" : "1.2.166"
+            "com.google.external-dependency-manager" : "1.2.167"
           }
         }
       }


### PR DESCRIPTION
### Description
EDM4U 1.2.167 changed folder structure.  Updated CMakeLists.txt to
reflect the change.  

Also group all the `unity_pack_cs` and
`unity_pack_file` call together to be migrated to `unity_pack_folder`

### Testing
> Describe how you've tested these changes.

Ran './build_macos` and check the content in the produced `zip` file. 

### Type of Change
Place an `x` the applicable box:
- [ ] Bug fix. Add the issue # below if applicable.
- [ ] New feature. A non-breaking change which adds functionality.
- [X] Other, such as a build process or documentation change.
***

