### PR TITLE
Fix cancel workflow run

### DIFF
--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -116,7 +116,7 @@ jobs:
             else
               echo "::set-output name=requested_tests::expanded"
             fi
-          elif [[ "${{ github.event.action }}" == "closed" && ${{ github.event.pull_request.merged }} = true ]]; then
+          elif [[ "${{ github.event.action }}" == "closed" && "${{ github.event.pull_request.merged == true}}" == "true"  ]]; then
             echo "::set-output name=trigger::postsubmit_trigger"
             echo "::set-output name=pr_number::${{ github.event.pull_request.number }}"
             echo "::set-output name=requested_tests::auto"


### PR DESCRIPTION
### Description
[Yesterday's fix](https://github.com/firebase/firebase-unity-sdk/pull/183) causes an error, because certain GitHub variable doesn't exist with non-PR trigger:
https://github.com/firebase/firebase-unity-sdk/runs/5252098713?check_suite_focus=true

Now using this statement to ensure it works: `"${{ github.event.pull_request.merged == true}}" == "true"`
***
### Testing
PR closed but not merged - workflow canceled: https://github.com/firebase/firebase-unity-sdk/actions/runs/1866039558
Manual  trigger - workflow running: https://github.com/firebase/firebase-unity-sdk/actions/runs/1866043270
Label trigger - workflow running: https://github.com/firebase/firebase-unity-sdk/actions/runs/1866063380

[replace this line]: # (Describe your testing in detail.)
***

### Type of Change
Place an `x` the applicable box:
- [ ] Bug fix. Add the issue # below if applicable.
- [ ] New feature. A non-breaking change which adds functionality.
- [x] Other, such as a build process or documentation change.
***

