### PR TITLE
Update build testapp timeout & collect testapp build logs

### DIFF
--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -250,7 +250,7 @@ jobs:
         uses: actions/upload-artifact@v3
         if: ${{ !cancelled() }}
         with:
-          name: testapps-build-logs
+          name: testapps-build-logs-${{ steps.matrix_info.outputs.info }}
           path: testapps-${{ steps.matrix_info.outputs.info }}/build-logs
           retention-days: ${{ env.artifactRetentionDays }}
       - name: Upload Android integration tests artifact

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -243,8 +243,15 @@ jobs:
         uses: actions/upload-artifact@v3
         if: ${{ !cancelled() }}
         with:
-          name: log-artifact
+          name: build_and_test_results
           path: build-results-${{ steps.matrix_info.outputs.info }}*
+          retention-days: ${{ env.artifactRetentionDays }}
+      - name: Upload build logs artifact
+        uses: actions/upload-artifact@v3
+        if: ${{ !cancelled() }}
+        with:
+          name: testapps-build-logs
+          path: build-results-${{ steps.matrix_info.outputs.info }}/build-logs
           retention-days: ${{ env.artifactRetentionDays }}
       - name: Upload Android integration tests artifact
         uses: actions/upload-artifact@v3
@@ -306,7 +313,7 @@ jobs:
         uses: actions/download-artifact@v3
         with:
           path: test_results
-          name: log-artifact
+          name: build_and_test_results
       - name: Update PR label and comment
         if: ${{ needs.check_and_prepare.outputs.pr_number && failure() && !cancelled() }}
         shell: bash
@@ -404,7 +411,7 @@ jobs:
         uses: actions/upload-artifact@v3
         if: ${{ !cancelled() }}
         with:
-          name: log-artifact
+          name: build_and_test_results
           path: test-results-${{ steps.matrix_info.outputs.info }}*
           retention-days: ${{ env.artifactRetentionDays }}
       - name: Update PR label and comment
@@ -499,7 +506,7 @@ jobs:
         if: ${{ !cancelled() }}
         uses: actions/upload-artifact@v3
         with:
-          name: log-artifact
+          name: build_and_test_results
           path: testapps/test-results-${{ steps.matrix_info.outputs.info }}*
           retention-days: ${{ env.artifactRetentionDays }}
       - name: Download log artifacts
@@ -507,7 +514,7 @@ jobs:
         uses: actions/download-artifact@v3
         with:
           path: test_results
-          name: log-artifact
+          name: build_and_test_results
       - name: Update PR label and comment
         shell: bash
         if: ${{ needs.check_and_prepare.outputs.pr_number && failure() && !cancelled() }}
@@ -546,7 +553,7 @@ jobs:
         uses: actions/download-artifact@v3
         with:
           path: test_results
-          name: log-artifact
+          name: build_and_test_results
       # Use a different token to remove the "in-progress" label,
       # to allow the removal to trigger the "Check Labels" workflow.
       - name: Generate token for GitHub API

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -251,7 +251,7 @@ jobs:
         if: ${{ !cancelled() }}
         with:
           name: testapps-build-logs
-          path: build-results-${{ steps.matrix_info.outputs.info }}/build-logs
+          path: testapps-${{ steps.matrix_info.outputs.info }}/build-logs
           retention-days: ${{ env.artifactRetentionDays }}
       - name: Upload Android integration tests artifact
         uses: actions/upload-artifact@v3

--- a/scripts/gha/build_testapps.py
+++ b/scripts/gha/build_testapps.py
@@ -634,7 +634,7 @@ def run_xcodebuild(dir_helper, ios_config, device_type):
 
 
 def _collect_build_logs(root_output_dir, output_dir, artifact_name):
-  log_extension = ".buildlog"
+  log_extension = ".build.log"
   log_paths = []
   for file_dir, _, file_names in os.walk(output_dir):
     for file_name in file_names:
@@ -1211,7 +1211,7 @@ class _DirectoryHelper(object):
       (str) Absolute path.
 
     """
-    return os.path.join(self.output_dir, name + ".buildlog")
+    return os.path.join(self.output_dir, name + ".build.log")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
### Description
1. Change the timeout from 50 minutes to 20 (each testapp building process takes less than 12 minutes).
2. Upload build log file artifacts, which are named `testapps-build-logs`.  (log will be print out in the workflow run if there is a failure.)

According to the logs, it seems Crashlytisc missing the following logs and stuck there forever:
```
Generated Firebase Android Resources file Assets\Plugins\Android\FirebaseApp.androidlib\res\values\google-services.xml from D:/a/firebase-unity-sdk/firebase-unity-sdk/testapps2022_11_03-20_12_33/Unity2020.3.34f1-NET4.6/FirebaseAnalytics/testapp/Assets\..\Assets/Firebase/Sample/Analytics/google-services.json
	
Executed "D:\a\firebase-unity-sdk\firebase-unity-sdk\testapps2022_11_03-20_12_33\Unity2020.3.34f1-NET4.6\FirebaseAnalytics\testapp\Assets\Firebase\Editor\generate_xml_from_google_services_json.exe" -i "D:/a/firebase-unity-sdk/firebase-unity-sdk/testapps2022_11_03-20_12_33/Unity2020.3.34f1-NET4.6/FirebaseAnalytics/testapp/Assets\..\Assets/Firebase/Sample/Analytics/google-services.json" -o "D:/a/firebase-unity-sdk/firebase-unity-sdk/testapps2022_11_03-20_12_33/Unity2020.3.34f1-NET4.6/FirebaseAnalytics/testapp/Assets\..\Assets\Plugins\Android\FirebaseApp.androidlib\res\values\google-services.xml" -p "com.google.firebase.unity.analytics.testapp"
```
***
### Testing
https://github.com/firebase/firebase-unity-sdk/actions/runs/3389959359
https://github.com/firebase/firebase-unity-sdk/actions/runs/3389960751


[replace this line]: # (Describe your testing in detail.)
***

### Type of Change
Place an `x` the applicable box:
- [ ] Bug fix. Add the issue # below if applicable.
- [ ] New feature. A non-breaking change which adds functionality.
- [x] Other, such as a build process or documentation change.
***

