### PR TITLE
Fix #218 that Firebase editor tool not loading when iOS build support is not installed

### DIFF
--- a/docs/readme.md
+++ b/docs/readme.md
@@ -155,6 +155,11 @@ Support
 
 Release Notes
 -------------
+### 9.5.0
+- Changes
+    - Crashlytics: Fix #218 that Firebase editor tool not loading when iOS
+      build support is not installed.
+
 ### 9.4.0
 - Changes
     - General: Updated Firebase C++ SDK dependencies to v9.4.0.

--- a/editor/crashlytics/src/iOSPostBuild.cs
+++ b/editor/crashlytics/src/iOSPostBuild.cs
@@ -109,8 +109,9 @@ namespace Firebase.Crashlytics.Editor {
       pbxProject.WriteToFile(projectPath);
     }
 
-    private static void SetupGUIDForSymbolUploads(UnityEditor.iOS.Xcode.PBXProject pbxProject,
+    private static void SetupGUIDForSymbolUploads(object pbxProjectObj,
                                                   string completeRunScriptBody, string targetGuid) {
+      var pbxProject = (UnityEditor.iOS.Xcode.PBXProject) pbxProjectObj;
       try {
         // Use reflection to append a Crashlytics Run Script
         BindingFlags bindingFlags = BindingFlags.NonPublic | BindingFlags.Instance | BindingFlags.Public;
@@ -152,8 +153,9 @@ namespace Firebase.Crashlytics.Editor {
       }
     }
 
-    private static string GetUnityFrameworkTargetGuid(UnityEditor.iOS.Xcode.PBXProject project) {
-      // var project = (UnityEditor.iOS.Xcode.PBXProject)projectObj;
+    private static string GetUnityFrameworkTargetGuid(object projectObj) {
+      var project = (UnityEditor.iOS.Xcode.PBXProject)projectObj;
+
       MethodInfo getUnityFrameworkTargetGuid =
           project.GetType().GetMethod("GetUnityFrameworkTargetGuid");
 

--- a/scripts/gha/integration_testing/XcodeCapabilities.cs
+++ b/scripts/gha/integration_testing/XcodeCapabilities.cs
@@ -87,7 +87,8 @@ public sealed class XcodeCapabilities
     File.WriteAllText(projectPath, tempProject.WriteToString());
   }
 
-  static void AddEntitlements(PBXProject project, string path, string targetId){
+  static void AddEntitlements(object projectObj, string path, string targetId){
+    var project = (PBXProject)projectObj;
     string[] entitlements = AssetDatabase.FindAssets("dev")
       .Select(AssetDatabase.GUIDToAssetPath)
       .Where(p => p.Contains("dev.entitlements"))
@@ -112,20 +113,23 @@ public sealed class XcodeCapabilities
     Debug.Log("Added entitlement to xcode project.");
   }
 
-  static void MakeChangesForMessaging(PBXProject project, string path, string targetId) {
+  static void MakeChangesForMessaging(object projectObj, string path, string targetId) {
+    var project = (PBXProject)projectObj;
     Debug.Log("Messaging testapp detected.");
     AddFramework(project, targetId, "UserNotifications.framework");
     EnableRemoteNotification(project, path, targetId);
     Debug.Log("Finished making messaging-specific changes.");
   }
 
-  static void MakeChangesForAuth(PBXProject project, string path, string targetId) {
+  static void MakeChangesForAuth(object projectObj, string path, string targetId) {
+    var project = (PBXProject)projectObj;
     Debug.Log("Auth testapp detected.");
     AddFramework(project, targetId, "UserNotifications.framework");
     Debug.Log("Finished making auth-specific changes.");
   }
 
-  static void EnableRemoteNotification(PBXProject project, string path, string targetId) {
+  static void EnableRemoteNotification(object projectObj, string path, string targetId) {
+    var project = (PBXProject)projectObj;
     Debug.Log("Adding remote-notification to UIBackgroundModes");
     var plist = new PlistDocument();
     string plistPath = path + "/Info.plist";
@@ -137,13 +141,15 @@ public sealed class XcodeCapabilities
     Debug.Log("Finished adding remote-notification.");
   }
 
-  static void AddFramework(PBXProject project, string targetId, string framework) {
+  static void AddFramework(object projectObj, string targetId, string framework) {
+    var project = (PBXProject)projectObj;
     Debug.LogFormat("Adding framework to xcode project: {0}.", framework);
     project.AddFrameworkToProject(targetId, framework, false);
     Debug.Log("Finished adding framework.");
   }
 
-  static string GetMainTargetGUID(PBXProject pbxProject) {
+  static string GetMainTargetGUID(object pbxProjectObj) {
+    var pbxProject = (PBXProject)pbxProjectObj;
     // In 2019.3 Unity changed this API without an automated update path via the api-updater.
     // There doesn't seem to be a clean version-independent way to handle this logic.
     #if UNITY_2019_3_OR_NEWER


### PR DESCRIPTION
### Description
> Provide details of the change, and generalize the change in the PR title above.

Crashlytics editor tool will not load if the user only adds Android build support to the Unity editor but not iOS build support.  This is because Unity has more restricted validation to function signature when loading dlls.
    
This fix avoids passing `UnityEditor.iOS.Extensions.Xcode.PBXProject` directly but passing an `object` instead.
    
Also fixes the integration test script just in case we want to run the test against only one build target.

***
### Testing
> Describe how you've tested these changes.

GHA integration test

***

### Type of Change
Place an `x` the applicable box:
- [x] Bug fix. Add the issue # below if applicable.
- [ ] New feature. A non-breaking change which adds functionality.
- [ ] Other, such as a build process or documentation change.
***

