### PR TITLE
swig_fix.py: fix the ignore path for Firestore's exception checks

### DIFF
--- a/cmake/swig_fix.py
+++ b/cmake/swig_fix.py
@@ -156,7 +156,7 @@ def get_transformations(namespace):
           swig_post_process.SWIGEnumPostProcessing(),
           NamespaceCMethodsCMake(namespace),
           swig_post_process.ReplaceExceptionChecks(
-              'AppUtil', ['firebase/firestore/client/unity']),
+              'AppUtil', ['Firebase.Firestore.cs']),
           swig_post_process.FixSealedClasses(),
           swig_post_process.InternalMethodsToInternalVisibility(),
           swig_post_process.RenameAsyncMethods(),


### PR DESCRIPTION
This fixes the "exception propagation" issue in Firestore, where C++ exceptions were not propagating up to C# exceptions.

Googlers can see b/220897535 for details.