### PR TITLE
Force on the CXX11_ABI flag

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -130,16 +130,13 @@ enable_language(C)
 enable_language(CXX)
 
 if(NOT MSVC AND NOT APPLE)
-  # Linux-specific option.
-  if (FIREBASE_LINUX_USE_CXX11_ABI)
-    add_definitions(-D_GLIBCXX_USE_CXX11_ABI=1)
-    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -D_GLIBCXX_USE_CXX11_ABI=1")
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -D_GLIBCXX_USE_CXX11_ABI=1")
-  else()
-    add_definitions(-D_GLIBCXX_USE_CXX11_ABI=0)
-    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -D_GLIBCXX_USE_CXX11_ABI=0")
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -D_GLIBCXX_USE_CXX11_ABI=0")
-  endif()
+  # The Linux Unity Editor seems to require using the CXX11 ABI for Firestore,
+  # so we turn the option on, and set the flag to true for the C++ SDK to pick
+  # it up as well.
+  add_definitions(-D_GLIBCXX_USE_CXX11_ABI=1)
+  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -D_GLIBCXX_USE_CXX11_ABI=1")
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -D_GLIBCXX_USE_CXX11_ABI=1")
+  set(FIREBASE_LINUX_USE_CXX11_ABI TRUE)
 endif()
 
 if(NOT ANDROID AND NOT IOS)


### PR DESCRIPTION
### Description
> Provide details of the change, and generalize the change in the PR title above.

The Linux Unity editor was crashing in the Firestore testapp. From what I can tell, the Unity editor was likely build with this option enabled, and mixing the library without it was the cause of the crash. So we will force the option to always be on for Linux builds. Note that standalone builds were not crashing, so it was likely just a problem with the Unity editor being built with that option.
***
### Testing
> Describe how you've tested these changes.


[replace this line]: # (Describe your testing in detail.)
***

### Type of Change
Place an `x` the applicable box:
- [ ] Bug fix. Add the issue # below if applicable.
- [ ] New feature. A non-breaking change which adds functionality.
- [x] Other, such as a build process or documentation change.
***

