### PR TITLE
Handle passing null to cpp instance manager

### DIFF
--- a/app/src/cpp_instance_manager.h
+++ b/app/src/cpp_instance_manager.h
@@ -85,11 +85,9 @@ class CppInstanceManager {
   CppInstanceManager& operator=(CppInstanceManager&&) = delete;
 
   /// @brief Increase the reference count by 1.
-  /// @return Reference count after increment.
+  /// @return Reference count after increment. Return -1 if invalid instance.
   int AddReference(InstanceClass* instance) {
-    FIREBASE_DEV_ASSERT_MESSAGE(instance,
-                                "Null pointer is passed to AddReference<%s>().",
-                                typeid(InstanceClass).name());
+    if (!instance) return -1;
     MutexLock lock(manager_mutex_);
     auto it = container_.find(instance);
     if (it != container_.end()) {


### PR DESCRIPTION
### Description
> Provide details of the change, and generalize the change in the PR title above.

The internal GetInstance classes are sometimes expected to return null, for example Storage does if passing an invalid bucket.  Instead of checking for null in each case, it seems better to let the cpp_instance_manager handle when null is passed in, especially instead of storing those nulls, as it currently does, assuming assertions are off.
***
### Testing
> Describe how you've tested these changes.


Building and running locally
***

### Type of Change
Place an `x` the applicable box:
- [ ] Bug fix. Add the issue # below if applicable.
- [ ] New feature. A non-breaking change which adds functionality.
- [x] Other, such as a build process or documentation change.
***

