### PR TITLE
Force the windows workflow to use a specific python path

### DIFF
--- a/.github/workflows/sdk_build.yml
+++ b/.github/workflows/sdk_build.yml
@@ -151,7 +151,7 @@ jobs:
           # ./build_windows_x64.bat ${{ github.event.inputs.additional_cmake_flags }} TODO convert to python script
           mkdir ${{ matrix.build_dir }}
           pushd ${{ matrix.build_dir }}
-          cmake .. -G "Visual Studio 16 2019" -A x64 -DFIREBASE_CPP_SDK_DIR="${FIREBASE_CPP_SDK_DIR}" -DUNITY_ROOT_DIR="${UNITY_ROOT_DIR}" -DSWIG_DIR="${SWIG_DIR}" -DFIREBASE_PYTHON_HOST_EXECUTABLE:FILEPATH=C:\hostedtoolcache\windows\Python\3.7.9\x64\python.exe ${{ github.event.inputs.additional_cmake_flags }}
+          cmake .. -G "Visual Studio 16 2019" -A x64 -DFIREBASE_CPP_SDK_DIR="${FIREBASE_CPP_SDK_DIR}" -DUNITY_ROOT_DIR="${UNITY_ROOT_DIR}" -DSWIG_DIR="${SWIG_DIR}" -DFIREBASE_PYTHON_HOST_EXECUTABLE:FILEPATH=C:/hostedtoolcache/windows/Python/3.7.9/x64/python.exe ${{ github.event.inputs.additional_cmake_flags }}
           echo "=-=-=-=-=-=-=-=-="
           echo "Start Build"
           echo "=-=-=-=-=-=-=-=-="

--- a/.github/workflows/sdk_build.yml
+++ b/.github/workflows/sdk_build.yml
@@ -151,7 +151,7 @@ jobs:
           # ./build_windows_x64.bat ${{ github.event.inputs.additional_cmake_flags }} TODO convert to python script
           mkdir ${{ matrix.build_dir }}
           pushd ${{ matrix.build_dir }}
-          cmake .. -G "Visual Studio 16 2019" -A x64 -DFIREBASE_CPP_SDK_DIR="${FIREBASE_CPP_SDK_DIR}" -DUNITY_ROOT_DIR="${UNITY_ROOT_DIR}" -DSWIG_DIR="${SWIG_DIR}" ${{ github.event.inputs.additional_cmake_flags }}
+          cmake .. -G "Visual Studio 16 2019" -A x64 -DFIREBASE_CPP_SDK_DIR="${FIREBASE_CPP_SDK_DIR}" -DUNITY_ROOT_DIR="${UNITY_ROOT_DIR}" -DSWIG_DIR="${SWIG_DIR}" -DFIREBASE_PYTHON_HOST_EXECUTABLE:FILEPATH=C:\hostedtoolcache\windows\Python\3.7.9\x64\python.exe ${{ github.event.inputs.additional_cmake_flags }}
           echo "=-=-=-=-=-=-=-=-="
           echo "Start Build"
           echo "=-=-=-=-=-=-=-=-="


### PR DESCRIPTION
### Description
> Provide details of the change, and generalize the change in the PR title above.

Firestore is having a problem with python, as it finds multiple versions. This can be worked around by setting FIREBASE_PYTHON_HOST_EXECUTABLE, so for now force that to be the version of python we are installing.
***
### Testing
> Describe how you've tested these changes.

Ran this: https://github.com/firebase/firebase-unity-sdk/actions/runs/2210433023
***

### Type of Change
Place an `x` the applicable box:
- [ ] Bug fix. Add the issue # below if applicable.
- [ ] New feature. A non-breaking change which adds functionality.
- [x] Other, such as a build process or documentation change.
***

