### PR TITLE
Add workflow that builds tvOS

### DIFF
--- a/.github/workflows/build_tvos.yml
+++ b/.github/workflows/build_tvos.yml
@@ -130,9 +130,25 @@ jobs:
         run: |
           echo "UNITY_ROOT_DIR=$( python scripts/gha/print_matrix_configuration.py -u ${{ inputs.unity_version }} -k unity_path )" >> $GITHUB_ENV
 
-      - name: Install prerequisites
+      - name: Pod repo list (pre)
+        shell: bash
+        run: pod repo list
+
+      - name: Pod repo add
+        shell: bash
+        run: pod repo add cocoapods https://github.com/CocoaPods/Specs.git
+
+      - name: Pod repo update
         shell: bash
         run: pod repo update
+
+      - name: List cocoapod repo
+        shell: bash
+        run: ls -l ~/.cocoapods/repos
+
+      - name: Pod repo list (post)
+        shell: bash
+        run: pod repo list
 
       - name: Build SDK (tvOS)
         timeout-minutes: 90

--- a/.github/workflows/build_tvos.yml
+++ b/.github/workflows/build_tvos.yml
@@ -25,7 +25,7 @@ on:
         type: string
       unity_platform_name:
         description: 'The platform name Unity should install with'
-        default: 'tvOS'
+        default: 'tvOS,iOS'
         required: true
         type: string
 
@@ -116,6 +116,11 @@ jobs:
         run: |
           pip install -r scripts/gha/requirements.txt
 
+      - name: Pod repo add
+        shell: bash
+        # run: pod repo add cocoapods https://github.com/CocoaPods/Specs.git
+        run: pod setup
+
       - name: Install Unity
         uses: nick-invision/retry@v2
         with:
@@ -129,26 +134,6 @@ jobs:
         shell: bash
         run: |
           echo "UNITY_ROOT_DIR=$( python scripts/gha/print_matrix_configuration.py -u ${{ inputs.unity_version }} -k unity_path )" >> $GITHUB_ENV
-
-      - name: Pod repo list (pre)
-        shell: bash
-        run: pod repo list
-
-      - name: Pod repo add
-        shell: bash
-        run: pod repo add cocoapods https://github.com/CocoaPods/Specs.git
-
-      - name: Pod repo update
-        shell: bash
-        run: pod repo update
-
-      - name: List cocoapod repo
-        shell: bash
-        run: ls -l ~/.cocoapods/repos
-
-      - name: Pod repo list (post)
-        shell: bash
-        run: pod repo list
 
       - name: Build SDK (tvOS)
         timeout-minutes: 90

--- a/.github/workflows/build_tvos.yml
+++ b/.github/workflows/build_tvos.yml
@@ -3,7 +3,7 @@ name: Build tvOS (SubWorkflow)
 
 on:
   workflow_dispatch:
-  inputs:
+    inputs:
       unity_version:
         description: 'Unity version'
         default: '2019'

--- a/.github/workflows/build_tvos.yml
+++ b/.github/workflows/build_tvos.yml
@@ -130,6 +130,10 @@ jobs:
         run: |
           echo "UNITY_ROOT_DIR=$( python scripts/gha/print_matrix_configuration.py -u ${{ inputs.unity_version }} -k unity_path )" >> $GITHUB_ENV
 
+      - name: Install prerequisites
+        shell: bash
+        run: pod repo update
+
       - name: Build SDK (tvOS)
         timeout-minutes: 90
         shell: bash

--- a/.github/workflows/build_tvos.yml
+++ b/.github/workflows/build_tvos.yml
@@ -119,7 +119,8 @@ jobs:
       - name: Pod repo add
         shell: bash
         # The pod install fails during the cmake build, so preinstall it.
-        run: pod repo add cocoapods https://github.com/CocoaPods/Specs.git
+        run: |
+          pod repo add cocoapods https://github.com/CocoaPods/Specs.git
 
       - name: Install Unity
         uses: nick-invision/retry@v2
@@ -139,7 +140,6 @@ jobs:
         timeout-minutes: 90
         shell: bash
         run: |
-          # TODO add handling cmake_extras
           python scripts/build_scripts/build_zips.py --gha --platform=tvos --unity_root=$UNITY_ROOT_DIR --apis=${{ inputs.apis }}
 
       - name: Check zip file

--- a/.github/workflows/build_tvos.yml
+++ b/.github/workflows/build_tvos.yml
@@ -140,6 +140,7 @@ jobs:
         timeout-minutes: 90
         shell: bash
         run: |
+          # TODO add handling cmake_extras
           python scripts/build_scripts/build_zips.py --gha --platform=tvos --unity_root=$UNITY_ROOT_DIR --apis=${{ inputs.apis }}
 
       - name: Check zip file

--- a/.github/workflows/build_tvos.yml
+++ b/.github/workflows/build_tvos.yml
@@ -118,8 +118,8 @@ jobs:
 
       - name: Pod repo add
         shell: bash
-        # run: pod repo add cocoapods https://github.com/CocoaPods/Specs.git
-        run: pod setup
+        # The pod install fails during the cmake build, so preinstall it.
+        run: pod repo add cocoapods https://github.com/CocoaPods/Specs.git
 
       - name: Install Unity
         uses: nick-invision/retry@v2


### PR DESCRIPTION
### Description
> Provide details of the change, and generalize the change in the PR title above.

Fixed up workflow to build Unity for tvOS targets.
Workflow is triggered by manual triggers still - and not by the `Firebase Unity SDK build` which kicks-off builds for all of the platforms. This is simply so we don't release the tvOS libraries. Later, when the tvOS release is ready, we'll add this `Build tvOS (SubWorkflow)` to the main build list.

***
### Testing
> Describe how you've tested these changes.

- [Build tvOS CI](https://github.com/firebase/firebase-unity-sdk/actions/runs/3234991120)
- Inspected resulting artifact to ensure it contains unity libraries for all of the corresponding products, and that they're in the correct paths.
- Executed `lipo -info` on the resulting static libraries to ensure that they contain the intended architectures of `x86_64` for simulator targets and `arm64` for AppleTV device targets.

***

### Type of Change
Place an `x` the applicable box:
- [ ] Bug fix. Add the issue # below if applicable.
- [ ] New feature. A non-breaking change which adds functionality.
- [X] Other, such as a build process or documentation change.
***