### PR TITLE
Update build workflow to use the C++ version input

### DIFF
--- a/.github/workflows/build_starter.yml
+++ b/.github/workflows/build_starter.yml
@@ -95,6 +95,7 @@ jobs:
             echo "::set-output name=unity_version::${{ github.event.inputs.unity_version }}"
             echo "::set-output name=should_trigger_package::${{ github.event.inputs.should_trigger_package }}"
             echo "::set-output name=runIntegrationTests::${{ github.event.inputs.runIntegrationTests }}"
+            echo "::set-output name=firebase_cpp_sdk_version::${{ github.event.inputs.firebase_cpp_sdk_version }}"
             echo "::set-output name=unity_branch::${{ github.event.inputs.unity_branch }}"
             echo "::set-output name=additional_cmake_flags::${{ github.event.inputs.unity_branch }}"
           else
@@ -104,7 +105,7 @@ jobs:
             echo "::set-output name=apis::'analytics,auth,crashlytics,database,dynamic_links,firestore,functions,installations,messaging,remote_config,storage'"
             echo "::set-output name=unity_version::2019"
             echo "::set-output name=should_trigger_package::true"
-            echo "::set-output name=firebase_cpp_sdk_version::${{ github.event.inputs.firebase_cpp_sdk_version }}"
+            echo "::set-output name=firebase_cpp_sdk_version::"
             echo "::set-output name=unity_branch::"
             echo "::set-output name=additional_cmake_flags::"
             if [[ "${{ github.event_name }}" == "schedule" ]]; then

--- a/.github/workflows/build_starter.yml
+++ b/.github/workflows/build_starter.yml
@@ -104,7 +104,7 @@ jobs:
             echo "::set-output name=apis::'analytics,auth,crashlytics,database,dynamic_links,firestore,functions,installations,messaging,remote_config,storage'"
             echo "::set-output name=unity_version::2019"
             echo "::set-output name=should_trigger_package::true"
-            echo "::set-output name=firebase_cpp_sdk_version::"
+            echo "::set-output name=firebase_cpp_sdk_version::${{ github.event.inputs.firebase_cpp_sdk_version }}"
             echo "::set-output name=unity_branch::"
             echo "::set-output name=additional_cmake_flags::"
             if [[ "${{ github.event_name }}" == "schedule" ]]; then


### PR DESCRIPTION
### Description
The C++ version input was being ignored and empty string was set instead.
***
### Testing
Ran this workflow and verified that the Print Outputs step printed outputs.firebase_cpp_sdk_version as a non-empty string
https://github.com/firebase/firebase-unity-sdk/actions/runs/3115233731/jobs/5051915301
***

### Type of Change
Place an `x` the applicable box:
- [ ] Bug fix. Add the issue # below if applicable.
- [ ] New feature. A non-breaking change which adds functionality.
- [x] Other, such as a build process or documentation change.
***

