### PR TITLE
Turn on size optimization on Android

### DIFF
--- a/scripts/build_scripts/build_zips.py
+++ b/scripts/build_scripts/build_zips.py
@@ -270,6 +270,9 @@ def get_android_args():
   result_args.append("-DFIREBASE_ANDROID_BUILD=true")
   # android default to build release.
   result_args.append("-DCMAKE_BUILD_TYPE=release")
+  # Turn on optimization for size
+  result_args.append("-DCMAKE_C_FLAGS=-Oz")
+  result_args.append("-DCMAKE_CXX_FLAGS=-Oz")
   return result_args
 
 


### PR DESCRIPTION
### Description
> Provide details of the change, and generalize the change in the PR title above.

The previous build system used -Oz to optimize the Android libraries for size. Turning it on, to maintain the same behavior.
***
### Testing
> Describe how you've tested these changes.


[replace this line]: # (Describe your testing in detail.)
***

### Type of Change
Place an `x` the applicable box:
- [ ] Bug fix. Add the issue # below if applicable.
- [ ] New feature. A non-breaking change which adds functionality.
- [x] Other, such as a build process or documentation change.
***

