### PR TITLE
Turn boringssl on for Linux, with C++ fix

### DIFF
--- a/.github/workflows/sdk_build.yml
+++ b/.github/workflows/sdk_build.yml
@@ -136,7 +136,7 @@ jobs:
         if: startsWith(matrix.os, 'ubuntu')
         shell: bash
         run: |
-          ./build_linux.sh ${{ github.event.inputs.additional_cmake_flags }}
+          ./build_linux.sh -DFIREBASE_USE_BORINGSSL=ON ${{ github.event.inputs.additional_cmake_flags }}
 
       - name: Build SDK (MacOS)
         if: startsWith(matrix.os, 'macos')

--- a/cmake/firebase_unity_version.cmake
+++ b/cmake/firebase_unity_version.cmake
@@ -27,7 +27,7 @@ set(FIREBASE_UNITY_JAR_RESOLVER_VERSION "1.2.171"
 )
 
 # https://github.com/firebase/firebase-cpp-sdk
-set(FIREBASE_CPP_SDK_PRESET_VERSION "v9.0.0"
+set(FIREBASE_CPP_SDK_PRESET_VERSION "aac1d3eb34e88cff9e05402c478717473b95c52f"
    CACHE STRING
   "Version tag of Firebase CPP SDK to download (if no local or not passed in) and use (no trailing .0)"
 )


### PR DESCRIPTION
### Description
> Provide details of the change, and generalize the change in the PR title above.

The problem with boringssl on linux was because the C++ repo was not passing along the PIC flag correctly. This will be fixed with https://github.com/firebase/firebase-cpp-sdk/pull/957, at which point we can use boringssl on linux.
***
### Testing
> Describe how you've tested these changes.


[replace this line]: # (Describe your testing in detail.)
***

### Type of Change
Place an `x` the applicable box:
- [ ] Bug fix. Add the issue # below if applicable.
- [ ] New feature. A non-breaking change which adds functionality.
- [x] Other, such as a build process or documentation change.
***

