### PR TITLE
De-flaky the unity installation in CI

### DIFF
--- a/.github/workflows/build_starter.yml
+++ b/.github/workflows/build_starter.yml
@@ -98,7 +98,7 @@ jobs:
             echo "::set-output name=unity_branch::${{ github.event.inputs.unity_branch }}"
             echo "::set-output name=additional_cmake_flags::${{ github.event.inputs.unity_branch }}"
           else
-            echo "::set-output name=platform::'Android,iOS,Windows,macOS,Linux'"
+            echo "::set-output name=platform::'Android,iOS,Windows,macOS,Linux,Playmode'"
             echo "::set-output name=release_label::nightly-$(date "+%Y%m%d-%H%M%S")"
             echo "::set-output name=release_version::NoVersion"
             echo "::set-output name=apis::'analytics,auth,crashlytics,database,dynamic_links,firestore,functions,installations,messaging,remote_config,storage'"

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -395,7 +395,7 @@ jobs:
           max_attempts: 3
           shell: bash
           command:  |
-            gem install u3d
+            gem install u3d -v 1.2.3
             u3d available
       - name: Setup python
         uses: actions/setup-python@v2

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -387,6 +387,8 @@ jobs:
       LC_ALL: en_US.UTF-8
       LANG: en_US.UTF-8
       U3D_PASSWORD: ""
+      # Disable checking for U3D updates, since it is buggy
+      U3D_SKIP_UPDATE_CHECK: 1
     steps:
       - uses: actions/checkout@v2
       - uses: ruby/setup-ruby@v1
@@ -411,7 +413,7 @@ jobs:
       - name: Install Unity
         uses: nick-invision/retry@v2
         with:
-          timeout_minutes: 15
+          timeout_minutes: 20
           max_attempts: 3
           shell: bash
           command: |

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -200,7 +200,6 @@ jobs:
           shell: bash
           command:  |
             gem install u3d -v 1.2.3
-            u3d available
       - name: Setup python
         uses: actions/setup-python@v2
         with:
@@ -396,7 +395,6 @@ jobs:
           shell: bash
           command:  |
             gem install u3d -v 1.2.3
-            u3d available
       - name: Setup python
         uses: actions/setup-python@v2
         with:

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -192,14 +192,16 @@ jobs:
       U3D_SKIP_UPDATE_CHECK: 1
     steps:
       - uses: actions/checkout@v2
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: 3.0.2
       - name: Install Unity installer (U3D)
         uses: nick-invision/retry@v2
         with:
           timeout_minutes: 10
           max_attempts: 3
           shell: bash
-          command:  |
-            gem install u3d -v 1.2.3
+          command: gem install u3d -v 1.2.3
       - name: Setup python
         uses: actions/setup-python@v2
         with:
@@ -215,7 +217,7 @@ jobs:
           timeout_minutes: 30
           max_attempts: 3
           shell: bash
-          command:  |
+          command: |
             python scripts/gha/unity_installer.py --install \
               --platforms ${{ matrix.platform }} \
               --version ${{ matrix.unity_version }}
@@ -387,14 +389,16 @@ jobs:
       U3D_PASSWORD: ""
     steps:
       - uses: actions/checkout@v2
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: 3.0.2
       - name: Install Unity installer (U3D)
         uses: nick-invision/retry@v2
         with:
           timeout_minutes: 10
           max_attempts: 3
           shell: bash
-          command:  |
-            gem install u3d -v 1.2.3
+          command: gem install u3d -v 1.2.3
       - name: Setup python
         uses: actions/setup-python@v2
         with:
@@ -410,7 +414,7 @@ jobs:
           timeout_minutes: 15
           max_attempts: 3
           shell: bash
-          command:  |
+          command: |
             python scripts/gha/unity_installer.py --install \
               --version ${{ matrix.unity_version }}
       - name: Activate Unity license

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -5,9 +5,7 @@ on:
   workflow_dispatch:
     inputs:
       packaged_sdk_run_id:
-        description: 'run # of "Firebase Unity SDK build" workflow'
-        default: '0'
-        required: true
+        description: 'run # of "Firebase Unity SDK build" workflow. (If Leave it empty, the latest released Unity SDK will be used.)'
       unity_versions:
         description: 'Unity version'
         default: '2019'
@@ -238,6 +236,7 @@ jobs:
         run: |
           python scripts/gha/restore_secrets.py --passphrase "${{ secrets.TEST_SECRET }}"
       - name: Fetch prebuilt packaged SDK from previous run
+        if: ${{ github.event.inputs.packaged_sdk_run_id != '' }}
         uses: dawidd6/action-download-artifact@v2
         with:
           name: 'firebase_unity_sdk.zip'
@@ -247,7 +246,12 @@ jobs:
         timeout-minutes: 240
         shell: bash
         run: |
-          unzip -q firebase_unity_sdk.zip -d ~/Downloads/
+          if [[ -n "${{ github.event.inputs.packaged_sdk_run_id }}" ]]; then
+            unzip -q firebase_unity_sdk.zip -d ~/Downloads/
+          else
+            curl -L "https://firebase.google.com/download/unity" -o ~/Downloads/firebase_unity_sdk.zip
+            unzip -q ~/Downloads/firebase_unity_sdk.zip -d ~/Downloads/
+          fi
           python scripts/gha/build_testapps.py \
             --t ${{ needs.check_and_prepare.outputs.apis }} \
             --u $( python scripts/gha/print_matrix_configuration.py -k version -u ${{matrix.unity_version}}) \
@@ -427,15 +431,21 @@ jobs:
         run: |
           python scripts/gha/restore_secrets.py --passphrase "${{ secrets.TEST_SECRET }}"
       - name: Fetch prebuilt packaged SDK from previous run
+        if: ${{ github.event.inputs.packaged_sdk_run_id != '' }}
         uses: dawidd6/action-download-artifact@v2
         with:
           name: 'firebase_unity_sdk.zip'
           workflow: 'build_starter.yml'
-          run_id: ${{ github.event.inputs.packaged_sdk_run_id }}  
+          run_id: ${{ github.event.inputs.packaged_sdk_run_id }} 
       - name: Run Playmode (in editor mode) integration tests
         shell: bash
         run: |
-          unzip -q firebase_unity_sdk.zip -d ~/Downloads/
+          if [[ -n "${{ github.event.inputs.packaged_sdk_run_id }}" ]]; then
+            unzip -q firebase_unity_sdk.zip -d ~/Downloads/
+          else
+            curl -L "https://firebase.google.com/download/unity" -o ~/Downloads/firebase_unity_sdk.zip
+            unzip -q ~/Downloads/firebase_unity_sdk.zip -d ~/Downloads/
+          fi
           python scripts/gha/build_testapps.py \
             --t ${{ needs.check_and_prepare.outputs.apis }} \
             --u $( python scripts/gha/print_matrix_configuration.py -k version -u ${{matrix.unity_version}}) \

--- a/scripts/gha/unity_installer.py
+++ b/scripts/gha/unity_installer.py
@@ -68,7 +68,7 @@ X4-XXXX-XXXX-XXXX-XXXX
 
 
 (3) License release:
-  unity_installer.py --release_license --version 2017.3.1f1 --logfile return.log
+  unity_installer.py --release_license --version 2019 --logfile return.log
 
 """
 
@@ -109,7 +109,7 @@ flags.DEFINE_bool(
     "release_license", False,
     "Release an activated Unity license. Supply --version and --logfile.")
 
-flags.DEFINE_string("version", None, "Version string, e.g. 2017.3.1f1")
+flags.DEFINE_string("version", None, "Major version string, e.g. 2018")
 flags.DEFINE_string("license_file", None, "Path to the license file.")
 flags.DEFINE_string("username", None, "username for a Unity account.")
 flags.DEFINE_string("password", None, "password for that Unity account.")

--- a/scripts/gha/unity_installer.py
+++ b/scripts/gha/unity_installer.py
@@ -189,8 +189,8 @@ def uninstall_unity(unity_version):
   unity_full_version = UNITY_SETTINGS[unity_version][os]["version"]
 
   u3d = find_u3d()
-  run([u3d, "install", "--trace", "--verbose", unity_full_version], check=False)
-  logging.info("Finished installing Unity.")
+  run([u3d, "uninstall", "--trace", unity_full_version], check=False)
+  logging.info("Finished uninstalling Unity.")
 
 
 def activate_license(username, password, serial_ids, logfile, unity_version):

--- a/scripts/gha/unity_installer.py
+++ b/scripts/gha/unity_installer.py
@@ -83,7 +83,7 @@ from absl import logging
 from print_matrix_configuration import UNITY_SETTINGS
 
 
-_CMD_TIMEOUT = 600
+_CMD_TIMEOUT = 900
 
 _DEFALUT = "Default"
 _ANDROID = "Android"

--- a/scripts/gha/unity_installer.py
+++ b/scripts/gha/unity_installer.py
@@ -139,6 +139,7 @@ def main(argv):
     raise app.UsageError("Too many command-line arguments.")
 
   if FLAGS.install:
+    uninstall_unity(FLAGS.version)
     install_unity(FLAGS.version, FLAGS.platforms)
 
   if FLAGS.activate_license:
@@ -178,6 +179,17 @@ def install_unity(unity_version, platforms):
   run([u3d, "install", "--trace",
        "--verbose", unity_full_version,
        "-p", package_csv])
+  logging.info("Finished installing Unity.")
+
+
+def uninstall_unity(unity_version):
+  """Uninstalls Unity and build supports (packages)."""
+  # Cleaning up installed Unity.
+  os = get_os()
+  unity_full_version = UNITY_SETTINGS[unity_version][os]["version"]
+
+  u3d = find_u3d()
+  run([u3d, "install", "--trace", "--verbose", unity_full_version], check=False)
   logging.info("Finished installing Unity.")
 
 


### PR DESCRIPTION
### Description
1. cleaning un unity installation before retry unity installation
2. specify `u3d` version and disable `u3d` version check
3. remove flaky `u3d` cmd
4. set ruby version
5. add `playmode` test as default
6. If leave the `packaged_sdk_run_id` empty, then uses latest released Unity SDK

***
### Testing
Unity installation passed:
Packaging workflow:
https://github.com/firebase/firebase-unity-sdk/actions/runs/2701251024
https://github.com/firebase/firebase-unity-sdk/actions/runs/2701049788

Integration Test workflow:
https://github.com/firebase/firebase-unity-sdk/actions/runs/2701391198
https://github.com/firebase/firebase-unity-sdk/actions/runs/2701387893
https://github.com/firebase/firebase-unity-sdk/actions/runs/2701386315
https://github.com/firebase/firebase-unity-sdk/actions/runs/2701434427
https://github.com/firebase/firebase-unity-sdk/actions/runs/2701427066
***

### Type of Change
Place an `x` the applicable box:
- [x] Bug fix. Add the issue # below if applicable.
- [ ] New feature. A non-breaking change which adds functionality.
- [ ] Other, such as a build process or documentation change.
***

