### PR TITLE
Update the ndk version to 21e

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -68,8 +68,8 @@ jobs:
         id: cache_ndk
         uses: actions/cache@v2
         with:
-          path: /tmp/android-ndk-r16b
-          key: android-ndk-${{ matrix.os }}-r16b
+          path: /tmp/android-ndk-r21e
+          key: android-ndk-${{ matrix.os }}-r21e
 
       - name: Install Unity installer (U3D)
         shell: bash

--- a/.github/workflows/build_android.yml
+++ b/.github/workflows/build_android.yml
@@ -87,8 +87,8 @@ jobs:
         id: cache_ndk
         uses: actions/cache@v2
         with:
-          path: /tmp/android-ndk-r16b
-          key: android-ndk-${{ matrix.os }}-r16b
+          path: /tmp/android-ndk-r21e
+          key: android-ndk-${{ matrix.os }}-r21e
 
       - name: Install Unity installer (U3D)
         shell: bash

--- a/scripts/gha/print_matrix_configuration.py
+++ b/scripts/gha/print_matrix_configuration.py
@@ -83,12 +83,12 @@ UNITY_SETTINGS = {
     _WINDOWS: {
       "version": "2020.3.34f1",
       "packages": {"Default": ["Unity"], "Android": ["Android"], "iOS": ["Ios"], "Windows": None, "macOS": ["Mac-mono"], "Linux": ["Linux-mono"]},
-      "ndk": "https://dl.google.com/android/repository/android-ndk-r19-windows-x86_64.zip"
+      "ndk": "https://dl.google.com/android/repository/android-ndk-r21e-windows-x86_64.zip"
     },
     _MACOS: {
       "version": "2020.3.34f1",
       "packages": {"Default": ["Unity"], "Android": ["Android"], "iOS": ["Ios"], "Windows": ["Windows-mono"], "macOS": None, "Linux": ["Linux-mono"]},
-      "ndk": "https://dl.google.com/android/repository/android-ndk-r19-darwin-x86_64.zip"
+      "ndk": "https://dl.google.com/android/repository/android-ndk-r21e-darwin-x86_64.zip"
     },
     _LINUX: {
       "version": "2020.3.29f1",
@@ -99,12 +99,12 @@ UNITY_SETTINGS = {
     _WINDOWS: {
       "version": "2019.4.39f1",
       "packages": {"Default": ["Unity"], "Android": ["Android"], "iOS": ["Ios"], "Windows": None, "macOS": ["Mac-mono"], "Linux": ["Linux-mono"]},
-      "ndk": "https://dl.google.com/android/repository/android-ndk-r19-windows-x86_64.zip"
+      "ndk": "https://dl.google.com/android/repository/android-ndk-r21e-windows-x86_64.zip"
     },
     _MACOS: {
       "version": "2019.4.39f1",
       "packages": {"Default": ["Unity"], "Android": ["Android"], "iOS": ["Ios"], "Windows": ["Windows-mono"], "macOS": None, "Linux": ["Linux-mono"]},
-      "ndk": "https://dl.google.com/android/repository/android-ndk-r19-darwin-x86_64.zip"
+      "ndk": "https://dl.google.com/android/repository/android-ndk-r21e-darwin-x86_64.zip"
     },
     _LINUX: {
       "version": "2019.4.39f1",
@@ -115,12 +115,12 @@ UNITY_SETTINGS = {
     _WINDOWS: {
       "version": "2018.4.36f1",
       "packages": {"Default": ["Unity"], "Android": ["Android"], "iOS": ["Ios"], "Windows": ["Windows-il2cpp"], "macOS": ["Mac-mono"], "Linux": ["Linux"]},
-      "ndk": "https://dl.google.com/android/repository/android-ndk-r16b-windows-x86_64.zip"
+      "ndk": "https://dl.google.com/android/repository/android-ndk-r21e-windows-x86_64.zip"
     },
     _MACOS: {
       "version": "2018.4.36f1",
       "packages": {"Default": ["Unity"], "Android": ["Android"], "iOS": ["Ios"], "Windows": ["Windows-mono"], "macOS": ["Mac-il2cpp"], "Linux": ["Linux"]},
-      "ndk": "https://dl.google.com/android/repository/android-ndk-r16b-darwin-x86_64.zip"
+      "ndk": "https://dl.google.com/android/repository/android-ndk-r21e-darwin-x86_64.zip"
     },
     _LINUX: {
       "version": "2018.3.0f2",


### PR DESCRIPTION
### Description
> Provide details of the change, and generalize the change in the PR title above.

The C++ repo recently changed the ndk version to 21e, so update the Unity repo to use the same.
***
### Testing
> Describe how you've tested these changes.


https://github.com/firebase/firebase-unity-sdk/actions/runs/2466239666
***

### Type of Change
Place an `x` the applicable box:
- [ ] Bug fix. Add the issue # below if applicable.
- [ ] New feature. A non-breaking change which adds functionality.
- [x] Other, such as a build process or documentation change.
***

