### PR TITLE
Fix an issue with bitcode not being enabled

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -234,7 +234,7 @@ endif()
 
 # Includes platform which needs to be invoked first
 add_subdirectory(app)
-set(TARGET_LINK_LIB_NAMES "firebase_app" "firebase_app_swig" "flatbuffers")
+set(TARGET_LINK_LIB_NAMES "firebase_app" "firebase_app_swig")
 set(PROJECT_LIST_HEADER "#define PROJECT_LIST(X)")
 list(APPEND PROJECT_LIST_HEADER "  X(App)")
 
@@ -301,7 +301,7 @@ endif()
 
 if(FIREBASE_UNI_LIBRARY)
   if(FIREBASE_IOS_BUILD)
-    ios_pack(firebase_lib_uni libFirebaseCppApp DEPS "firebase_app" "firebase_app_swig" "flatbuffers")
+    ios_pack(firebase_lib_uni libFirebaseCppApp DEPS "firebase_app" "firebase_app_swig")
   else()
     build_uni(
       "${TARGET_LINK_LIB_NAMES}"

--- a/cmake/build_shared.cmake
+++ b/cmake/build_shared.cmake
@@ -79,6 +79,12 @@ function(build_firebase_shared LIBRARY_NAME ARTIFACT_NAME OUTPUT_NAME)
         PREFIX "lib"
         SUFFIX ".a"
     )
+
+    # Enable Automatic Reference Counting (ARC) and Bitcode.
+    target_compile_options(${shared_target}
+                           PUBLIC "-fobjc-arc" "-fembed-bitcode")
+    target_link_libraries(${shared_target}
+                          PUBLIC "-fembed-bitcode")
   elseif(ANDROID)
     set_target_properties(${shared_target}
       PROPERTIES

--- a/docs/readme.md
+++ b/docs/readme.md
@@ -158,6 +158,7 @@ Release Notes
 ### Upcoming
 - Changes
     - General: Added a missing namespace to the Google.MiniJson.dll.
+    - General (iOS): Fix an issue with bitcode not being enabled correctly.
     - Functions: Add a new method `GetHttpsCallableFromURL`, to create callables
       with URLs other than cloudfunctions.net.
     - Analytics (iOS): Added InitiateOnDeviceConversionMeasurementWithEmail function to facilitate the


### PR DESCRIPTION
### Description
> Provide details of the change, and generalize the change in the PR title above.

First, explicitly enable bitcode, instead of depending on it being defined in the C++ SDKs. Second, remove linking against flatbuffers, since on mobile the symbols are put directly in the firebase_app library, which was causing the unity library to have double symbols, and on desktop it is linked against by firebase_app, and so shouldn't need to be added again.
***
### Testing
> Describe how you've tested these changes.


[replace this line]: # (Describe your testing in detail.)
***

### Type of Change
Place an `x` the applicable box:
- [x] Bug fix. Add the issue # below if applicable.
- [ ] New feature. A non-breaking change which adds functionality.
- [ ] Other, such as a build process or documentation change.
***

https://github.com/firebase/firebase-unity-sdk/issues/336