### PR TITLE
Fix issue with Android package name

### DIFF
--- a/aar_builder/build_aar.py
+++ b/aar_builder/build_aar.py
@@ -69,17 +69,15 @@ def main(unused_argv):
   temp_dir = tempfile.mkdtemp()
   patched_manifest = shutil.copy(android_manifest_file, temp_dir)
   if FLAGS.manifest_package_name:
-    manifest_lines = []
-    with open(patched_manifest, "r+") as file:
-      contents = file.read()
+    with open(patched_manifest, "r") as new_file:
+      contents = new_file.read()
 
-      package_re = re.compile(r'package=".+"')
-      re.sub(r'package=".+"',
-             r'package="%s"' % FLAGS.manifest_package_name,
-             contents)
+    contents = re.sub('package=".+"',
+                      'package="%s"' % FLAGS.manifest_package_name,
+                    contents)
 
-      file.truncate(0)
-      file.write(contents)
+    with open(patched_manifest, "w") as new_file:
+      new_file.write(contents)
 
   # Delete the aar file, if it already exists
   if os.path.exists(output_file):
@@ -101,7 +99,7 @@ def main(unused_argv):
 
   with zipfile.ZipFile(output_file, "w") as myzip:
     # Write the generic base files that are required in an aar file.
-    myzip.write(android_manifest_file, "AndroidManifest.xml")
+    myzip.write(patched_manifest, "AndroidManifest.xml")
     myzip.write(classes_jar_file, "classes.jar")
     myzip.write(os.path.join(file_dir, "R.txt"), "R.txt")
     myzip.writestr("res/", "")

--- a/cmake/build_aar.cmake
+++ b/cmake/build_aar.cmake
@@ -52,7 +52,7 @@ function(build_aar LIBRARY_NAME LIBRARY_TARGET PROGUARD_TARGET
       "--proguard_file=${${PROGUARD_TARGET}}"
       "--android_manifest=${BUILD_AAR_ARGS_ANDROID_MANIFEST}"
       "--classes_jar=${BUILD_AAR_ARGS_CLASSES_JAR}"
-      "--manifest_package_name="${BUILD_AAR_ARGS_MANIFEST_PACKAGE_NAME}"
+      "--manifest_package_name=${BUILD_AAR_ARGS_MANIFEST_PACKAGE_NAME}"
     DEPENDS
       "${LIBRARY_TARGET}"
       "${PROGUARD_TARGET}"

--- a/cmake/build_aar.cmake
+++ b/cmake/build_aar.cmake
@@ -33,10 +33,11 @@ set(MAVEN_TEMPLATE ${CMAKE_CURRENT_LIST_DIR}/maven.template)
 # Optional Args:
 #  ANDROID_MANIFEST: The custom AndroidManifest file to include.
 #  CLASSES_JAR: The custom classes.jar file to include.
+#  MANIFEST_PACKAGE_NAME: Package name to overwrite the AndroidManifest with.
 function(build_aar LIBRARY_NAME LIBRARY_TARGET PROGUARD_TARGET
                    ARTIFACT_ID VERSION)
   # Parse the additional arguments
-  set(single ANDROID_MANIFEST CLASSES_JAR)
+  set(single ANDROID_MANIFEST CLASSES_JAR MANIFEST_PACKAGE_NAME)
   cmake_parse_arguments(BUILD_AAR_ARGS "" "${single}" "" ${ARGN})
 
   set(AAR_NAME "${ARTIFACT_ID}-${VERSION}")
@@ -51,6 +52,7 @@ function(build_aar LIBRARY_NAME LIBRARY_TARGET PROGUARD_TARGET
       "--proguard_file=${${PROGUARD_TARGET}}"
       "--android_manifest=${BUILD_AAR_ARGS_ANDROID_MANIFEST}"
       "--classes_jar=${BUILD_AAR_ARGS_CLASSES_JAR}"
+      "--manifest_package_name="${BUILD_AAR_ARGS_MANIFEST_PACKAGE_NAME}"
     DEPENDS
       "${LIBRARY_TARGET}"
       "${PROGUARD_TARGET}"

--- a/cmake/build_firebase_aar.cmake
+++ b/cmake/build_firebase_aar.cmake
@@ -47,5 +47,7 @@ function(build_firebase_aar LIBRARY_NAME ARTIFACT_NAME LIBRARY_TARGET
       ${FIREBASE_AAR_ARGS_ANDROID_MANIFEST}
     CLASSES_JAR
       ${FIREBASE_AAR_ARGS_CLASSES_JAR}
+    MANIFEST_PACKAGE_NAME
+      "com.google.firebase.unity.${LIBRARY_NAME}"
   )
 endfunction()

--- a/cmake/firebase_unity_version.cmake
+++ b/cmake/firebase_unity_version.cmake
@@ -14,7 +14,7 @@
 
 # This file defines the version numbers used by the Firebase Unity SDK.
 
-set(FIREBASE_UNITY_SDK_VERSION "8.10.0"
+set(FIREBASE_UNITY_SDK_VERSION "8.10.1"
     CACHE STRING "The version of the Unity SDK, used in the names of files.")
 
 set(FIREBASE_IOS_POD_VERSION "8.15.0"

--- a/docs/readme.md
+++ b/docs/readme.md
@@ -163,6 +163,10 @@ Support
 
 Release Notes
 -------------
+### 8.10.1
+- Changes
+    - General (Android): Fix an issue when building with mainTemplate.gradle.
+
 ### 8.10.0
 - Changes
     - General (Editor, macOS): Fix an issue when finding "python" executable.


### PR DESCRIPTION
### Description
> Provide details of the change, and generalize the change in the PR title above.

The Android srcaar files need to have unique package names in the AndroidManifest files within them, so that when they get merged together with a mainTemplate.gradle file, they can be resolved correctly.
***
### Testing
> Describe how you've tested these changes.


[replace this line]: # (Describe your testing in detail.)
***

### Type of Change
Place an `x` the applicable box:
- [x] Bug fix. Add the issue # below if applicable.
- [ ] New feature. A non-breaking change which adds functionality.
- [ ] Other, such as a build process or documentation change.
***

https://github.com/firebase/quickstart-unity/issues/1264