### PR TITLE
fix linux build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -247,7 +247,7 @@ set(PROJECT_LIST_HEADER "#define PROJECT_LIST(X)")
 list(APPEND PROJECT_LIST_HEADER "  X(App)")
 
 # Include Firebase editor tools.
-if (DESKTOP AND FIREBASE_INCLUDE_EDITOR_TOOL)
+if (DESKTOP AND APPLE AND FIREBASE_INCLUDE_EDITOR_TOOL)
   add_subdirectory(editor)
 endif()
 

--- a/cmake/FindUnity.cmake
+++ b/cmake/FindUnity.cmake
@@ -138,27 +138,7 @@ if(FIREBASE_INCLUDE_UNITY)
           "${UNITY_CSHARP_BUILD_EXE}" NAME
       )
 
-      # On Linux, Unity's mono distribution can fail to execute build tools in a
-      # non-clean environment so wrap in a script that clears the environment.
-      if(CMAKE_HOST_UNIX AND NOT CMAKE_HOST_APPLE)
-        set(UNITY_CSHARP_BUILD_WRAPPER_DIR
-          "${CMAKE_CURRENT_BINARY_DIR}/unity_csharp_build_wrapper"
-        )
-        set(UNITY_CSHARP_BUILD_WRAPPER
-          "${UNITY_CSHARP_BUILD_WRAPPER_DIR}/${UNITY_CSHARP_BUILD_EXE_NAME}"
-        )
-        file(MAKE_DIRECTORY "${UNITY_CSHARP_BUILD_WRAPPER_DIR}")
-        # Copy the build script to preserve the executable bit.
-        file(COPY "${UNITY_CSHARP_BUILD_EXE}"
-          DESTINATION "${UNITY_CSHARP_BUILD_WRAPPER_DIR}"
-        )
-        file(WRITE "${UNITY_CSHARP_BUILD_WRAPPER}"
-          "#!/bin/sh\nenv -i ${UNITY_CSHARP_BUILD_EXE} \$@\n"
-        )
-        set(UNITY_CSHARP_BUILD_EXE "${UNITY_CSHARP_BUILD_WRAPPER}"
-          CACHE STRING "" FORCE
-        )
-      elseif(CMAKE_HOST_WIN32)
+      if(CMAKE_HOST_WIN32)
         # Mono that is packaged with unity has a bug in resgen.bat where it
         # incorrectly forwards arguments. Resgen.bat gets passed an argument
         # like 'a,b' and incorrectly forwards it as 'a b'. Copy the mono folder

--- a/firestore/CMakeLists.txt
+++ b/firestore/CMakeLists.txt
@@ -66,7 +66,7 @@ set(firebase_firestore_src
   src/ListenerRegistration.cs
   src/ListenerRegistrationMap.cs
   src/LoadBundleTaskProgress.cs
-  src/Metadatachanges.cs
+  src/MetadataChanges.cs
   src/MonoPInvokeCallbackAttribute.cs
   src/Query.cs
   src/QuerySnapshot.cs


### PR DESCRIPTION
### Description
+ Linux mono wrapper script doesn't work for newer version of Unity (>2019), comment out for now
   Unity modify the folder structure under MonoBleedingEdge folder, remove mono from bin and only leave xbuild there, which would fail the file size check during wrapping the env. The script only looked under /bin/ folder, but the actual working one is the msbuild under /lib/ folder
+ Firestore one file name failed the case sensitive check on linux
+ Only build editor on mac desktop
***
### Testing
Local and GHA
***

### Type of Change
Place an `x` the applicable box:
- [ ] Bug fix. Add the issue # below if applicable.
- [ ] New feature. A non-breaking change which adds functionality.
- [ ] Other, such as a build process or documentation change.
***

