### PR TITLE
Fix iOS integration tests failing to build due to bitcode

### DIFF
--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -169,6 +169,8 @@ jobs:
       U3D_PASSWORD: ""
       # Disable checking for U3D updates, since it is buggy
       U3D_SKIP_UPDATE_CHECK: 1
+      # Which xcode version to use
+      xcodeVersion: "13.3.1"
     steps:
       - id: matrix_info
         run: |
@@ -226,6 +228,9 @@ jobs:
           name: 'firebase_unity_sdk.zip'
           workflow: 'build_starter.yml'
           run_id: ${{ github.event.inputs.packaged_sdk_run_id }}
+      - name: setup Xcode version
+        if: runner.os == 'macOS'
+        run: sudo xcode-select -s /Applications/Xcode_${{ env.xcodeVersion }}.app/Contents/Developer
 
       - name: Build integration tests
         timeout-minutes: 240

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -196,6 +196,9 @@ jobs:
         shell: bash
         run: |
           pip install -r scripts/gha/requirements.txt
+      - name: setup Xcode version
+        if: runner.os == 'macOS'
+        run: sudo xcode-select -s /Applications/Xcode_${{ env.xcodeVersion }}.app/Contents/Developer
       - name: Install Unity
         uses: nick-invision/retry@v2
         with:
@@ -228,9 +231,6 @@ jobs:
           name: 'firebase_unity_sdk.zip'
           workflow: 'build_starter.yml'
           run_id: ${{ github.event.inputs.packaged_sdk_run_id }}
-      - name: setup Xcode version
-        if: runner.os == 'macOS'
-        run: sudo xcode-select -s /Applications/Xcode_${{ env.xcodeVersion }}.app/Contents/Developer
 
       - name: Build integration tests
         timeout-minutes: 240


### PR DESCRIPTION
### Description
> Provide details of the change, and generalize the change in the PR title above.

XCode 14 gets rid of bitcode support, but some of our dependencies still rely on it, so pin to an older version of xcode until new versions of the dependencies are available.
***
### Testing
> Describe how you've tested these changes.

https://github.com/firebase/firebase-unity-sdk/actions/runs/3316431654/jobs/5478220777
***

### Type of Change
Place an `x` the applicable box:
- [ ] Bug fix. Add the issue # below if applicable.
- [ ] New feature. A non-breaking change which adds functionality.
- [x] Other, such as a build process or documentation change.
***

