### PR TITLE
Cancel unnecessary workflow run

### DIFF
--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -124,10 +124,6 @@ jobs:
         fi
     ### If it's not a defined trigger, cancel workflow
     ### e.g. Triggered by non-"test-request" label; triggered by not merged PR close event.
-    - name: Test Trigger
-      run: |
-        echo ${{ steps.set_outputs.outputs.trigger }}
-        echo ${{ !steps.set_outputs.outputs.trigger }}
     - name: Cancel workflow
       if: ${{ !steps.set_outputs.outputs.trigger }}
       uses: andymckay/cancel-action@0.2

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -124,6 +124,10 @@ jobs:
         fi
     ### If it's not a defined trigger, cancel workflow
     ### e.g. Triggered by non-"test-request" label; triggered by not merged PR close event.
+    - name: Test Trigger
+      run: |
+        echo ${{ steps.set_outputs.outputs.trigger }}
+        echo ${{ !steps.set_outputs.outputs.trigger }}
     - name: Cancel workflow
       if: ${{ !steps.set_outputs.outputs.trigger }}
       uses: andymckay/cancel-action@0.2

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -116,7 +116,7 @@ jobs:
             else
               echo "::set-output name=requested_tests::expanded"
             fi
-          elif [[ "${{ github.event.action }}" == "closed" && ${{ github.event.pull_request.merged == true }} ]]; then
+          elif [[ "${{ github.event.action }}" == "closed" && ${{ github.event.pull_request.merged }} = true ]]; then
             echo "::set-output name=trigger::postsubmit_trigger"
             echo "::set-output name=pr_number::${{ github.event.pull_request.number }}"
             echo "::set-output name=requested_tests::auto"


### PR DESCRIPTION
### Description
Close event trigger workflow incorrectly. PR is not merged, but the workflow didn't cancel itself as excepted.
https://github.com/firebase/firebase-unity-sdk/actions/runs/1861582366

### Testing
Now workflow cancel itself correctly: 
https://github.com/firebase/firebase-unity-sdk/runs/5241454052?check_suite_focus=true

***

### Type of Change
Place an `x` the applicable box:
- [ ] Bug fix. Add the issue # below if applicable.
- [ ] New feature. A non-breaking change which adds functionality.
- [x] Other, such as a build process or documentation change.
***

