### PR TITLE
Fix MiniJSON namespace in Database

### DIFF
--- a/database/src/DataSnapshot.cs
+++ b/database/src/DataSnapshot.cs
@@ -18,7 +18,7 @@ using System.Collections;
 using System.Collections.Generic;
 
 using Firebase.Database.Internal;
-using MiniJSON;
+using Google.MiniJSON;
 
 namespace Firebase.Database {
   /// <summary>

--- a/database/src/DatabaseReference.cs
+++ b/database/src/DatabaseReference.cs
@@ -18,7 +18,7 @@ using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using Firebase.Database.Internal;
-using MiniJSON;
+using Google.MiniJSON;
 
 namespace Firebase.Database {
   /// <summary>


### PR DESCRIPTION
### Description
> Provide details of the change, and generalize the change in the PR title above.

Database was using the normal namespace for MiniJSON, so it needs to be updated for the Google one.
***
### Testing
> Describe how you've tested these changes.


[replace this line]: # (Describe your testing in detail.)
***

### Type of Change
Place an `x` the applicable box:
- [x] Bug fix. Add the issue # below if applicable.
- [ ] New feature. A non-breaking change which adds functionality.
- [ ] Other, such as a build process or documentation change.
***

