### PR TITLE
Make shared libraries link against the universal one

### DIFF
--- a/cmake/build_shared.cmake
+++ b/cmake/build_shared.cmake
@@ -35,13 +35,25 @@ function(build_firebase_shared LIBRARY_NAME ARTIFACT_NAME OUTPUT_NAME)
 
   set(shared_target "firebase_${LIBRARY_NAME}_shared")
   
-  add_library(${shared_target} SHARED
-    ${FIREBASE_SOURCE_DIR}/empty.cc
-    $<TARGET_OBJECTS:firebase_${LIBRARY_NAME}>
-    $<TARGET_OBJECTS:firebase_${LIBRARY_NAME}_swig>
-  )
-  
-  set(SHARED_TARGET_LINK_LIB_NAMES "firebase_${LIBRARY_NAME}" "firebase_${LIBRARY_NAME}_swig")
+  if(FIREBASE_IOS_BUILD OR NOT FIREBASE_UNI_LIBRARY)
+    # On iOS, we want to include all the symbols in the library
+    add_library(${shared_target} SHARED
+      ${FIREBASE_SOURCE_DIR}/empty.cc
+      $<TARGET_OBJECTS:firebase_${LIBRARY_NAME}>
+      $<TARGET_OBJECTS:firebase_${LIBRARY_NAME}_swig>
+    )
+
+    set(SHARED_TARGET_LINK_LIB_NAMES "firebase_${LIBRARY_NAME}" "firebase_${LIBRARY_NAME}_swig")
+  else()
+    # On other platforms, we only want the symbols from the
+    # generated swig C++ file, and then linked against the
+    # universal library, which has the symbols we need
+    add_library(${shared_target} SHARED
+      ${firebase_${LIBRARY_NAME}_swig_gen_cpp_src}
+    )
+
+    set(SHARED_TARGET_LINK_LIB_NAMES "firebase_app_uni")
+  endif()
 
   target_link_libraries(${shared_target}
     ${SHARED_TARGET_LINK_LIB_NAMES}

--- a/cmake/firebase_swig.cmake
+++ b/cmake/firebase_swig.cmake
@@ -258,5 +258,8 @@ macro(firebase_swig_add_library name)
   )
 
   set(${name}_gen_src ${UNITY_SWIG_CS_FIX_FILE})
+  # Set a variable so that the C++ file can be referenced elsewhere
+  set(${name}_gen_cpp_src ${UNITY_SWIG_CPP_FIX_FILE})
+  set(${name}_gen_cpp_src ${UNITY_SWIG_CPP_FIX_FILE} PARENT_SCOPE)
 
 endmacro()

--- a/firestore/CMakeLists.txt
+++ b/firestore/CMakeLists.txt
@@ -150,6 +150,14 @@ else()
     firestore
     FirebaseCppFirestore
   )
+
+  target_include_directories(firebase_firestore_shared
+    PUBLIC
+      ${FIRESTORE_SOURCE_DIR}/Firestore/core/include
+      ${FIRESTORE_SOURCE_DIR}/Firestore/Protos/nanopb
+    PRIVATE
+      ${FIRESTORE_SOURCE_DIR}
+  )
 endif()
 
 unity_pack_cs(firebase_firestore_cs)


### PR DESCRIPTION
### Description
> Provide details of the change, and generalize the change in the PR title above.

The shared libraries have too many symbols, duplicating what is in app. Change it to link against the universal app library, which will keep the symbols in the shared libraries down.
***
### Testing
> Describe how you've tested these changes.


[replace this line]: # (Describe your testing in detail.)
***

### Type of Change
Place an `x` the applicable box:
- [ ] Bug fix. Add the issue # below if applicable.
- [ ] New feature. A non-breaking change which adds functionality.
- [x] Other, such as a build process or documentation change.
***

