### PR TITLE
Fix Crashlytics proguard file generation

### DIFF
--- a/crashlytics/src/cpp/CMakeLists.txt
+++ b/crashlytics/src/cpp/CMakeLists.txt
@@ -72,13 +72,18 @@ if(ANDROID)
   set(FIREBASE_CPP_CRASHLYTICS_PROGUARD ${CMAKE_CURRENT_BINARY_DIR}/crashlytics.pro
       CACHE FILEPATH "Proguard file for Crashlytics" FORCE)
 
+  # The Crashlytics NDK symbols aren't properly caught by the usual strings logic,
+  # so we explicitly append it at the end.
   add_custom_command(
     OUTPUT ${FIREBASE_CPP_CRASHLYTICS_PROGUARD}
     COMMAND strings $<TARGET_FILE:firebase_crashlytics> |
             grep %PG% |
             sed -r 'sI/I.Ig' |
-            sed -r 's/%PG%/-keep,includedescriptorclasses public class /g'
-            > ${FIREBASE_CPP_CRASHLYTICS_PROGUARD}
+            sed -r 's/%PG%/-keep,includedescriptorclasses public class /g' |
+            sed -r 'sI\$\$I { *\; }Ig'
+            > ${FIREBASE_CPP_CRASHLYTICS_PROGUARD} &&
+            echo '-keep class com.google.firebase.crashlytics.ndk.** { *\; }'
+            >> ${FIREBASE_CPP_CRASHLYTICS_PROGUARD}
     DEPENDS firebase_crashlytics
     COMMENT "Generating Crashlytics Proguard file."
   )

--- a/docs/readme.md
+++ b/docs/readme.md
@@ -161,6 +161,8 @@ Release Notes
     - General (Editor, macOS): Add support for Apple Silicon chips.
     - General (iOS): Firebase Unity on iOS is now built using Xcode 13.3.1.
     - Analytics: Removed deprecated event names and parameters.
+    - Crashlytics (Android): Fixed a bug with missing symbols when enabling
+      minification via proguard.
     - Realtime Database (Desktop): Fixed a bug handling server timestamps
       on 32-bit CPUs.
     - Storage (Desktop): Set Content-Type HTTP header when uploading with


### PR DESCRIPTION
### Description
> Provide details of the change, and generalize the change in the PR title above.

Add missing { *; } to the Crashlytics proguard file, and add special logic for the FirebaseCrashlyticsNdk library, which is incorrectly not being kept when enabling proguard.
***
### Testing
> Describe how you've tested these changes.


Tested locally by replacing the proguard file with the generated one.
***

### Type of Change
Place an `x` the applicable box:
- [x] Bug fix. Add the issue # below if applicable.
- [ ] New feature. A non-breaking change which adds functionality.
- [ ] Other, such as a build process or documentation change.
***

https://github.com/firebase/quickstart-unity/issues/1268