### PR TITLE
Patch MiniJson with a google namespace

### DIFF
--- a/cmake/external/google_minijson.patch
+++ b/cmake/external/google_minijson.patch
@@ -1,0 +1,17 @@
+diff --git a/MiniJSON.cs b/MiniJSON.cs
+index c73cbe5..fcc4397 100644
+--- a/MiniJSON.cs
++++ b/MiniJSON.cs
+@@ -32,6 +32,7 @@ using System.Collections.Generic;
+ using System.IO;
+ using System.Text;
+ 
++namespace Google {
+ namespace MiniJSON {
+     // Example usage:
+     //
+@@ -562,3 +563,4 @@ namespace MiniJSON {
+         }
+     }
+ }
++}

--- a/cmake/external/minijson.cmake
+++ b/cmake/external/minijson.cmake
@@ -27,6 +27,8 @@ ExternalProject_Add(
 
   PREFIX ${PROJECT_BINARY_DIR}
 
+  PATCH_COMMAND git apply ${CMAKE_CURRENT_LIST_DIR}/google_minijson.patch
+
   CONFIGURE_COMMAND ""
   BUILD_COMMAND ""
   INSTALL_COMMAND ""

--- a/docs/readme.md
+++ b/docs/readme.md
@@ -155,6 +155,10 @@ Support
 
 Release Notes
 -------------
+### Upcoming
+- Changes
+    - General: Added a missing namespace to the Google.MiniJson.dll.
+
 ### 9.0.0
 - Changes
     - General: Minimum supported editor version is now Unity 2018.


### PR DESCRIPTION
### Description
> Provide details of the change, and generalize the change in the PR title above.

In the previous build system, the MiniJson library was put into a Google namespace, to prevent overlapping with other usages. This adds that logic back in, by patching the file when it is downloaded.
***
### Testing
> Describe how you've tested these changes.


Building locally
***

### Type of Change
Place an `x` the applicable box:
- [x] Bug fix. Add the issue # below if applicable.
- [ ] New feature. A non-breaking change which adds functionality.
- [ ] Other, such as a build process or documentation change.
***

https://github.com/firebase/firebase-unity-sdk/issues/306
