### PR TITLE
Bump up Unity version after I/O 2022

### DIFF
--- a/unity_packer/exports.json
+++ b/unity_packer/exports.json
@@ -185,7 +185,7 @@
       "export_upm": 1,
       "upm_package_config" : {
         "manifest" : {
-          "unity": "2017.1",
+          "unity": "2018.1",
           "dependencies": {
             "com.google.external-dependency-manager" : "1.2.171"
           }
@@ -296,7 +296,7 @@
       "export_upm": 1,
       "upm_package_config" : {
         "manifest" : {
-          "unity": "2017.1"
+          "unity": "2018.1"
         }
       }
     },
@@ -385,7 +385,7 @@
       "export_upm": 1,
       "upm_package_config" : {
         "manifest" : {
-          "unity": "2017.1"
+          "unity": "2018.1"
         }
       }
     },
@@ -485,7 +485,7 @@
       "export_upm": 1,
       "upm_package_config" : {
         "manifest" : {
-          "unity": "2017.1"
+          "unity": "2018.1"
         }
       }
     },
@@ -570,7 +570,7 @@
       "export_upm": 1,
       "upm_package_config" : {
         "manifest" : {
-          "unity": "2017.1"
+          "unity": "2018.1"
         }
       }
     },
@@ -658,7 +658,7 @@
       "export_upm": 1,
       "upm_package_config" : {
         "manifest" : {
-          "unity": "2017.1"
+          "unity": "2018.1"
         }
       }
     },
@@ -766,7 +766,7 @@
       "export_upm": 1,
       "upm_package_config" : {
         "manifest" : {
-          "unity": "2017.1"
+          "unity": "2018.1"
         }
       }
     },
@@ -865,7 +865,7 @@
       "export_upm": 1,
       "upm_package_config" : {
         "manifest" : {
-          "unity": "2017.1"
+          "unity": "2018.1"
         }
       }
     },
@@ -951,7 +951,7 @@
       "export_upm": 1,
       "upm_package_config" : {
         "manifest" : {
-          "unity": "2017.1"
+          "unity": "2018.1"
         }
       }
     },
@@ -1050,7 +1050,7 @@
       "export_upm": 1,
       "upm_package_config" : {
         "manifest" : {
-          "unity": "2017.1"
+          "unity": "2018.1"
         }
       }
     },
@@ -1137,7 +1137,7 @@
       "export_upm": 1,
       "upm_package_config" : {
         "manifest" : {
-          "unity": "2017.1"
+          "unity": "2018.1"
         }
       }
     },
@@ -1225,7 +1225,7 @@
       "export_upm": 1,
       "upm_package_config" : {
         "manifest" : {
-          "unity": "2017.1"
+          "unity": "2018.1"
         }
       }
     },
@@ -1312,7 +1312,7 @@
       "export_upm": 1,
       "upm_package_config" : {
         "manifest" : {
-          "unity": "2017.1"
+          "unity": "2018.1"
         }
       }
     },
@@ -1401,7 +1401,7 @@
       "export_upm": 1,
       "upm_package_config" : {
         "manifest" : {
-          "unity": "2017.1"
+          "unity": "2018.1"
         }
       }
     }


### PR DESCRIPTION
### Description
> Provide details of the change, and generalize the change in the PR title above.

We bump up supported Unity version to `2018` for I/O build. This change will make sure all the manifest and GPRv2 are updated properly.

***
### Testing
> Describe how you've tested these changes.

N/A

***

### Type of Change
Place an `x` the applicable box:
- [ ] Bug fix. Add the issue # below if applicable.
- [ ] New feature. A non-breaking change which adds functionality.
- [x] Other, such as a build process or documentation change.
***

