### PR TITLE
Update print_matrix script to support integration test CI

### DIFF
--- a/scripts/gha/integration_testing/build_testapps.json
+++ b/scripts/gha/integration_testing/build_testapps.json
@@ -6,7 +6,6 @@
       "captial_name": "Analytics",
       "bundle_id": "com.google.firebase.unity.analytics.testapp",
       "testapp_path": "analytics/testapp",
-      "tvos_target": "integration_test_tvos",
       "plugins": [
         "FirebaseAnalytics.unitypackage"
       ],
@@ -23,7 +22,6 @@
       "captial_name": "Auth",
       "bundle_id": "com.google.FirebaseUnityAuthTestApp.dev",
       "testapp_path": "auth/testapp",
-      "tvos_target": "integration_test_tvos",
       "plugins": [
         "FirebaseAuth.unitypackage"
       ],
@@ -41,7 +39,6 @@
       "captial_name": "Crashlytics",
       "bundle_id": "com.google.firebase.unity.crashlytics.testapp",
       "testapp_path": "crashlytics/testapp",
-      "tvos_target": "integration_test_tvos",
       "plugins": [
         "FirebaseCrashlytics.unitypackage"
       ],
@@ -58,7 +55,6 @@
       "captial_name": "Database",
       "bundle_id": "com.google.firebase.unity.database.testapp",
       "testapp_path": "database/testapp",
-      "tvos_target": "integration_test_tvos",
       "plugins": [
         "FirebaseDatabase.unitypackage"
       ],
@@ -76,7 +72,6 @@
       "captial_name": "DynamicLinks",
       "bundle_id": "com.google.FirebaseUnityDynamicLinksTestApp.dev",
       "testapp_path": "dynamic_links/testapp",
-      "tvos_target": "",
       "plugins": [
         "FirebaseDynamicLinks.unitypackage"
       ],
@@ -94,7 +89,6 @@
       "captial_name": "Firestore",
       "bundle_id": "com.google.firebase.firestore.unity.testapp",
       "testapp_path": "firestore/testapp",
-      "tvos_target": "integration_test_tvos",
       "plugins": [
         "FirebaseFirestore.unitypackage",
         "FirebaseAuth.unitypackage"
@@ -114,7 +108,6 @@
       "captial_name": "Functions",
       "bundle_id": "com.google.firebase.unity.functions.testapp",
       "testapp_path": "functions/testapp",
-      "tvos_target": "integration_test_tvos",
       "plugins": [
         "FirebaseFunctions.unitypackage",
         "FirebaseAuth.unitypackage"
@@ -133,7 +126,6 @@
       "captial_name": "Installations",
       "bundle_id": "com.google.firebase.unity.fis.testapp",
       "testapp_path": "installations/testapp",
-      "tvos_target": "integration_test_tvos",
       "plugins": [
         "FirebaseInstallations.unitypackage"
       ],
@@ -150,7 +142,6 @@
       "captial_name": "Messaging",
       "bundle_id": "com.google.FirebaseUnityMessagingTestApp.dev",
       "testapp_path": "messaging/testapp",
-      "tvos_target": "integration_test_tvos",
       "plugins": [
         "FirebaseMessaging.unitypackage"
       ],
@@ -168,7 +159,6 @@
       "captial_name": "RemoteConfig",
       "bundle_id": "com.google.firebase.unity.remoteconfig.testapp",
       "testapp_path": "remote_config/testapp",
-      "tvos_target": "integration_test_tvos",
       "plugins": [
         "FirebaseRemoteConfig.unitypackage"
       ],
@@ -185,7 +175,6 @@
       "captial_name": "Storage",
       "bundle_id": "com.google.firebase.unity.storage.testapp",
       "testapp_path": "storage/testapp",
-      "tvos_target": "integration_test_tvos",
       "plugins": [
         "FirebaseStorage.unitypackage"
       ],

--- a/scripts/gha/integration_testing/build_testapps.json
+++ b/scripts/gha/integration_testing/build_testapps.json
@@ -6,6 +6,7 @@
       "captial_name": "Analytics",
       "bundle_id": "com.google.firebase.unity.analytics.testapp",
       "testapp_path": "analytics/testapp",
+      "tvos_target": "integration_test_tvos",
       "plugins": [
         "FirebaseAnalytics.unitypackage"
       ],
@@ -22,6 +23,7 @@
       "captial_name": "Auth",
       "bundle_id": "com.google.FirebaseUnityAuthTestApp.dev",
       "testapp_path": "auth/testapp",
+      "tvos_target": "integration_test_tvos",
       "plugins": [
         "FirebaseAuth.unitypackage"
       ],
@@ -39,6 +41,7 @@
       "captial_name": "Crashlytics",
       "bundle_id": "com.google.firebase.unity.crashlytics.testapp",
       "testapp_path": "crashlytics/testapp",
+      "tvos_target": "integration_test_tvos",
       "plugins": [
         "FirebaseCrashlytics.unitypackage"
       ],
@@ -55,6 +58,7 @@
       "captial_name": "Database",
       "bundle_id": "com.google.firebase.unity.database.testapp",
       "testapp_path": "database/testapp",
+      "tvos_target": "integration_test_tvos",
       "plugins": [
         "FirebaseDatabase.unitypackage"
       ],
@@ -72,6 +76,7 @@
       "captial_name": "DynamicLinks",
       "bundle_id": "com.google.FirebaseUnityDynamicLinksTestApp.dev",
       "testapp_path": "dynamic_links/testapp",
+      "tvos_target": "",
       "plugins": [
         "FirebaseDynamicLinks.unitypackage"
       ],
@@ -89,6 +94,7 @@
       "captial_name": "Firestore",
       "bundle_id": "com.google.firebase.firestore.unity.testapp",
       "testapp_path": "firestore/testapp",
+      "tvos_target": "integration_test_tvos",
       "plugins": [
         "FirebaseFirestore.unitypackage",
         "FirebaseAuth.unitypackage"
@@ -108,6 +114,7 @@
       "captial_name": "Functions",
       "bundle_id": "com.google.firebase.unity.functions.testapp",
       "testapp_path": "functions/testapp",
+      "tvos_target": "integration_test_tvos",
       "plugins": [
         "FirebaseFunctions.unitypackage",
         "FirebaseAuth.unitypackage"
@@ -126,6 +133,7 @@
       "captial_name": "Installations",
       "bundle_id": "com.google.firebase.unity.fis.testapp",
       "testapp_path": "installations/testapp",
+      "tvos_target": "integration_test_tvos",
       "plugins": [
         "FirebaseInstallations.unitypackage"
       ],
@@ -142,6 +150,7 @@
       "captial_name": "Messaging",
       "bundle_id": "com.google.FirebaseUnityMessagingTestApp.dev",
       "testapp_path": "messaging/testapp",
+      "tvos_target": "integration_test_tvos",
       "plugins": [
         "FirebaseMessaging.unitypackage"
       ],
@@ -159,6 +168,7 @@
       "captial_name": "RemoteConfig",
       "bundle_id": "com.google.firebase.unity.remoteconfig.testapp",
       "testapp_path": "remote_config/testapp",
+      "tvos_target": "integration_test_tvos",
       "plugins": [
         "FirebaseRemoteConfig.unitypackage"
       ],
@@ -175,6 +185,7 @@
       "captial_name": "Storage",
       "bundle_id": "com.google.firebase.unity.storage.testapp",
       "testapp_path": "storage/testapp",
+      "tvos_target": "integration_test_tvos",
       "plugins": [
         "FirebaseStorage.unitypackage"
       ],

--- a/scripts/gha/print_matrix_configuration.py
+++ b/scripts/gha/print_matrix_configuration.py
@@ -66,7 +66,7 @@ PARAMETERS = {
       "unity_versions": ["2020"],
       "build_os": [""],
       "platforms": [WINDOWS, MACOS, LINUX, ANDROID, IOS, TVOS, PLAYMODE],
-      "mobile_devices": ["android_target", "ios_target", "tvos_target"],
+      "mobile_devices": ["android_target", "ios_target", "tvos_simulator"],
       "mobile_test_on": ["real"],
 
       MINIMAL_KEY: {
@@ -77,7 +77,7 @@ PARAMETERS = {
         "build_os": [MACOS_RUNNER,WINDOWS_RUNNER],
         "unity_versions": ["2020"],
         "mobile_test_on": ["real", "virtual"],
-        "mobile_devices": ["android_target", "ios_target", "tvos_target", "simulator_target"],
+        "mobile_devices": ["android_target", "ios_target", "simulator_target", "tvos_simulator"],
       }
     },
     "config": {
@@ -341,7 +341,7 @@ def get_testapp_test_matrix(matrix_type, unity_versions, platforms, build_os, mo
         device_platform = TEST_DEVICES.get(mobile_device).get("platform")
         if device_platform == platform and device_type in mobile_device_types:
           test_os = _get_test_os(platform, device_type)
-          ios_sdk = device_type if device_platform == IOS else "NA"
+          ios_sdk = device_type if device_platform == IOS or device_platform == TVOS else "NA"
           matrix["include"].append({"unity_version": unity_version, "platform": platform, "build_os": build_os, "test_os": test_os, "test_device": mobile_device, "device_detail": device_detail, "device_type": device_type, "ios_sdk": ios_sdk})
 
   return matrix

--- a/scripts/gha/print_matrix_configuration.py
+++ b/scripts/gha/print_matrix_configuration.py
@@ -65,8 +65,8 @@ PARAMETERS = {
     "matrix": {
       "unity_versions": ["2020"],
       "build_os": [""],
-      "platforms": [WINDOWS, MACOS, LINUX, ANDROID, IOS, PLAYMODE],
-      "mobile_devices": ["android_target", "ios_target"],
+      "platforms": [WINDOWS, MACOS, LINUX, ANDROID, IOS, TVOS, PLAYMODE],
+      "mobile_devices": ["android_target", "ios_target", "tvos_target"],
       "mobile_test_on": ["real"],
 
       MINIMAL_KEY: {
@@ -77,7 +77,7 @@ PARAMETERS = {
         "build_os": [MACOS_RUNNER,WINDOWS_RUNNER],
         "unity_versions": ["2020"],
         "mobile_test_on": ["real", "virtual"],
-        "mobile_devices": ["android_target", "ios_target", "simulator_target"],
+        "mobile_devices": ["android_target", "ios_target", "tvos_target", "simulator_target"],
       }
     },
     "config": {
@@ -141,6 +141,7 @@ TEST_DEVICES = {
   "simulator_min": {"platform": IOS, "type": "virtual", "name": "iPhone 6", "version": "11.4"},
   "simulator_target": {"platform": IOS, "type": "virtual", "name": "iPhone 8", "version": "14.5"},
   "simulator_latest": {"platform": IOS, "type": "virtual", "name": "iPhone 11", "version": "14.4"},
+  "tvos_simulator": {"platform": TVOS, "type": "virtual", "name": "Apple TV", "version": "14.3"},
 }
 
 

--- a/scripts/gha/print_matrix_configuration.py
+++ b/scripts/gha/print_matrix_configuration.py
@@ -60,12 +60,13 @@ WINDOWS_RUNNER = "windows-latest"
 MACOS_RUNNER = "macos-latest"
 LINUX_RUNNER = "ubuntu-latest"
 
+# TODO @drsanta add TVOS to the platforms once the integration tests can be run on tvOS.
 PARAMETERS = {
   "integration_tests": {
     "matrix": {
       "unity_versions": ["2020"],
       "build_os": [""],
-      "platforms": [WINDOWS, MACOS, LINUX, ANDROID, IOS, TVOS, PLAYMODE],
+      "platforms": [WINDOWS, MACOS, LINUX, ANDROID, IOS, PLAYMODE],
       "mobile_devices": ["android_target", "ios_target", "tvos_simulator"],
       "mobile_test_on": ["real"],
 


### PR DESCRIPTION
### Description
> Provide details of the change, and generalize the change in the PR title above.

Updates to `print_matrix_configuration.py` to support tvOS builds in the Integration Test Workflow.  I have not changed the Integration Test workflow to enable tvOS builds by default yet since `build_testapps.py` doesn't yet support tvOs testing (but that's next).

***
### Testing
Three different methods for testing.

1: [Integration CI run](https://github.com/firebase/firebase-unity-sdk/actions/runs/3292266005) and an [Expanded Matrix Integration Test CI run](https://github.com/firebase/firebase-unity-sdk/actions/runs/3292270698) to ensure I didn't break our current CI flow.

2: Ensured that the existing command line arguments we use to invoke `print_matrix.py` doesn't differ from the main branch. Executed the following commands and diffed the results - they were identical:

> $ python scripts/gha/print_matrix_configuration.py -build_matrix -unity_versions 2020 -platforms Android,iOS,Windows,macOS,Linux,Playmode -os macos-latest -mobile_test_on real,virtual -m=expanded

> $ python scripts/gha/print_matrix_configuration.py -build_matrix -unity_versions 2020 -platforms Android,iOS,Windows,macOS,Linux,Playmode -os macos-latest -mobile_test_on real,virtual

> $ python scripts/gha/print_matrix_configuration.py -test_matrix -unity_versions 2020 -platforms Android,iOS,Windows,macOS,Linux,Playmode -os mac_latest -mobile_test_on real,virtual -m=expanded=1

> $python scripts/gha/print_matrix_configuration.py -test_matrix -unity_versions 2020 -platforms Android,iOS,Windows,macOS,Linux,Playmode -os mac_latest -mobile_test_on real,virtual

3: Local execution of parameters for tvOS matrix exports:

**Build Matrix**
tvOS should be included in the build matrix for simulator targets. FTL doesn't have tvOS devices yet.

> $ python scripts/gha/print_matrix_configuration.py -build_matrix -unity_versions 2020 -platforms Android,iOS,Windows,macOS,Linux,Playmode,tvOS -os macos-latest  -mobile_test_on real,virtual

_Result_:
`{'include': [{'unity_version': '2020', 'platform': 'Android', 'os': 'macos-latest', 'ios_sdk': 'NA'}, {'unity_version': '2020', 'platform': 'iOS', 'os': 'macos-latest', 'ios_sdk': 'real'}, {'unity_version': '2020', 'platform': 'iOS', 'os': 'macos-latest', 'ios_sdk': 'virtual'}, {'unity_version': '2020', 'platform': 'tvOS', 'os': 'macos-latest', 'ios_sdk': 'real'}, {'unity_version': '2020', 'platform': 'tvOS', 'os': 'macos-latest', 'ios_sdk': 'virtual'}, {'unity_version': '2020', 'platform': 'Windows,macOS,Linux', 'os': 'macos-latest', 'ios_sdk': 'NA'}]}`

**Test Matrix**
Simliar with Build Matrix, tvOS should have a test target for simulators.
> $python scripts/gha/print_matrix_configuration.py -test_matrix -unity_versions 2020 -platforms Android,iOS,Windows,macOS,Linux,Playmode,tvOS  -os mac_latest -mobile_test_on real,virtual

_Result_: 
`{'include': [{'unity_version': '2020', 'platform': 'Android', 'build_os': 'mac_latest', 'test_os': 'ubuntu-latest', 'test_device': 'android_target', 'device_detail': 'model=blueline,version=28', 'device_type': 'real', 'ios_sdk': 'NA'}, {'unity_version': '2020', 'platform': 'iOS', 'build_os': 'mac_latest', 'test_os': 'ubuntu-latest', 'test_device': 'ios_target', 'device_detail': 'model=iphone8,version=13.6', 'device_type': 'real', 'ios_sdk': 'real'}, {'unity_version': '2020', 'platform': 'Windows', 'build_os': 'mac_latest', 'test_os': 'windows-latest', 'test_device': 'github_runner', 'ios_sdk': 'NA'}, {'unity_version': '2020', 'platform': 'macOS', 'build_os': 'mac_latest', 'test_os': 'macos-latest', 'test_device': 'github_runner', 'ios_sdk': 'NA'}, {'unity_version': '2020', 'platform': 'Linux', 'build_os': 'mac_latest', 'test_os': 'ubuntu-latest', 'test_device': 'github_runner', 'ios_sdk': 'NA'}, {'unity_version': '2020', 'platform': 'tvOS', 'build_os': 'mac_latest', 'test_os': 'macos-latest', 'test_device': 'tvos_simulator', 'device_detail': None, 'device_type': 'virtual', 'ios_sdk': 'virtual'}]}`

**Playmode Matrix**
The playmode matrix shouldn't change.

> $ python scripts/gha/print_matrix_configuration.py -playmode_matrix -unity_versions 2020 -platforms Android,iOS,Windows,macOS,Linux,Playmode,tvOS -os macos-latest  -mobile_test_on real,virtual

_Result_: 
`{'include': [{'unity_version': '2020', 'os': 'macos-latest'}]}`


***

### Type of Change
Place an `x` the applicable box:
- [ ] Bug fix. Add the issue # below if applicable.
- [ ] New feature. A non-breaking change which adds functionality.
- [X] Other, such as a build process or documentation change.
***

