### PR TITLE
Add logic to generate the Crashlytics proguard file

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,7 +40,7 @@ option(FIREBASE_INCLUDE_AUTH
        ${FIREBASE_INCLUDE_LIBRARY_DEFAULT})
 option(FIREBASE_INCLUDE_CRASHLYTICS
        "Include the Firebase Crashlytics library."
-       OFF)
+       ${FIREBASE_INCLUDE_LIBRARY_DEFAULT})
 option(FIREBASE_INCLUDE_DATABASE
        "Include the Firebase Realtime Database library."
        ${FIREBASE_INCLUDE_LIBRARY_DEFAULT})

--- a/build_android.sh
+++ b/build_android.sh
@@ -80,7 +80,7 @@ mkdir -p android_build
 pushd android_build
 
 # Configure cmake with option value
-cmake .. ${CMAKE_OPTIONS} -DANDROID_ABI=armeabi-v7a
+cmake .. ${CMAKE_OPTIONS} -DANDROID_ABI=armeabi-v7a "$@"
 check_exit_code $?
 
 # Build the SDK

--- a/crashlytics/CMakeLists.txt
+++ b/crashlytics/CMakeLists.txt
@@ -14,6 +14,8 @@
 
 # CMake file for the firebase crashlytics library
 
+include(build_shared)
+
 # Only for unity builds
 if(NOT FIREBASE_INCLUDE_UNITY)
   return()

--- a/crashlytics/src/cpp/CMakeLists.txt
+++ b/crashlytics/src/cpp/CMakeLists.txt
@@ -67,6 +67,28 @@ target_compile_definitions(firebase_crashlytics
     -DINTERNAL_EXPERIMENTAL=1
 )
 
+# Generate the Proguard file
+if(ANDROID)
+  set(FIREBASE_CPP_CRASHLYTICS_PROGUARD ${CMAKE_CURRENT_BINARY_DIR}/crashlytics.pro
+      CACHE FILEPATH "Proguard file for Crashlytics" FORCE)
+
+  add_custom_command(
+    OUTPUT ${FIREBASE_CPP_CRASHLYTICS_PROGUARD}
+    COMMAND strings $<TARGET_FILE:firebase_crashlytics> |
+            grep %PG% |
+            sed -r 'sI/I.Ig' |
+            sed -r 's/%PG%/-keep,includedescriptorclasses public class /g'
+            > ${FIREBASE_CPP_CRASHLYTICS_PROGUARD}
+    DEPENDS firebase_crashlytics
+    COMMENT "Generating Crashlytics Proguard file."
+  )
+
+  add_custom_target(
+    FIREBASE_CPP_CRASHLYTICS_PROGUARD
+    DEPENDS ${FIREBASE_CPP_CRASHLYTICS_PROGUARD}
+  )
+endif()
+
 if(IOS)
  # Enable Automatic Reference Counting (ARC).
   set_property(


### PR DESCRIPTION
### Description
> Provide details of the change, and generalize the change in the PR title above.

Add the special logic needed to generate the Crashlytics proguard file. This is needed since Crashlytics does not exist in the C++ repo like the other products do.
***
### Testing
> Describe how you've tested these changes.


Built for Android locally
***

### Type of Change
Place an `x` the applicable box:
- [ ] Bug fix. Add the issue # below if applicable.
- [ ] New feature. A non-breaking change which adds functionality.
- [x] Other, such as a build process or documentation change.
***

