### PR TITLE
Check env-var UNITY_ROOT_DIR as well during build

### DIFF
--- a/cmake/FindUnity.cmake
+++ b/cmake/FindUnity.cmake
@@ -20,18 +20,23 @@ if (NOT EXISTS "${UNITY_ROOT_DIR}")
   # Make our best attempt to find the latest unity installed on the system.
   # Note that Unity <=2018 include mono 2.x which causes compilation errors.
   # Minimum supported version of mono is 3.5.
-  if(CMAKE_HOST_WIN32)
-    set(editordir "C:/Program Files/Unity/Hub/Editor")
-  elseif(CMAKE_HOST_APPLE)
-    set(editordir "/Applications/Unity/Hub/Editor")
-  elseif(CMAKE_HOST_UNIX) # Linux
-    set(editordir "$ENV{HOME}/Unity/Hub/Editor")
+  if (EXISTS "$ENV{UNITY_ROOT_DIR}")
+    set(UNITY_ROOT_DIR "$ENV{UNITY_ROOT_DIR}")
+    message(STATUS "Detected Unity version from env-var 'UNITY_ROOT_DIR': ${UNITY_ROOT_DIR}")
+  else()
+    if(CMAKE_HOST_WIN32)
+        set(editordir "C:/Program Files/Unity/Hub/Editor")
+    elseif(CMAKE_HOST_APPLE)
+        set(editordir "/Applications/Unity/Hub/Editor")
+    elseif(CMAKE_HOST_UNIX) # Linux
+        set(editordir "$ENV{HOME}/Unity/Hub/Editor")
+    endif()
+    file(GLOB unity_versions RELATIVE ${editordir} ${editordir}/*)
+    list(SORT unity_versions ORDER DESCENDING)
+    list(GET unity_versions 0 latest_unity_version)
+    set(UNITY_ROOT_DIR ${editordir}/${latest_unity_version})
+    message(STATUS "Auto detected latest Unity version: ${UNITY_ROOT_DIR}")
   endif()
-  file(GLOB unity_versions RELATIVE ${editordir} ${editordir}/*)
-  list(SORT unity_versions ORDER DESCENDING)
-  list(GET unity_versions 0 latest_unity_version)
-  set(UNITY_ROOT_DIR ${editordir}/${latest_unity_version})
-  message(STATUS "Auto detected latest Unity version: ${UNITY_ROOT_DIR}")
 endif()
 
 if(FIREBASE_INCLUDE_UNITY)
@@ -95,7 +100,7 @@ if(FIREBASE_INCLUDE_UNITY)
 
   message(STATUS "UNITY_MONO_EXE is ${UNITY_MONO_EXE}")
   message(STATUS "UNITY_CSHARP_BUILD_EXE is ${UNITY_CSHARP_BUILD_EXE}")
-    
+
   if(NOT EXISTS UNITY_MONO_EXE OR
     NOT EXISTS UNITY_CSHARP_BUILD_EXE)
     set(FIND_TOOL_OPTIONS


### PR DESCRIPTION
### Description
> Provide details of the change, and generalize the change in the PR title above.

Currently the build script would automatically find the latest version of Unity unless it is passed with `-unity_root=` parameter.

This change make sure that the build script also check environment variable `UNITY_ROOT_DIR` before searching for the latest version of Unity.

***
### Testing
> Describe how you've tested these changes.

Run it locally
***

### Type of Change
Place an `x` the applicable box:
- [ ] Bug fix. Add the issue # below if applicable.
- [ ] New feature. A non-breaking change which adds functionality.
- [x] Other, such as a build process or documentation change.
***

