### PR TITLE
Set the iOS minimum version flag in the toolchain

### DIFF
--- a/cmake/unity_ios.cmake
+++ b/cmake/unity_ios.cmake
@@ -16,7 +16,10 @@ message(STATUS "gcc found at: ${CMAKE_C_COMPILER}")
 message(STATUS "g++ found at: ${CMAKE_CXX_COMPILER}")
 message(STATUS "Using iOS SDK: ${CMAKE_OSX_SYSROOT}")
 
-set(CMAKE_OSX_SYSROOT "iphoneos;iphonesimulator")
+set(CMAKE_SYSTEM_NAME "iOS")
+# In order to build for both device and simulator, this needs to be empty,
+# or the CMAKE_OSX_DEPLOYMENT_TARGET setting below is not handled correctly.
+set(CMAKE_OSX_SYSROOT "")
 set(CMAKE_OSX_ARCHITECTURES "arm64;armv7;x86_64;i386" CACHE STRING "")
 set(CMAKE_XCODE_EFFECTIVE_PLATFORMS "-iphoneos;-iphonesimulator")
 set(IOS_PLATFORM_LOCATION "iPhoneOS.platform;iPhoneSimulator.platform")
@@ -25,6 +28,7 @@ set(CMAKE_IOS_INSTALL_UNIVERSAL_LIBS "YES")
 set(CMAKE_XCODE_ATTRIBUTE_ONLY_ACTIVE_ARCH "NO")
 set(CMAKE_XCODE_ATTRIBUTE_CODE_SIGNING_REQUIRED "NO")
 set(CMAKE_XCODE_ATTRIBUTE_ENABLE_BITCODE "YES")
+set(CMAKE_OSX_DEPLOYMENT_TARGET "8.0" CACHE STRING "")
 
 # skip TRY_COMPILE checks
 set(CMAKE_CXX_COMPILER_WORKS TRUE)

--- a/cmake/unity_ios.cmake
+++ b/cmake/unity_ios.cmake
@@ -19,6 +19,9 @@ message(STATUS "Using iOS SDK: ${CMAKE_OSX_SYSROOT}")
 set(CMAKE_SYSTEM_NAME "iOS")
 # In order to build for both device and simulator, this needs to be empty,
 # or the CMAKE_OSX_DEPLOYMENT_TARGET setting below is not handled correctly.
+# Note, this seems to cause an issue with repeating builds on some cmake versions,
+# the long term fix will likely be to not handle both device and simulator with
+# the same toolchain, and instead merge the libraries after the fact.
 set(CMAKE_OSX_SYSROOT "")
 set(CMAKE_OSX_ARCHITECTURES "arm64;armv7;x86_64;i386" CACHE STRING "")
 set(CMAKE_XCODE_EFFECTIVE_PLATFORMS "-iphoneos;-iphonesimulator")

--- a/docs/readme.md
+++ b/docs/readme.md
@@ -160,10 +160,10 @@ Release Notes
     - General: Minimum supported editor version is now Unity 2018.
     - General (Editor, macOS): Add support for Apple Silicon chips.
     - General (iOS): Firebase Unity on iOS is now built using Xcode 13.3.1.
+    - General (iOS): Fixed crash when running on iPhoneOS 12 and older.
     - Analytics: Removed deprecated event names and parameters.
     - Crashlytics (Android): Fixed a bug with missing symbols when enabling
       minification via proguard.
-    - Messaging (iOS): Fixed crash when running on iPhoneOS 12 and older.
     - Realtime Database (Desktop): Fixed a bug handling server timestamps
       on 32-bit CPUs.
     - Storage (Desktop): Set Content-Type HTTP header when uploading with

--- a/docs/readme.md
+++ b/docs/readme.md
@@ -163,6 +163,7 @@ Release Notes
     - Analytics: Removed deprecated event names and parameters.
     - Crashlytics (Android): Fixed a bug with missing symbols when enabling
       minification via proguard.
+    - Messaging (iOS): Fixed crash when running on iPhoneOS 12 and older.
     - Realtime Database (Desktop): Fixed a bug handling server timestamps
       on 32-bit CPUs.
     - Storage (Desktop): Set Content-Type HTTP header when uploading with


### PR DESCRIPTION
### Description
> Provide details of the change, and generalize the change in the PR title above.

Set CMAKE_OSX_DEPLOYMENT_TARGET, which in turn sets the iOS minimum version flag. Note though that it seems a bit buggy when building fat libraries, as it gets confused on which minimum version flag to use. This will work on clean builds, which will be enough for a release, but for a long term fix we will likely need to change the build scripts to build device and simulator separately, and then merge them together afterwards.
***
### Testing
> Describe how you've tested these changes.


Building locally, and running on an iOS simulator with iPhoneOS 12.4, and running on a device with iPhoneOS 13.3
***

### Type of Change
Place an `x` the applicable box:
- [x] Bug fix. Add the issue # below if applicable.
- [ ] New feature. A non-breaking change which adds functionality.
- [ ] Other, such as a build process or documentation change.
***

https://github.com/firebase/firebase-unity-sdk/issues/294

https://github.com/firebase/quickstart-unity/issues/1275