### PR TITLE
Fix messaging duplicate symbol bug

### DIFF
--- a/cmake/android_dependencies.cmake
+++ b/cmake/android_dependencies.cmake
@@ -60,9 +60,11 @@ set(FIREBASE_INSTALLATIONS_ANDROID_DEPS
     "com.google.firebase:firebase-analytics:21.0.0"
 )
 
+# iid is needed by messaging to avoid a conflict with functions
 set(FIREBASE_MESSAGING_ANDROID_DEPS
     "com.google.firebase:firebase-messaging:23.0.4"
     "com.google.firebase:firebase-analytics:21.0.0"
+    "com.google.firebase:firebase-iid:21.1.0"
 )
 
 set(FIREBASE_REMOTE_CONFIG_ANDROID_DEPS

--- a/docs/readme.md
+++ b/docs/readme.md
@@ -164,6 +164,8 @@ Release Notes
     - Analytics: Removed deprecated event names and parameters.
     - Crashlytics (Android): Fixed a bug with missing symbols when enabling
       minification via proguard.
+    - Messaging (Android): Fixed a bug with duplicate symbols when also
+      using Functions.
     - Realtime Database (Desktop): Fixed a bug handling server timestamps
       on 32-bit CPUs.
     - Storage (Desktop): Set Content-Type HTTP header when uploading with


### PR DESCRIPTION
### Description
> Provide details of the change, and generalize the change in the PR title above.

In the transition to GHA, Messaging lost the extra dependency on iid it needs, or else there is a problem when also using Functions with duplicated symbols.
***
### Testing
> Describe how you've tested these changes.


***

### Type of Change
Place an `x` the applicable box:
- [x] Bug fix. Add the issue # below if applicable.
- [ ] New feature. A non-breaking change which adds functionality.
- [ ] Other, such as a build process or documentation change.
***

https://github.com/firebase/quickstart-unity/issues/1274