### PR TITLE
[Analytics] Add InitiateOnDeviceConversionMeasurementWithEmailAddress

### DIFF
--- a/analytics/testapp/Assets/Firebase/Sample/Analytics/UIHandler.cs
+++ b/analytics/testapp/Assets/Firebase/Sample/Analytics/UIHandler.cs
@@ -59,6 +59,8 @@ namespace Firebase.Sample.Analytics {
     void InitializeFirebase() {
       DebugLog("Enabling data collection.");
       FirebaseAnalytics.SetAnalyticsCollectionEnabled(true);
+      DebugLog("Initiate on-device conversion measurement.");
+      FirebaseAnalytics.InitiateOnDeviceConversionMeasurementWithEmailAddress("test@testemail.com");
 
       DebugLog("Set user properties.");
       // Set the user's sign up method.

--- a/docs/readme.md
+++ b/docs/readme.md
@@ -158,6 +158,8 @@ Release Notes
 ### Upcoming
 - Changes
     - General: Added a missing namespace to the Google.MiniJson.dll.
+    - Analytics (iOS): Added InitiateOnDeviceConversionMeasurementWithEmail function to facilitate the
+      [on-device conversion measurement](https://support.google.com/google-ads/answer/12119136) API.
 
 ### 9.0.0
 - Changes


### PR DESCRIPTION
### Description
Call InitiateOnDeviceConversionMeasurementWithEmailAddress in the analytics testapp
No actual code change is necessary since swig autogenerates this method.
The underlying C++ method is in the C++ SDK's 9.1.0 release.
***
### Testing

Built from source and verified that the swig generated file defines the following:
public static void InitiateOnDeviceConversionMeasurementWithEmailAddress(string emailAddress)

Used this built version of the SDK in an analytics testapp and updated the testapp to call the new method
Verified that testapp tests still succeeded with no new errors.
***

### Type of Change
Place an `x` the applicable box:
- [ ] Bug fix. Add the issue # below if applicable.
- [x] New feature. A non-breaking change which adds functionality.
- [ ] Other, such as a build process or documentation change.
***

