### PR TITLE
Update the Dynamic Links testapp to handle Windows and Linux

### DIFF
--- a/dynamic_links/testapp/Assets/Firebase/Sample/DynamicLinks/UIHandlerAutomated.cs
+++ b/dynamic_links/testapp/Assets/Firebase/Sample/DynamicLinks/UIHandlerAutomated.cs
@@ -105,7 +105,8 @@ namespace Firebase.Sample.DynamicLinks {
               differences.Add(String.Format(
                   "{0}: \n" +
                   "  Expected: {1}\n" +
-                  "  Actual: {2}", key, expectedParams[key], resultParams[key]));
+                  "  Actual: {2}", key, expectedParams[key],
+                  resultParams.ContainsKey(key) ? resultParams[key] : "(missing key)"));
             }
           }
           source.TrySetException(new Exception(String.Join("\n", differences.ToArray())));

--- a/dynamic_links/testapp/Assets/Firebase/Sample/DynamicLinks/UIHandlerAutomated.cs
+++ b/dynamic_links/testapp/Assets/Firebase/Sample/DynamicLinks/UIHandlerAutomated.cs
@@ -78,9 +78,17 @@ namespace Firebase.Sample.DynamicLinks {
       // can't be relied upon.
       var expectedParams = extractUrlParams(expected);
 
+      DebugLog("Start of Expected Params");
+      foreach (var key in expectedParams.Keys) {
+        DebugLog(key + " -> " + expectedParams[key]);
+      }
+      DebugLog("End of Expected Params");
+
       var source = new TaskCompletionSource<string>();
       try {
-        var result = Uri.UnescapeDataString(CreateAndDisplayLongLink().ToString());
+        var resultString = CreateAndDisplayLongLink().ToString();
+        DebugLog("Got resultString of: " + resultString);
+        var result = Uri.UnescapeDataString(resultString);
         var resultHost = new Regex("/\\?").Split(result)[0];
         var sameHost = resultHost == urlHost;
         var resultParams = extractUrlParams(result);

--- a/dynamic_links/testapp/Assets/Firebase/Sample/DynamicLinks/UIHandlerAutomated.cs
+++ b/dynamic_links/testapp/Assets/Firebase/Sample/DynamicLinks/UIHandlerAutomated.cs
@@ -64,12 +64,19 @@ namespace Firebase.Sample.DynamicLinks {
         return result;
       };
 
+      // Dynamic Links only uses the identifier on mobile and Apple platforms
+#if UNITY_EDITOR_OSX || UNITY_STANDALONE_OSX || UNITY_IOS || UNITY_TVOS || UNITY_ANDROID
+      string identifier = "com.google.FirebaseUnityDynamicLinksTestApp.dev";
+#else
+      string identifier = "";
+#endif
+
       // This is taken from the values given in UIHandler.
       var expected =
         urlHost + "/?afl=https://mysite/fallback&" +
-        "amv=12&apn=com.google.FirebaseUnityDynamicLinksTestApp.dev&at=abcdefg&ct=hijklmno&" +
-        "ibi=com.google.FirebaseUnityDynamicLinksTestApp.dev&ifl=https://mysite/fallback&imv=1.2.3&" +
-        "ipbi=com.google.FirebaseUnityDynamicLinksTestApp.dev&" +
+        "amv=12&apn=" + identifier + "&at=abcdefg&ct=hijklmno&" +
+        "ibi=" + identifier + "&ifl=https://mysite/fallback&imv=1.2.3&" +
+        "ipbi=" + identifier + "&" +
         "ipfl=https://mysite/fallbackipad&ius=mycustomscheme&link=https://google.com/abc&" +
         "pt=pq-rstuv&sd=My app is awesome!&si=https://mysite.com/someimage.jpg&st=My App!&" +
         "utm_campaign=mycampaign&utm_content=mycontent&utm_medium=mymedium&utm_source=mysource&" +
@@ -78,17 +85,9 @@ namespace Firebase.Sample.DynamicLinks {
       // can't be relied upon.
       var expectedParams = extractUrlParams(expected);
 
-      DebugLog("Start of Expected Params");
-      foreach (var key in expectedParams.Keys) {
-        DebugLog(key + " -> " + expectedParams[key]);
-      }
-      DebugLog("End of Expected Params");
-
       var source = new TaskCompletionSource<string>();
       try {
-        var resultString = CreateAndDisplayLongLink().ToString();
-        DebugLog("Got resultString of: " + resultString);
-        var result = Uri.UnescapeDataString(resultString);
+        var result = Uri.UnescapeDataString(CreateAndDisplayLongLink().ToString());
         var resultHost = new Regex("/\\?").Split(result)[0];
         var sameHost = resultHost == urlHost;
         var resultParams = extractUrlParams(result);

--- a/dynamic_links/testapp/Assets/Firebase/Sample/DynamicLinks/UIHandlerAutomated.cs
+++ b/dynamic_links/testapp/Assets/Firebase/Sample/DynamicLinks/UIHandlerAutomated.cs
@@ -64,12 +64,9 @@ namespace Firebase.Sample.DynamicLinks {
         return result;
       };
 
-      // Dynamic Links only uses the identifier on mobile and Apple platforms
-#if UNITY_EDITOR_OSX || UNITY_STANDALONE_OSX || UNITY_IOS || UNITY_TVOS || UNITY_ANDROID
-      string identifier = "com.google.FirebaseUnityDynamicLinksTestApp.dev";
-#else
-      string identifier = "";
-#endif
+      // Dynamic Links uses the Application identifier for some of the fields.
+      // Note that on Windows and Linux desktop, this field will likely be empty.
+      string identifier = Application.identifier;
 
       // This is taken from the values given in UIHandler.
       var expected =


### PR DESCRIPTION
### Description
> Provide details of the change, and generalize the change in the PR title above.

Dynamic Links uses Unity's Application.identifier under the hood to fill in some fields, but that results in an empty string on Windows and Linux. Since that is expected on desktop, change the tests to only check for that identifier on mobile and Apple platforms, which are expected to be present.
***
### Testing
> Describe how you've tested these changes.


[replace this line]: # (Describe your testing in detail.)
***

### Type of Change
Place an `x` the applicable box:
- [x] Bug fix. Add the issue # below if applicable.
- [ ] New feature. A non-breaking change which adds functionality.
- [ ] Other, such as a build process or documentation change.
***

