### PR TITLE
Don't log an error about missing python on windows

### DIFF
--- a/editor/app/src/PythonExecutor.cs
+++ b/editor/app/src/PythonExecutor.cs
@@ -137,12 +137,16 @@ namespace Firebase.Editor {
               // This one failed, ignore and move on to the next one.
             }
           }
+          // Only log an error for non-Windows platform, since Windows can use
+          // an executable instead of the python interpreter.
+          if (Application.platform != RuntimePlatform.WindowsEditor) {
+            Debug.LogError(
+                "Could not find a working python interpreter. " +
+                "Please make sure one of the following is in your PATH: " +
+                String.Join(" ", PYTHON_INTERPRETERS));
+          }
           // Fall back to the first option in case none worked, so this doesn't
           // keep retrying.
-          Debug.LogError(
-              "Could not find a working python interpreter. " +
-              "Please make sure one of the following is in your PATH: " +
-              String.Join(" ", PYTHON_INTERPRETERS));
           s_pythonInterpreter = PYTHON_INTERPRETERS[0];
         }
 


### PR DESCRIPTION
### Description
Disables the error log when unable to find python on a windows machine.
This is done because for Windows devices, PythonExecutor uses an executable instead of python. So even if python is not found, the build should still succeed and there is no need to log an error. 
Resolves https://github.com/firebase/quickstart-unity/issues/1289
***
### Testing
> Describe how you've tested these changes.
Not yet tested.
***

### Type of Change
Place an `x` the applicable box:
- [ x] Bug fix. Add the issue # below if applicable.
- [ ] New feature. A non-breaking change which adds functionality.
- [ ] Other, such as a build process or documentation change.
***

