### PR TITLE
Possible fix to PR 201 (Fix for swig post process for analytics properties)

### DIFF
--- a/swig_post_process.py
+++ b/swig_post_process.py
@@ -508,7 +508,7 @@ class StaticFunctionKInitRemoval(SWIGPostProcessingInterface):
       if match:
         function_name = match.groups()[1]
         line = ''.join([line[:match.end(1)+1],
-                        function_name.replace('k', ''),
+                        function_name.replace('k', '', 1),
                         line[match.end(2):]])
       output.append(line)
     return '\n'.join(output)


### PR DESCRIPTION
Currently, it is observed in versions 8.10.0 onward that some functions (like public static EventCheckoutProgress) have the letter 'k' omitted. 

Updated the replace function to replace the first 'k'

Resolves #279 