### PR TITLE
Fix python issue on macOS 12.3 or later #152

### DIFF
--- a/editor/app/src/PythonExecutor.cs
+++ b/editor/app/src/PythonExecutor.cs
@@ -124,7 +124,7 @@ namespace Firebase.Editor {
                 if (UnityEngine.SystemInfo.operatingSystemFamily == OperatingSystemFamily.MacOSX)
                 {
                     // Currently Unity API return Fixed format, so just remove that part, may have better solution
-                    var versionCodeString = UnityEngine.SystemInfo.operatingSystem.Replace("Mac OS X ", "").Split('.').First();
+                    var versionCodeString = UnityEngine.SystemInfo.operatingSystem.Replace("Mac OS X ", "").Split('.')[0];
                     // Default is 10, due to before Big Sur is 10.x
                     int versionCode = 10;
                     if (int.TryParse(versionCodeString, out versionCode))

--- a/editor/app/src/PythonExecutor.cs
+++ b/editor/app/src/PythonExecutor.cs
@@ -114,7 +114,34 @@ namespace Firebase.Editor {
             }
         }
 
-        private const string PYTHON_INTERPRETER = "python3";
+        private static string PYTHON_INTERPRETER
+        {
+            get
+            {
+                // Default using 'python'
+                string result = "python";
+
+                if (UnityEngine.SystemInfo.operatingSystemFamily == OperatingSystemFamily.MacOSX)
+                {
+                    // Currently Unity API return Fixed format, so just remove that part, may have better solution
+                    var versionCodeString = UnityEngine.SystemInfo.operatingSystem.Replace("Mac OS X ", "").Split('.').First();
+                    // Default is 10, due to before Big Sur is 10.x
+                    int versionCode = 10;
+                    if (int.TryParse(versionCodeString, out versionCode))
+                    {
+                        // If versionCode >= 12 means it is macOS Monterey, we can use python3 instead
+                        // Since after 12.3 there is no 'python' inside /usr/bin, Apple make it to two different files 'python3' and 'python2.7' (and 'python2.7' may be removed in future macOS release)
+                        if (versionCode >= 12)
+                        {
+                            result = "python3";
+                        }
+                    }
+                }
+
+                return result;
+            }
+        }
+
 
         /// <summary>
         /// Get the executable to run the script.

--- a/editor/app/src/PythonExecutor.cs
+++ b/editor/app/src/PythonExecutor.cs
@@ -114,7 +114,7 @@ namespace Firebase.Editor {
             }
         }
 
-        private const string PYTHON_INTERPRETER = "python";
+        private const string PYTHON_INTERPRETER = "python3";
 
         /// <summary>
         /// Get the executable to run the script.


### PR DESCRIPTION
### Description
> Provide details of the change, and generalize the change in the PR title above.

Auto detect the OS family and OS Version and change the return value of `PYTHON_INTERPRETER` property (also change the member type of this member), because of the new version macOS(after 12.3) will no longer shipped the Python2.

***
> Describe how you've tested these changes.

Tested on macOS 12.3 beta2, macOS 12.2, with Unity Editor 2020.3.x, Unity 2021.2.x
Not tested on earlier macOS version and earlier Unity Editor version.

***

### Type of Change
Place an `x` the applicable box:
- [x] Bug fix. Add the issue # below if applicable.
- [ ] New feature. A non-breaking change which adds functionality.
- [ ] Other, such as a build process or documentation change.
***
Due to #154, the 'python' binary doesn't shipped with macOS after 12.3 (which is replace to 'python2.7' and 'python3').
So the Firebase.Editor script needs to change the binary file name if the macOS version is greater than 12.3. 
(Currently, just detect is the os version greater than 12 or not due to macOS 12 already shipped 'python3')

