### PR TITLE
Add support for Apple M1 Silicon

### DIFF
--- a/.github/workflows/sdk_build.yml
+++ b/.github/workflows/sdk_build.yml
@@ -142,7 +142,7 @@ jobs:
         if: startsWith(matrix.os, 'macos')
         shell: bash
         run: |
-          ./build_macos.sh ${{ github.event.inputs.additional_cmake_flags }}
+          python scripts/build_scripts/build_zips.py --platform=macos --unity_root=$UNITY_ROOT_DIR --use_boringssl --architecture=x86_64 --architecture=arm64 --cmake_extras="${{ github.event.inputs.additional_cmake_flags }}"
 
       - name: Build SDK (Windows)
         if: startsWith(matrix.os, 'windows')

--- a/docs/readme.md
+++ b/docs/readme.md
@@ -163,6 +163,10 @@ Support
 
 Release Notes
 -------------
+### Upcoming
+- Changes
+    - General (Editor, macOS): Add support for Apple Silicon chips.
+
 ### 8.10.1
 - Changes
     - General (Android): Fix an issue when building with mainTemplate.gradle.

--- a/scripts/build_scripts/build_zips.py
+++ b/scripts/build_scripts/build_zips.py
@@ -84,7 +84,7 @@ flags.DEFINE_multi_string(
     "For iOS device ({}).\n"
     "For iOS simulator ({}).\n"
     "For android ({}).\n"
-    "For MacOS".format(",".join(IOS_CONFIG_DICT["device"]["architecture"]),
+    "For MacOS ({})".format(",".join(IOS_CONFIG_DICT["device"]["architecture"]),
                                ",".join(
         IOS_CONFIG_DICT["simulator"]["architecture"]),
         ",".join(ANDROID_SUPPORT_ARCHITECTURE),

--- a/scripts/build_scripts/build_zips.py
+++ b/scripts/build_scripts/build_zips.py
@@ -498,6 +498,13 @@ def is_macos_build():
   """
   return FLAGS.platform == "macos"
 
+def is_linux_build():
+  """
+    Returns:
+      If the build platform is linux
+  """
+  return FLAGS.platform == "linux"
+
 
 def main(argv):
   if len(argv) > 1:
@@ -565,7 +572,11 @@ def main(argv):
     make_macos_multi_arch_build(cmake_setup_args)
   else:
     subprocess.call(cmake_setup_args)
-    subprocess.call("make")
+    # Ideally they should all use multi jobs, but some of the platforms currently fail 
+    if is_linux_build() or is_macos_build():
+      subprocess.call("make", "-j")
+    else:
+      subprocess.call("make")
 
     cmake_pack_args = [
         "cpack",

--- a/scripts/build_scripts/build_zips.py
+++ b/scripts/build_scripts/build_zips.py
@@ -406,7 +406,7 @@ def make_macos_multi_arch_build(cmake_args):
     os.chdir(arch)
     cmake_args.append('-DCMAKE_OSX_ARCHITECTURES='+arch)
     subprocess.call(cmake_args)
-    subprocess.call("make")
+    subprocess.call("make", "-j")
 
     cmake_pack_args = [
         "cpack",


### PR DESCRIPTION
### Description
> Provide details of the change, and generalize the change in the PR title above.

Now that we are building on GHA, we can add support for Apple Silicon chips. This adds logic to the python script to build both x86_64 and arm64, and then merge them together with lipo.
***
### Testing
> Describe how you've tested these changes.

Validating that the bundle files have both symbols, and running it locally on an M1 Mac.
***

### Type of Change
Place an `x` the applicable box:
- [ ] Bug fix. Add the issue # below if applicable.
- [x] New feature. A non-breaking change which adds functionality.
- [ ] Other, such as a build process or documentation change.
***

https://github.com/firebase/firebase-unity-sdk/issues/278