### PR TITLE
Unity Editor support for tvOS pods and xcode projects

### DIFF
--- a/app/platform/Unity/PlatformInformation.cs
+++ b/app/platform/Unity/PlatformInformation.cs
@@ -31,7 +31,8 @@ internal static class PlatformInformation {
   // Is the current platform iOS?
   internal static bool IsIOS {
     get {
-      return UnityEngine.Application.platform == UnityEngine.RuntimePlatform.IPhonePlayer;
+      return UnityEngine.Application.platform == UnityEngine.RuntimePlatform.IPhonePlayer ||
+         UnityEngine.Application.platform == UnityEngine.RuntimePlatform.tvOS;
     }
   }
 

--- a/app/platform/Unity/PlatformInformation.cs
+++ b/app/platform/Unity/PlatformInformation.cs
@@ -28,7 +28,7 @@ internal static class PlatformInformation {
     }
   }
 
-  // Is the current platform iOS?
+  // Is the current platform iOS or tvOS?
   internal static bool IsIOS {
     get {
       return UnityEngine.Application.platform == UnityEngine.RuntimePlatform.IPhonePlayer ||

--- a/app/src/ErrorMessages.cs
+++ b/app/src/ErrorMessages.cs
@@ -43,7 +43,7 @@ internal class ErrorMessages {
       "* Rebuild your APK and deploy.\n";
 
   private static string DEPENDENCY_NOT_FOUND_ERROR_IOS =
-      "On iOS, Firebase requires native (C/C++) and Cocoapod components\n" +
+      "On iOS+ Firebase requires native (C/C++) and Cocoapod components\n" +
       "that are distributed with the Firebase SDK and via Cocoapods.\n" +
       "\n" +
       "It's likely that you did not include the require Cocoapod\n" +

--- a/editor/app/src/DocRef.Designer.cs
+++ b/editor/app/src/DocRef.Designer.cs
@@ -514,7 +514,7 @@ namespace Firebase.Editor {
         }
 
         /// <summary>
-        ///   Looks up a localized string similar to Ready to use Firebase on iOS..
+        ///   Looks up a localized string similar to Ready to use Firebase on iOS.
         /// </summary>
         internal static string IOSConnected {
             get {

--- a/editor/app/src/GenerateXmlFromGoogleServicesJson.cs
+++ b/editor/app/src/GenerateXmlFromGoogleServicesJson.cs
@@ -20,7 +20,7 @@
 //
 // It also creates the google-services-desktop.json file, (used when building on
 // desktop or running in the editor) based on either the google-services.json or
-// GoogleService-Info.plist file, depending on your current build target.  (iOS
+// GoogleService-Info.plist file, depending on your current build target.  (iOS+
 // targets will prefer the GoogleService-Info.plist file, while Android build
 // targets will prefer google-services.json.)
 //
@@ -172,7 +172,7 @@ namespace Firebase.Editor {
       // file.
 
       // If the project is set to build for Android, the google-services.json file
-      // is preferred.  If it is set to build for iOS, the GoogleServices-Info.plist
+      // is preferred.  If it is set to build for iOS+, the GoogleServices-Info.plist
       // file is preferred.  When set to standalone desktop, it tries to match the
       // current bundleid, and if it can't, it takes any plist/json file it can find.
 
@@ -201,7 +201,8 @@ namespace Firebase.Editor {
         // Regenerate google-services-desktop file.
         switch (EditorUserBuildSettings.selectedBuildTargetGroup) {
           case BuildTargetGroup.iOS:
-            // If we're on iOS, generate the desktop file from the plist, if possible.
+          case BuildTargetGroup.tvOS:
+            // If we're on iOS+, generate the desktop file from the plist, if possible.
             if (googleServiceInfoFile != null) {
               CreateDesktopJsonFromPlist(googleServiceInfoFile);
             } else if (googleServicesFile != null) {
@@ -229,7 +230,8 @@ namespace Firebase.Editor {
         logMessageForNoConfigFiles(
             String.Format(DocRef.GoogleServicesFileBundleIdMissing,
                 GetAndroidApplicationId(),
-                EditorUserBuildSettings.selectedBuildTargetGroup == BuildTargetGroup.iOS ?
+                (EditorUserBuildSettings.selectedBuildTargetGroup == BuildTargetGroup.iOS ||
+                 EditorUserBuildSettings.selectedBuildTargetGroup == BuildTargetGroup.tvOS) ?
                     "GoogleService-Info.plist" : "google-services.json",
                 String.Join("\n", BundleIdsFromBundleIdsByConfigFile(
                     ConfigFileDirectory).ToArray()),
@@ -465,10 +467,11 @@ namespace Firebase.Editor {
       ConfigFileType fileType;
       if (EditorUserBuildSettings.selectedBuildTargetGroup == BuildTargetGroup.Android) {
         fileType = ConfigFileType.Json;
-      } else if (EditorUserBuildSettings.selectedBuildTargetGroup == BuildTargetGroup.iOS) {
+      } else if (EditorUserBuildSettings.selectedBuildTargetGroup == BuildTargetGroup.iOS ||
+                 EditorUserBuildSettings.selectedBuildTargetGroup == BuildTargetGroup.tvOS) {
         fileType = ConfigFileType.Plist;
       } else {
-        // Don't need to be here, if we're not on iOS or Android.
+        // Don't need to be here, if we're not on iOS+ or Android.
         return;
       }
       var configFile = FindGoogleServicesFile(fileType, bundleId,

--- a/editor/app/src/XcodeProjectModifier.cs
+++ b/editor/app/src/XcodeProjectModifier.cs
@@ -203,7 +203,7 @@ internal class XcodeProjectModifier {
   // the methods. Once that is complete it saves the modifications back over the original files.
   [PostProcessBuild]
   internal static void PostProcessBuild(BuildTarget buildTarget, string pathToBuiltProject) {
-    if (buildTarget != BuildTarget.iOS && buildTarget != BuildTarget.tvOS)
+    if (buildTarget != BuildTarget.iOS && buildTarget != BuildTarget.tvOS) {
       logger.LogDebug("Skipping PostProcessBuild as target {0} is not for iOS+", buildTarget);
       return;
     }

--- a/editor/app/src/XcodeProjectModifier.cs
+++ b/editor/app/src/XcodeProjectModifier.cs
@@ -203,9 +203,8 @@ internal class XcodeProjectModifier {
   // the methods. Once that is complete it saves the modifications back over the original files.
   [PostProcessBuild]
   internal static void PostProcessBuild(BuildTarget buildTarget, string pathToBuiltProject) {
-    // BuiltTarget.iOS is not defined in Unity 4, so we just use strings here
-    if (buildTarget.ToString() != "iOS" && buildTarget.ToString() != "iPhone") {
-      logger.LogDebug("Skipping PostProcessBuild as target {0} is not for iOS", buildTarget);
+    if (buildTarget != BuildTarget.iOS && buildTarget != BuildTarget.tvOS)
+      logger.LogDebug("Skipping PostProcessBuild as target {0} is not for iOS+", buildTarget);
       return;
     }
 

--- a/editor/app/src/XcodeProjectPatcher.cs
+++ b/editor/app/src/XcodeProjectPatcher.cs
@@ -227,8 +227,16 @@ internal class XcodeProjectPatcher : AssetPostprocessor {
                     "Cancel",
                     selectedBundleId => {
                         if (!String.IsNullOrEmpty(selectedBundleId)) {
-                            UnityCompat.SetApplicationId(
-                                EditorUserBuildSettings.activeBuildTarget, selectedBundleId);
+                            switch(EditorUserBuildSettings.activeBuildTarget) {
+                                case BuildTarget.iOS:
+                                    UnityCompat.SetApplicationId(BuildTarget.iOS, selectedBundleId)
+                                    break;
+                                case BuildTarget.tvOS:
+                                    UnityCompat.SetApplicationId(BuildTarget.tvOS, selectedBundleId)
+                                    break;
+                                default:
+                                    throw new Exception("unsupported iOS+ version");
+                            }
                         } else {
                             Measurement.ReportWithBuildTarget("bundleidmismatch/cancel", null,
                                                               "Mismatched Bundle ID: Cancel");

--- a/editor/app/src/XcodeProjectPatcher.cs
+++ b/editor/app/src/XcodeProjectPatcher.cs
@@ -100,23 +100,18 @@ internal class XcodeProjectPatcher : AssetPostprocessor {
     }
 
     // Get the iOS+ bundle / application ID.
-    private static string GetApplicationId() {
-        switch(EditorUserBuildSettings.activeBuildTarget) {
-            case BuildTarget.iOS:
-                return UnityCompat.GetApplicationId(BuildTarget.iOS);
-                break;
-            case BuildTarget.tvOS:
-                return UnityCompat.GetApplicationId(BuildTarget.tvOS);
-                break;
-            default:
-                throw new Exception("unsupported iOS+ version");
+    private static string GetIosPlusApplicationId() {
+        if (EditorUserBuildSettings.activeBuildTarget == BuildTarget.tvOS) {
+            return UnityCompat.GetApplicationId(BuildTarget.tvOS);
+        } else {
+            return UnityCompat.GetApplicationId(BuildTarget.iOS);
         }
     }
 
     // Check the editor environment on the first update after loading this
     // module.
     private static void CheckConfiguration() {
-        CheckBundleId(GetApplicationId());
+        CheckBundleId(GetIosPlusApplicationId());
         CheckBuildEnvironment();
     }
 
@@ -187,7 +182,7 @@ internal class XcodeProjectPatcher : AssetPostprocessor {
             object sender,
             PlayServicesResolver.BundleIdChangedEventArgs args) {
         ReadConfig(errorOnNoConfig: false);
-        CheckBundleId(GetApplicationId());
+        CheckBundleId(GetIosPlusApplicationId());
     }
 
     // Check the bundle ID
@@ -271,7 +266,7 @@ internal class XcodeProjectPatcher : AssetPostprocessor {
         if (configFilePresent) {
             spamguard = false; // Reset our spamguard to show a dialog.
             ReadConfig(errorOnNoConfig: false);
-            CheckBundleId(GetApplicationId());
+            CheckBundleId(GetIosPlusApplicationId());
         }
     }
 
@@ -303,7 +298,7 @@ internal class XcodeProjectPatcher : AssetPostprocessor {
                         GOOGLE_SERVICES_INFO_PLIST_FILE, Link.IOSAddApp));
             }
         } else if (files.Length > 1) {
-            var bundleId = GetApplicationId();
+            var bundleId = GetIosPlusApplicationId();
             string selectedBundleId = null;
             // Search files for the first file matching the project's bundle identifier.
             foreach (var filename in files) {
@@ -353,7 +348,7 @@ internal class XcodeProjectPatcher : AssetPostprocessor {
             return;
         }
 
-        CheckBundleId(GetApplicationId(), promptUpdate: false);
+        CheckBundleId(GetIosPlusApplicationId(), promptUpdate: false);
 
         // Copy the config file to the Xcode project folder.
         string configFileBasename = Path.GetFileName(configFile);

--- a/editor/app/src/XcodeProjectPatcher.cs
+++ b/editor/app/src/XcodeProjectPatcher.cs
@@ -175,7 +175,7 @@ internal class XcodeProjectPatcher : AssetPostprocessor {
         // If iOS+ is the selected build target but we're not on a OSX
         // machine report an error as pod installation will fail among other
         // things.
-        const BuildTarget buildTarget = EditorUserBuildSettings.activeBuildTarget;
+        BuildTarget buildTarget = EditorUserBuildSettings.activeBuildTarget;
         if ((buildTarget == BuildTarget.iOS || buildTarget == BuildTarget.tvOS) &&
             Application.platform == RuntimePlatform.WindowsEditor) {
             Debug.LogError(DocRef.IOSNotSupportedOnWindows);
@@ -229,10 +229,10 @@ internal class XcodeProjectPatcher : AssetPostprocessor {
                         if (!String.IsNullOrEmpty(selectedBundleId)) {
                             switch(EditorUserBuildSettings.activeBuildTarget) {
                                 case BuildTarget.iOS:
-                                    UnityCompat.SetApplicationId(BuildTarget.iOS, selectedBundleId)
+                                    UnityCompat.SetApplicationId(BuildTarget.iOS, selectedBundleId);
                                     break;
                                 case BuildTarget.tvOS:
-                                    UnityCompat.SetApplicationId(BuildTarget.tvOS, selectedBundleId)
+                                    UnityCompat.SetApplicationId(BuildTarget.tvOS, selectedBundleId);
                                     break;
                                 default:
                                     throw new Exception("unsupported iOS+ version");
@@ -334,7 +334,7 @@ internal class XcodeProjectPatcher : AssetPostprocessor {
     internal static void OnPostProcessAddGoogleServicePlist(
             BuildTarget buildTarget, string pathToBuiltProject) {
         if (!Enabled) return;
-        string platform = (buildTarget == BuildTarget.iOS) ? "iOS" : "tvOS"
+        string platform = (buildTarget == BuildTarget.iOS) ? "iOS" : "tvOS";
         Measurement.analytics.Report("ios/xcodepatch",
             platform + " Xcode Project Patcher: Start");
         AddGoogleServicePlist(buildTarget, pathToBuiltProject);

--- a/editor/app/src/XcodeProjectPatcher.cs
+++ b/editor/app/src/XcodeProjectPatcher.cs
@@ -227,27 +227,8 @@ internal class XcodeProjectPatcher : AssetPostprocessor {
                     "Cancel",
                     selectedBundleId => {
                         if (!String.IsNullOrEmpty(selectedBundleId)) {
-                            // If we have a valid value, the user hit apply.
-                            const BuildTarget activeBuildTarget =
-                                EditorUserBuildSettings.activeBuildTarget;
-                            if (activeBuildTarget == BuildTarget.iOS) {
-                                UnityCompat.SetApplicationId(BuildTarget.iOS,
-                                    selectedBundleId);
-                            } else if (activeBuildTarget == BuildTarget.tvOS) {
-                                UnityCompat.SetApplicationId(BuildTarget.tvOS,
-                                    selectedBundleId);
-                            } else {
-                                // If the user hits cancel, we disable the dialog to
-                                // avoid spamming the user.
-                                spamguard = true;
-                                string unsupportedTargetErrorMessage = String.format(
-                                    "Internal error setting bundleId for unsupported " +
-                                    "target." );
-                                Debug.LogError(unsupportedTargetErrorMessage);
-                            }
-
-                            Measurement.ReportWithBuildTarget("bundleidmismatch/apply", null,
-                                                              "Mismatched Bundle ID: Apply");
+                            UnityCompat.SetApplicationId(
+                                EditorUserBuildSettings.activeBuildTarget, selectedBundleId);
                         } else {
                             Measurement.ReportWithBuildTarget("bundleidmismatch/cancel", null,
                                                               "Mismatched Bundle ID: Cancel");

--- a/editor/crashlytics/src/iOSPostBuild.cs
+++ b/editor/crashlytics/src/iOSPostBuild.cs
@@ -68,7 +68,6 @@ namespace Firebase.Crashlytics.Editor {
     /// </param>
     [PostProcessBuild(100)]
     public static void OnPostprocessBuild(BuildTarget buildTarget, string buildPath) {
-      // BuiltTarget.iOS is not defined in Unity 4, so we just use strings here
       if (buildTarget == BuildTarget.iOS || buildTarget == BuildTarget.tvOS) {
         string projectPath = Path.Combine(buildPath, "Unity-iPhone.xcodeproj/project.pbxproj");
         string plistPath = Path.Combine(buildPath, "Info.plist");

--- a/editor/crashlytics/src/iOSPostBuild.cs
+++ b/editor/crashlytics/src/iOSPostBuild.cs
@@ -69,18 +69,19 @@ namespace Firebase.Crashlytics.Editor {
     [PostProcessBuild(100)]
     public static void OnPostprocessBuild(BuildTarget buildTarget, string buildPath) {
       // BuiltTarget.iOS is not defined in Unity 4, so we just use strings here
-      if (buildTarget.ToString() == "iOS" || buildTarget.ToString() == "iPhone") {
+      if (buildTarget == BuildTarget.iOS || buildTarget == BuildTarget.tvOS) {
         string projectPath = Path.Combine(buildPath, "Unity-iPhone.xcodeproj/project.pbxproj");
         string plistPath = Path.Combine(buildPath, "Info.plist");
 
         IFirebaseConfigurationStorage configurationStorage = StorageProvider.ConfigurationStorage;
 
-        PrepareProject(projectPath, configurationStorage);
+        PrepareProject(projectPath, configurationStorage, buildTarget);
         AddCrashlyticsDevelopmentPlatformToPlist(plistPath);
       }
     }
 
-    private static void PrepareProject(string projectPath, IFirebaseConfigurationStorage configurationStorage) {
+    private static void PrepareProject(string projectPath, IFirebaseConfigurationStorage configurationStorage,
+                                       BuildTarget build_target) {
       // Return if we have already added the script
       var xcodeProjectLines = File.ReadAllLines(projectPath);
       foreach (var line in xcodeProjectLines) {
@@ -96,7 +97,7 @@ namespace Firebase.Crashlytics.Editor {
 
       string completeRunScriptBody = GetRunScriptBody(configurationStorage);
 
-      string appGUID = iOSPostBuild.GetMainUnityProjectTargetGuid(pbxProject);
+      string appGUID = iOSPostBuild.GetMainUnityProjectTargetGuid(pbxProject, buildTarget);
       SetupGUIDForSymbolUploads(pbxProject, completeRunScriptBody, appGUID);
 
       // In older versions of Unity there is no separate framework GUID, so this can
@@ -183,7 +184,7 @@ namespace Firebase.Crashlytics.Editor {
     /// </summary>
     /// <param name="projectObj">The project where the main target GUID will be read from</param>
     /// <returns>The main target GUID</returns>
-    private static string GetMainUnityProjectTargetGuid(object projectObj) {
+    private static string GetMainUnityProjectTargetGuid(object projectObj, BuildTarget buildTarget) {
       var project = (UnityEditor.iOS.Xcode.PBXProject)projectObj;
       MethodInfo getUnityMainTargetGuid =  project.GetType().GetMethod("GetUnityMainTargetGuid");
 
@@ -194,7 +195,7 @@ namespace Firebase.Crashlytics.Editor {
       } else {
         // Hardcode the main target name "Unity-iPhone" by default, just in case
         // GetUnityTargetName() is not available.
-        string targetName = "Unity-iPhone";
+        string targetName = (buildTarget == BuildTarget.tvOS) ? "Unity-tvOS" : "Unity-iPhone";
         MethodInfo getUnityTargetName =  project.GetType().GetMethod("GetUnityTargetName");
         if (getUnityTargetName != null) {
           targetName = (string) getUnityTargetName.Invoke(null, new object[] {});

--- a/editor/crashlytics/src/iOSPostBuild.cs
+++ b/editor/crashlytics/src/iOSPostBuild.cs
@@ -81,7 +81,7 @@ namespace Firebase.Crashlytics.Editor {
     }
 
     private static void PrepareProject(string projectPath, IFirebaseConfigurationStorage configurationStorage,
-                                       BuildTarget build_target) {
+                                       BuildTarget buildTarget) {
       // Return if we have already added the script
       var xcodeProjectLines = File.ReadAllLines(projectPath);
       foreach (var line in xcodeProjectLines) {

--- a/firestore/testapp/Assets/Firebase/Editor/Builder.cs
+++ b/firestore/testapp/Assets/Firebase/Editor/Builder.cs
@@ -43,6 +43,23 @@ public class Builder {
     Build(options);
   }
 
+  public static void BuildTvos() {
+    var options = new BuildPlayerOptions();
+
+    // For tvOS, this is the name of the folder containing the generated XCode
+    // project.
+    options.locationPathName = "tvos-build";
+    options.target = BuildTarget.tvOS;
+    // Firebase Unity plugins don't seem to work on a simulator.
+    PlayerSettings.tvOS.sdkVersion = tvOSSdkVersion.DeviceSDK;
+
+    // AcceptExternalModificationsToPlayer corresponds to "Append" in the Unity
+    // UI -- it allows doing incremental builds.
+    options.options = BuildOptions.AcceptExternalModificationsToPlayer;
+
+    Build(options);
+  }
+
   public static void BuildAndroid() {
     var options = new BuildPlayerOptions();
 

--- a/scripts/gha/integration_testing/XcodeCapabilities.cs
+++ b/scripts/gha/integration_testing/XcodeCapabilities.cs
@@ -63,7 +63,7 @@ public sealed class XcodeCapabilities
   [PostProcessBuild]
   public static void OnPostprocessBuild (BuildTarget buildTarget, string path)
   {
-    if (buildTarget != BuildTarget.iOS) {
+    if (buildTarget != BuildTarget.iOS && buildTarget != BuildTarget.tvOS) {
       return;
     }
 


### PR DESCRIPTION
### Description
> Provide details of the change, and generalize the change in the PR title above.

Updates to the Unity build process to handle tvOS pod dependencies and xcode project file configuration.

***
### Testing
> Describe how you've tested these changes.

- Local builds on macOS for macOS, iOS and tvOS.
- [Integration Test CI](https://github.com/firebase/firebase-unity-sdk/actions/runs/3183486870)
- [Unity SDK Build CI](https://github.com/firebase/firebase-unity-sdk/actions/runs/3183497310)


***

### Type of Change
Place an `x` the applicable box:
- [ ] Bug fix. Add the issue # below if applicable.
- [ ] New feature. A non-breaking change which adds functionality.
- [X] Other, such as a build process or documentation change.
***

