### PR TITLE
Add an additional path for iOS Crashlytics headers

### DIFF
--- a/crashlytics/src/cpp/CMakeLists.txt
+++ b/crashlytics/src/cpp/CMakeLists.txt
@@ -101,6 +101,12 @@ if(IOS)
     POD_NAMES
       FirebaseCrashlytics
   )
+  # The Crashlytics cocoapod can use a unique path that does not match the pattern used by
+  # other Firebase cocoapods, so add the path explicitly here.
+  target_include_directories(firebase_crashlytics
+    PUBLIC
+      ${FIREBASE_POD_DIR}/Pods/FirebaseCrashlytics/Crashlytics/Crashlytics/Public/FirebaseCrashlytics
+  )
 
   # Crashlytics pods use 'iOS' dir instead of 'Frameworks' dir
   symlink_pod_headers(firebase_crashlytics Crashlytics CrashlyticsiOS


### PR DESCRIPTION
### Description
> Provide details of the change, and generalize the change in the PR title above.

The new Crashlytics cocoapods uses a different structure than the rest of the Firebase pods, so we explicitly add the new path to the set of include directories.
***
### Testing
> Describe how you've tested these changes.


Building iOS locally against the 9.0.0 Cocoapods
***

### Type of Change
Place an `x` the applicable box:
- [ ] Bug fix. Add the issue # below if applicable.
- [ ] New feature. A non-breaking change which adds functionality.
- [x] Other, such as a build process or documentation change.
***

