### PR TITLE
Comment in TestAuthIntegration about the required security rules

### DIFF
--- a/firestore/testapp/Assets/Firebase/Sample/Firestore/UIHandlerAutomated.cs
+++ b/firestore/testapp/Assets/Firebase/Sample/Firestore/UIHandlerAutomated.cs
@@ -1706,6 +1706,23 @@ namespace Firebase.Sample.Firestore {
       });
     }
 
+    /*
+    Anonymous authentication must be enabled for TestAuthIntegration to pass.
+    
+    Also, the following security rules are required for TestAuthIntegrationt to pass:
+    
+    rules_version='2'
+    service cloud.firestore {
+      match /databases/{database}/documents {
+        match /{somePath=**}/{collection}/{document} {
+          allow read, write: if collection != 'private';
+        }
+        match /private/{document=**} {
+          allow read, write: if request.auth != null;
+        }
+      }
+    }
+    */
     Task TestAuthIntegration() {
       return Async(() => {
         var firebaseAuth = Firebase.Auth.FirebaseAuth.DefaultInstance;


### PR DESCRIPTION
`TestAuthIntegration` requires a specific Security Rules setup in the Firestore console. This PR adds a comment to document this requirement. Without this setup, the test will erroneously fail.