### PR TITLE
Move python to the back of the list of interpreters

### DIFF
--- a/docs/readme.md
+++ b/docs/readme.md
@@ -163,6 +163,10 @@ Support
 
 Release Notes
 -------------
+### Unreleased
+- Changes
+    - General (Editor, macOS): Fix an issue when finding "python" executable.
+
 ### 8.9.0
 - Changes
     - General (Editor, macOS): Support non-default "python" executable names,

--- a/editor/app/src/PythonExecutor.cs
+++ b/editor/app/src/PythonExecutor.cs
@@ -114,8 +114,9 @@ namespace Firebase.Editor {
             }
         }
 
+        // Just 'python' might prompt the user for input, so try that last
         private static readonly string[] PYTHON_INTERPRETERS = {
-          "python", "python3", "python3.8","python3.7", "python2.7", "python2"
+          "python3", "python3.8","python3.7", "python2.7", "python2", "python"
         };
 
         private static string s_pythonInterpreter = null;


### PR DESCRIPTION
### Description
> Provide details of the change, and generalize the change in the PR title above.

Some users are still having problems with finding the python interpreter. One possible reason is that when checking just "python" it is prompting for user input and failing, so we will move that to the back of the list, so that it checks the most common case of "python3", which does not seem to have this problem, first.
***
### Testing
> Describe how you've tested these changes.


[replace this line]: # (Describe your testing in detail.)
***

### Type of Change
Place an `x` the applicable box:
- [x] Bug fix. Add the issue # below if applicable.
- [ ] New feature. A non-breaking change which adds functionality.
- [ ] Other, such as a build process or documentation change.
***
https://github.com/firebase/firebase-unity-sdk/issues/154
