### PR TITLE
Add GetHttpsCallableFromURL to Functions

### DIFF
--- a/docs/readme.md
+++ b/docs/readme.md
@@ -158,6 +158,8 @@ Release Notes
 ### Upcoming
 - Changes
     - General: Added a missing namespace to the Google.MiniJson.dll.
+    - Functions: Add a new method `GetHttpsCallableFromURL`, to create callables
+      with URLs other than cloudfunctions.net.
 
 ### 9.0.0
 - Changes

--- a/functions/src/FirebaseFunctions.cs
+++ b/functions/src/FirebaseFunctions.cs
@@ -222,6 +222,26 @@ namespace Firebase.Functions {
     }
 
     /// <summary>
+    ///   Creates a
+    ///   <see cref="HttpsCallableReference" />
+    ///   given a URL.
+    /// </summary>
+    public HttpsCallableReference GetHttpsCallableFromURL(string url) {
+      ThrowIfNull();
+      return new HttpsCallableReference(this, functionsInternal.GetHttpsCallableFromURL(url));
+    }
+
+    /// <summary>
+    ///   Creates a
+    ///   <see cref="HttpsCallableReference" />
+    ///   given a URL.
+    /// </summary>
+    public HttpsCallableReference GetHttpsCallableFromURL(Uri url) {
+      ThrowIfNull();
+      return GetHttpsCallableFromURL(url.ToString());
+    }
+
+    /// <summary>
     ///   Sets an origin of a Cloud Functions Emulator instance to use.
     /// </summary>
     public void UseFunctionsEmulator(string origin) {

--- a/functions/testapp/Assets/Firebase/Sample/Functions/UIHandlerAutomated.cs
+++ b/functions/testapp/Assets/Firebase/Sample/Functions/UIHandlerAutomated.cs
@@ -54,6 +54,12 @@ namespace Firebase.Sample.Functions {
         FunctionsErrorCode.Internal);
       yield return new TestCase("explicitErrorTest", null, null,
         FunctionsErrorCode.OutOfRange);
+
+      // Test calling via Url
+      string projectId = FirebaseApp.DefaultInstance.Options.ProjectId;
+      yield return new TestCaseWithURL("scalarTest via Url",
+        new System.Uri("https://us-central1-" + projectId + ".cloudfunctions.net/scalarTest"),
+        17, 76L);
     }
 
     protected override void Start() {


### PR DESCRIPTION
### Description
> Provide details of the change, and generalize the change in the PR title above.

Adds GetHttpsCallableFromURL to the Functions SDK. This was recently added to both the Android and iOS SDKs.
***
### Testing
> Describe how you've tested these changes.


Running locally
***

### Type of Change
Place an `x` the applicable box:
- [ ] Bug fix. Add the issue # below if applicable.
- [x] New feature. A non-breaking change which adds functionality.
- [ ] Other, such as a build process or documentation change.
***

Will require https://github.com/firebase/firebase-cpp-sdk/pull/964, and updating the firebase_cpp default