### PR TITLE
Add boringssl back to Linux, with the fixed C++

### DIFF
--- a/.github/workflows/sdk_build.yml
+++ b/.github/workflows/sdk_build.yml
@@ -136,7 +136,7 @@ jobs:
         if: startsWith(matrix.os, 'ubuntu')
         shell: bash
         run: |
-          ./build_linux.sh ${{ github.event.inputs.additional_cmake_flags }}
+          ./build_linux.sh -DFIREBASE_USE_BORINGSSL=ON ${{ github.event.inputs.additional_cmake_flags }}
 
       - name: Build SDK (MacOS)
         if: startsWith(matrix.os, 'macos')

--- a/cmake/firebase_unity_version.cmake
+++ b/cmake/firebase_unity_version.cmake
@@ -27,7 +27,7 @@ set(FIREBASE_UNITY_JAR_RESOLVER_VERSION "1.2.171"
 )
 
 # https://github.com/firebase/firebase-cpp-sdk
-set(FIREBASE_CPP_SDK_PRESET_VERSION "v9.0.0"
+set(FIREBASE_CPP_SDK_PRESET_VERSION "origin/unity-v9.0.0"
    CACHE STRING
   "Version tag of Firebase CPP SDK to download (if no local or not passed in) and use (no trailing .0)"
 )


### PR DESCRIPTION
### Description
> Provide details of the change, and generalize the change in the PR title above.

Add boringssl back for Linux, since it is needed for Firestore to function properly. Pin the C++ SDK to the special unity-v9.0.0 branch, which has the PIC fix on top of the previous 9.0.0 release
***
### Testing
> Describe how you've tested these changes.


[replace this line]: # (Describe your testing in detail.)
***

### Type of Change
Place an `x` the applicable box:
- [ ] Bug fix. Add the issue # below if applicable.
- [ ] New feature. A non-breaking change which adds functionality.
- [x] Other, such as a build process or documentation change.
***

