### PR TITLE
Uninstall Android platforms that fail with Unity

### DIFF
--- a/scripts/gha/build_testapps.py
+++ b/scripts/gha/build_testapps.py
@@ -527,6 +527,16 @@ def patch_android_env(unity_version):
       logging.info("Uninstall Android build tool 31.0.0")
     except Exception as e:
       logging.info(str(e))
+
+  try:
+    # The platform android-33 includes libraries that were built with Java 11, and require a newer version of gradle
+    # than Unity comes with. Note this only happens when using minification.
+    # If this continues to be a problem, this logic might need to be smarter, to remove all versions newer than 32,
+    # but currently the GitHub runners have 33 as their max.
+    logging.info("Uninstall Android platform android-33")
+    _run([os.environ["ANDROID_HOME"]+"/tools/bin/sdkmanager", "--uninstall", "platforms;android-33"], check=False)
+  except Exception as e:
+    logging.info(str(e))
     
   os.environ["UNITY_ANDROID_SDK"]=os.environ["ANDROID_HOME"]
   os.environ["UNITY_ANDROID_NDK"]=os.environ["ANDROID_NDK_HOME"]

--- a/scripts/gha/build_testapps.py
+++ b/scripts/gha/build_testapps.py
@@ -536,7 +536,7 @@ def patch_android_env(unity_version):
     logging.info("Uninstall Android platform android-33")
     _run([os.environ["ANDROID_HOME"]+"/tools/bin/sdkmanager", "--uninstall", "platforms;android-33"], check=False)
   except Exception as e:
-    logging.info(str(e))
+    logging.exception("Failed to uninstall Android platform android-33")
     
   os.environ["UNITY_ANDROID_SDK"]=os.environ["ANDROID_HOME"]
   os.environ["UNITY_ANDROID_NDK"]=os.environ["ANDROID_NDK_HOME"]


### PR DESCRIPTION
### Description
> Provide details of the change, and generalize the change in the PR title above.

The Firestore Android testapp was failing to build, because it requires minification. The root cause is that the GitHub runners have the android-33 platform installed, and since it is the latest one, Unity tries to build with it, but some of the libraries (android.car.jar as an example) was build with Java 11.  This requires a newer JDK and Gradle than Unity uses, which causes the build to fail.  As a workaround, we can uninstall android-33 (the runners have 27 through 33 installed).
***
### Testing
> Describe how you've tested these changes.


https://github.com/firebase/firebase-unity-sdk/actions/runs/2792702607
***

### Type of Change
Place an `x` the applicable box:
- [x] Bug fix. Add the issue # below if applicable.
- [ ] New feature. A non-breaking change which adds functionality.
- [ ] Other, such as a build process or documentation change.
***

