### PR TITLE
Don't report test error if it's indeed build errors  & disable some failed testapps

### DIFF
--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -302,14 +302,14 @@ jobs:
             echo "__SUMMARY_MISSING__" > build-results-${{ matrix.unity_version }}-${{matrix.os}}-${{ matrix.platform }}.log.json
           fi
       - name: Upload build results artifact
-        uses: actions/upload-artifact@v2.2.2
+        uses: actions/upload-artifact@v3
         if: ${{ !cancelled() }}
         with:
           name: log-artifact
           path: build-results-${{ matrix.unity_version }}-${{matrix.os}}-${{ matrix.platform }}*
           retention-days: ${{ env.artifactRetentionDays }}
       - name: Upload Android integration tests artifact
-        uses: actions/upload-artifact@v2.2.2
+        uses: actions/upload-artifact@v3
         if: contains(matrix.platform, 'Android') && ${{ !cancelled() }}
         with:
           name: testapps-${{ matrix.unity_version }}-${{matrix.os}}-Android
@@ -320,7 +320,7 @@ jobs:
         shell: bash
         run: rm -rf testapps-${{ matrix.unity_version }}-${{matrix.os}}-${{ needs.check_and_prepare.outputs.platform }}/Android || true
       - name: Upload iOS integration tests artifact
-        uses: actions/upload-artifact@v2.2.2
+        uses: actions/upload-artifact@v3
         if: contains(matrix.platform, 'iOS') && ${{ !cancelled() }}
         with:
           name: testapps-${{ matrix.unity_version }}-${{matrix.os}}-iOS
@@ -331,7 +331,7 @@ jobs:
         shell: bash
         run: rm -rf testapps-${{ matrix.unity_version }}-${{matrix.os}}-${{ needs.check_and_prepare.outputs.platform }}/iOS || true
       - name: Upload Linux integration tests artifact
-        uses: actions/upload-artifact@v2.2.2
+        uses: actions/upload-artifact@v3
         if: contains(matrix.platform, 'Linux') && ${{ !cancelled() }}
         with:
           name: testapps-${{ matrix.unity_version }}-${{matrix.os}}-ubuntu-latest
@@ -342,7 +342,7 @@ jobs:
         shell: bash
         run: rm -rf testapps-${{ matrix.unity_version }}-${{matrix.os}}-${{ needs.check_and_prepare.outputs.platform }}/Linux || true
       - name: Upload macOS integration tests artifact
-        uses: actions/upload-artifact@v2.2.2
+        uses: actions/upload-artifact@v3
         if: contains(matrix.platform, 'macOS') && ${{ !cancelled() }}
         with:
           name: testapps-${{ matrix.unity_version }}-${{matrix.os}}-macos-latest
@@ -353,7 +353,7 @@ jobs:
         shell: bash
         run: rm -rf testapps-${{ matrix.unity_version }}-${{matrix.os}}-${{ needs.check_and_prepare.outputs.platform }}/macOS || true
       - name: Upload Windows integration tests artifact
-        uses: actions/upload-artifact@v2.2.2
+        uses: actions/upload-artifact@v3
         if: contains(matrix.platform, 'Windows') && ${{ !cancelled() }}
         with:
           name: testapps-${{ matrix.unity_version }}-${{matrix.os}}-windows-latest
@@ -365,7 +365,7 @@ jobs:
         run: rm -rf testapps-${{ matrix.unity_version }}-${{matrix.os}}-${{ needs.check_and_prepare.outputs.platform }}/Windows || true
       - name: Download log artifacts
         if: ${{ needs.check_and_prepare.outputs.pr_number && failure() && !cancelled() }}
-        uses: actions/download-artifact@v2.0.8
+        uses: actions/download-artifact@v3
         with:
           path: test_results
           name: log-artifact
@@ -405,7 +405,7 @@ jobs:
         with:
           ref: ${{needs.check_and_prepare.outputs.github_ref}}
       - name: Download Desktop integration tests artifact
-        uses: actions/download-artifact@v2.0.8
+        uses: actions/download-artifact@v3
         with:
           path: testapps
           name: testapps-${{ matrix.unity_version }}-${{ matrix.build_os }}-${{ matrix.os }}
@@ -428,19 +428,20 @@ jobs:
         if: ${{ !cancelled() }}
         shell: bash
         run: |
-          if [ ! -f testapps/test-results-${{ matrix.unity_version }}-${{ matrix.build_os }}-${{ matrix.os }}-desktop.log.json ]; then
+          # If testapps do not exist, then it's a build error not test error. 
+          if [ -d "testapps/testapps-${{ matrix.unity_version }}-${{ matrix.build_os }}-${{ matrix.os }}" &&  ! -f testapps/test-results-${{ matrix.unity_version }}-${{ matrix.build_os }}-${{ matrix.os }}-desktop.log.json ]; then
             mkdir -p testapps && echo "__SUMMARY_MISSING__" > testapps/test-results-${{ matrix.unity_version }}-${{ matrix.build_os }}-${{ matrix.os }}-desktop.log.json
           fi
       - name: Upload Desktop test results artifact
         if: ${{ !cancelled() }}
-        uses: actions/upload-artifact@v2.2.2
+        uses: actions/upload-artifact@v3
         with:
           name: log-artifact
           path: testapps/test-results-${{ matrix.unity_version }}-${{ matrix.build_os }}-${{ matrix.os }}-desktop*
           retention-days: ${{ env.artifactRetentionDays }}
       - name: Download log artifacts
         if: ${{ needs.check_and_prepare.outputs.pr_number && failure() && !cancelled() }}
-        uses: actions/download-artifact@v2.0.8
+        uses: actions/download-artifact@v3
         with:
           path: test_results
           name: log-artifact
@@ -492,7 +493,7 @@ jobs:
           echo "::set-output name=device_type::$( python scripts/gha/print_matrix_configuration.py -k ${{ matrix.mobile_device }} -get_device_type)"
           echo "::set-output name=device_platform::$( python scripts/gha/print_matrix_configuration.py -k ${{ matrix.mobile_device }} -get_device_platform)"
       - name: Download Desktop integration tests artifact
-        uses: actions/download-artifact@v2.0.8
+        uses: actions/download-artifact@v3
         with:
           path: testapps
           name: testapps-${{ matrix.unity_version }}-${{ matrix.build_os }}-${{ steps.device-info.outputs.device_platform }}
@@ -524,19 +525,20 @@ jobs:
         if: ${{ !cancelled() }}
         shell: bash
         run: |
-          if [ ! -f testapps/test-results-${{ matrix.unity_version }}-${{ matrix.build_os }}-${{ matrix.mobile_device }}-mobile.log.json ]; then
+          # If testapps do not exist, then it's a build error not test error. 
+          if [ -d "testapps/testapps-${{ matrix.unity_version }}-${{ matrix.build_os }}-${{ steps.device-info.outputs.device_platform }}" && ! -f testapps/test-results-${{ matrix.unity_version }}-${{ matrix.build_os }}-${{ matrix.mobile_device }}-mobile.log.json ]; then
             mkdir -p testapps && echo "__SUMMARY_MISSING__" > testapps/test-results-${{ matrix.unity_version }}-${{ matrix.build_os }}-${{ matrix.mobile_device }}-mobile.log.json
           fi
       - name: Upload Mobile test results artifact
         if: ${{ !cancelled() }}
-        uses: actions/upload-artifact@v2.2.2
+        uses: actions/upload-artifact@v3
         with:
           name: log-artifact
           path: testapps/test-results-${{ matrix.unity_version }}-${{ matrix.build_os }}-${{ matrix.mobile_device }}-mobile*
           retention-days: ${{ env.artifactRetentionDays }}
       - name: Download log artifacts
         if: ${{ needs.check_and_prepare.outputs.pr_number && failure() && !cancelled() }}
-        uses: actions/download-artifact@v2.0.8
+        uses: actions/download-artifact@v3
         with:
           path: test_results
           name: log-artifact
@@ -575,7 +577,7 @@ jobs:
       - name: Install python deps
         run: pip install -r scripts/gha/requirements.txt
       - name: Download log artifacts
-        uses: actions/download-artifact@v2.0.8
+        uses: actions/download-artifact@v3
         with:
           path: test_results
           name: log-artifact
@@ -600,16 +602,10 @@ jobs:
       - name: Update Daily Report
         if: needs.check_and_prepare.outputs.trigger == 'scheduled_trigger'
         run: |
-          if [[ "${{ github.event.inputs.test_pull_request }}" == "nightly-packaging" ]]; then
-            additional_flags=(--build_against sdk)
-          else
-            additional_flags=(--build_against repo)
-          fi
           python scripts/gha/it_workflow.py --stage report \
             --token ${{github.token}} \
             --actor ${{github.actor}} \
             --commit ${{needs.check_and_prepare.outputs.github_ref}} \
-            --run_id ${{github.run_id}} \
-            ${additional_flags[*]}
+            --run_id ${{github.run_id}} 
       - name: Summarize results into GitHub log
         run: python scripts/gha/summarize_test_results.py --dir test_results --github_log

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -209,7 +209,7 @@ jobs:
   trigger_integration_tests:
     # Trigger the integration_tests workflow.
     needs: [package_sdks]
-    if: (github.event.inputs.skipIntegrationTests == 0 || github.event.inputs.skipIntegrationTests == '') && !cancelled()
+    if: (github.event.inputs.skipIntegrationTests == 0 || github.event.inputs.skipIntegrationTests == '') && !cancelled() && !failure()
     runs-on: ubuntu-latest
     steps:
     - name: Checkout repo

--- a/scripts/gha/print_matrix_configuration.py
+++ b/scripts/gha/print_matrix_configuration.py
@@ -67,9 +67,10 @@ PARAMETERS = {
       }
     },
     "config": {
-      "platform": "Windows,macOS,Linux,Android,iOS",
-      "apis": "analytics,auth,crashlytics,database,dynamic_links,functions,installations,messaging,remote_config,storage",
-      "apis": "analytics,auth,crashlytics,database,dynamic_links,firestore,functions,installations,messaging,remote_config,storage",
+      "platform": "Windows,macOS,Linux,iOS",
+      # "platform": "Windows,macOS,Linux,Android,iOS",
+      "apis": "analytics,auth,crashlytics,database,functions,installations,remote_config",
+      # "apis": "analytics,auth,crashlytics,database,dynamic_links,firestore,functions,installations,messaging,remote_config,storage",
       "mobile_test_on": "real,virtual"
     }
   },

--- a/scripts/gha/summarize_test_results.py
+++ b/scripts/gha/summarize_test_results.py
@@ -238,6 +238,7 @@ def summarize_logs(dir, markdown=False, github_log=False):
           success_or_only_flakiness = False
           log_data.setdefault(testapp, {}).setdefault("test", {}).setdefault("errors", []).append(configs)
         for (testapp, failures) in log_reader_data["failures"].items():
+          success_or_only_flakiness = False
           log_data.setdefault(testapp, {}).setdefault("test", {}).setdefault("failures", []).append(configs)
           # for (test, _) in failures["failed_tests"].items():
           #   success_or_only_flakiness = False
@@ -360,7 +361,7 @@ def reorganize_configs(configs):
 #     ['ubuntu', 'windows']
 #     -> ['2/3 os: ubuntu,windows': ]
 def combine_configs(error_configs, all_configs):
-  logging.info("error_configs: %s; all_configs: %s", error_configs, all_configs)
+  # logging.info("error_configs: %s; all_configs: %s", error_configs, all_configs)
   for i in range(len(error_configs)):
     error_configs[i] = combine_config(error_configs[i], all_configs[i], i)
   return error_configs
@@ -368,7 +369,7 @@ def combine_configs(error_configs, all_configs):
 
 def combine_config(config, config_value, k):
   config_before_combination = config.copy()
-  logging.info("config: %s; config_value: %s", config, config_value)
+  # logging.info("config: %s; config_value: %s", config, config_value)
   config_name = BUILD_CONFIGS[k]
   # if certain config failed for all values, add message "All *"
   if len(config_value) > 1 and len(config) == len(config_value):


### PR DESCRIPTION
### Description
0. updated artifact related action version
1. If packaging workflow failed, don't run integeration test workflow. [e.g.](https://github.com/firebase/firebase-cpp-sdk/runs/5446230846?check_suite_focus=true)
2. If build testapps job failed (no testapp artifacts), don't report "missing log" test error. [e.g.](https://github.com/firebase/firebase-cpp-sdk/runs/5420852601?check_suite_focus=true#step:4:13)

Will have followup design about passing failure jobs info to next jobs.
***
### Testing
See the comment below
***

### Type of Change
Place an `x` the applicable box:
- [ ] Bug fix. Add the issue # below if applicable.
- [ ] New feature. A non-breaking change which adds functionality.
- [x] Other, such as a build process or documentation change.
***

#### Notes
- Bug fixes and feature changes require an update to the `Release Notes` section of `release_build_files/readme.md`.
- Read the contribution guidelines [CONTRIBUTING.md](https://github.com/firebase/firebase-cpp-sdk/blob/main/CONTRIBUTING.md).
- Changes to the public API require an internal API review. If you'd like to help us make Firebase APIs better, please propose your change in a feature request so that we can discuss it together.
