### PR TITLE
[bugfix] build for windows consistently fails on windows Unity installation.

### DIFF
--- a/scripts/gha/unity_installer.py
+++ b/scripts/gha/unity_installer.py
@@ -178,8 +178,6 @@ def install_unity(unity_version, platforms):
   run([u3d, "install", "--trace",
        "--verbose", unity_full_version,
        "-p", package_csv])
-  # This will list what u3d has installed. For debugging purposes.
-  run([u3d, "list"], check=False)
   logging.info("Finished installing Unity.")
 
 


### PR DESCRIPTION
### Description
`u3d` seems missing `u3d list` cmd on Windows platform. 
Removed this cmd.

[replace this line]: # (Describe your changes in detail.)
***
### Testing
Unity Installation now succeed on Windows runners: https://github.com/firebase/firebase-unity-sdk/actions/runs/2694648743

[replace this line]: # (Describe your testing in detail.)
***

### Type of Change
Place an `x` the applicable box:
- [x] Bug fix. Add the issue # below if applicable.
- [ ] New feature. A non-breaking change which adds functionality.
- [ ] Other, such as a build process or documentation change.
***

