### PR TITLE
Remove zlib on Windows build

### DIFF
--- a/.github/workflows/build_windows.yml
+++ b/.github/workflows/build_windows.yml
@@ -120,6 +120,12 @@ jobs:
           echo "$(swig -swiglib)" >> $GITHUB_PATH
           swig -swiglib
           echo "SWIG_DIR=$(swig -swiglib)" >> $GITHUB_ENV
+
+      # mingw has zlib installed, which causes problems for the build, so we remove it
+      - name: Remove zlib
+        shell: bash
+        run: |
+          rm C:/msys64/mingw64/lib/libz*
       
       - name: Build SDK (Windows)
         timeout-minutes: 90


### PR DESCRIPTION
### Description
> Provide details of the change, and generalize the change in the PR title above.

The windows build started failing recently, and the root cause seems to be zlib being installed with mingw. This results in CMake "finding" zlib, and adding it to the include path, which causes issues on the Windows build, as it uses the wrong system headers.  The fix for this is to remove the zlib library prior to the build, since we don't need it anyway.
***
### Testing
> Describe how you've tested these changes.

https://github.com/firebase/firebase-unity-sdk/actions/runs/2930380586
***

### Type of Change
Place an `x` the applicable box:
- [x] Bug fix. Add the issue # below if applicable.
- [ ] New feature. A non-breaking change which adds functionality.
- [ ] Other, such as a build process or documentation change.
***

