### PR TITLE
Fix the Android dependencies for Crashlytics and Messaging

### DIFF
--- a/cmake/android_dependencies.cmake
+++ b/cmake/android_dependencies.cmake
@@ -28,6 +28,11 @@ set(FIREBASE_AUTH_ANDROID_DEPS
     "com.google.firebase:firebase-analytics:19.0.0"
 )
 
+set(FIREBASE_CRASHLYTICS_ANDROID_DEPS
+    "com.google.firebase:firebase-crashlytics-ndk:18.2.4"
+    "com.google.firebase:firebase-analytics:19.0.0"
+)
+
 set(FIREBASE_DATABASE_ANDROID_DEPS
     "com.google.firebase:firebase-database:20.0.0"
     "com.google.firebase:firebase-analytics:19.0.0"
@@ -46,6 +51,7 @@ set(FIREBASE_FUNCTIONS_ANDROID_DEPS
 set(FIREBASE_MESSAGING_ANDROID_DEPS
     "com.google.firebase:firebase-messaging:22.0.0"
     "com.google.firebase:firebase-analytics:19.0.0"
+    "com.google.firebase:firebase-iid:21.1.0"
 )
 
 set(FIREBASE_REMOTE_CONFIG_ANDROID_DEPS

--- a/crashlytics/CMakeLists.txt
+++ b/crashlytics/CMakeLists.txt
@@ -97,7 +97,7 @@ if (FIREBASE_INCLUDE_UNITY)
     IOS_DEPS
       "Firebase/Crashlytics"
     ANDROID_DEPS
-      ${FIREBASE_AUTH_ANDROID_DEPS}
+      ${FIREBASE_CRASHLYTICS_ANDROID_DEPS}
     ANDROID_SPEC
       "crashlytics"
   )


### PR DESCRIPTION
Messaging has an additional dependency on iid, and Crashlytics was missing

### Description

Messaging depends on iid in Android, so add it to the set of dependencies.
Crashlytics was incorrectly using Auth, so added the Crashlytics dependencies.
***
### Testing
> Describe how you've tested these changes.

Building for Android, and checking the resulting Dependencies.xml files
***

### Type of Change
Place an `x` the applicable box:
- [ ] Bug fix. Add the issue # below if applicable.
- [ ] New feature. A non-breaking change which adds functionality.
- [x] Other, such as a build process or documentation change.
***

