### PR TITLE
Turn on boringssl on linux and windows builds

### DIFF
--- a/.github/workflows/sdk_build.yml
+++ b/.github/workflows/sdk_build.yml
@@ -136,7 +136,7 @@ jobs:
         if: startsWith(matrix.os, 'ubuntu')
         shell: bash
         run: |
-          ./build_linux.sh ${{ github.event.inputs.additional_cmake_flags }}
+          ./build_linux.sh -DFIREBASE_USE_BORINGSSL=ON ${{ github.event.inputs.additional_cmake_flags }}
 
       - name: Build SDK (MacOS)
         if: startsWith(matrix.os, 'macos')
@@ -151,7 +151,7 @@ jobs:
           # ./build_windows_x64.bat ${{ github.event.inputs.additional_cmake_flags }} TODO convert to python script
           mkdir ${{ matrix.build_dir }}
           pushd ${{ matrix.build_dir }}
-          cmake .. -G "Visual Studio 16 2019" -A x64 -DFIREBASE_CPP_SDK_DIR="${FIREBASE_CPP_SDK_DIR}" -DUNITY_ROOT_DIR="${UNITY_ROOT_DIR}" -DSWIG_DIR="${SWIG_DIR}" -DFIREBASE_PYTHON_HOST_EXECUTABLE:FILEPATH=C:/hostedtoolcache/windows/Python/3.7.9/x64/python.exe ${{ github.event.inputs.additional_cmake_flags }}
+          cmake .. -G "Visual Studio 16 2019" -A x64 -DFIREBASE_CPP_SDK_DIR="${FIREBASE_CPP_SDK_DIR}" -DUNITY_ROOT_DIR="${UNITY_ROOT_DIR}" -DSWIG_DIR="${SWIG_DIR}" -DFIREBASE_PYTHON_HOST_EXECUTABLE:FILEPATH=C:/hostedtoolcache/windows/Python/3.7.9/x64/python.exe -DFIREBASE_USE_BORINGSSL=ON ${{ github.event.inputs.additional_cmake_flags }}
           echo "=-=-=-=-=-=-=-=-="
           echo "Start Build"
           echo "=-=-=-=-=-=-=-=-="


### PR DESCRIPTION
### Description
> Provide details of the change, and generalize the change in the PR title above.

The previous build system used boringssl for builds, and it is required now on Mac, so turn it on for the other desktop platforms.
***
### Testing
> Describe how you've tested these changes.


[replace this line]: # (Describe your testing in detail.)
***

### Type of Change
Place an `x` the applicable box:
- [ ] Bug fix. Add the issue # below if applicable.
- [ ] New feature. A non-breaking change which adds functionality.
- [x] Other, such as a build process or documentation change.
***

