### PR TITLE
Retry unity installation in Python script instead of using GHA

### DIFF
--- a/.github/workflows/build_android.yml
+++ b/.github/workflows/build_android.yml
@@ -103,7 +103,7 @@ jobs:
           pip install -r scripts/gha/requirements.txt
       
       - id: unity_setup
-        uses: firebase/firebase-unity-sdk/gha/unity@feature/retry-unity
+        uses: ./gha/unity
         timeout-minutes: 30
         with:
           version: ${{ inputs.unity_version }}

--- a/.github/workflows/build_android.yml
+++ b/.github/workflows/build_android.yml
@@ -103,7 +103,7 @@ jobs:
           pip install -r scripts/gha/requirements.txt
       
       - id: unity_setup
-        uses: firebase/firebase-unity-sdk/gha/unity@main
+        uses: firebase/firebase-unity-sdk/gha/unity@feature/retry-unity
         with:
           version: ${{ inputs.unity_version }}
           platforms: ${{ inputs.unity_platform_name }}

--- a/.github/workflows/build_android.yml
+++ b/.github/workflows/build_android.yml
@@ -104,6 +104,7 @@ jobs:
       
       - id: unity_setup
         uses: firebase/firebase-unity-sdk/gha/unity@feature/retry-unity
+        timeout-minutes: 30
         with:
           version: ${{ inputs.unity_version }}
           platforms: ${{ inputs.unity_platform_name }}

--- a/.github/workflows/build_ios.yml
+++ b/.github/workflows/build_ios.yml
@@ -82,7 +82,7 @@ jobs:
           pip install -r scripts/gha/requirements.txt
       
       - id: unity_setup
-        uses: firebase/firebase-unity-sdk/gha/unity@main
+        uses: firebase/firebase-unity-sdk/gha/unity@feature/retry-unity
         with:
           version: ${{ inputs.unity_version }}
           platforms: ${{ inputs.unity_platform_name }}

--- a/.github/workflows/build_ios.yml
+++ b/.github/workflows/build_ios.yml
@@ -83,6 +83,7 @@ jobs:
       
       - id: unity_setup
         uses: firebase/firebase-unity-sdk/gha/unity@feature/retry-unity
+        timeout-minutes: 30
         with:
           version: ${{ inputs.unity_version }}
           platforms: ${{ inputs.unity_platform_name }}

--- a/.github/workflows/build_ios.yml
+++ b/.github/workflows/build_ios.yml
@@ -82,7 +82,7 @@ jobs:
           pip install -r scripts/gha/requirements.txt
       
       - id: unity_setup
-        uses: firebase/firebase-unity-sdk/gha/unity@feature/retry-unity
+        uses: ./gha/unity
         timeout-minutes: 30
         with:
           version: ${{ inputs.unity_version }}

--- a/.github/workflows/build_linux.yml
+++ b/.github/workflows/build_linux.yml
@@ -84,7 +84,7 @@ jobs:
           sudo apt install openssl
 
       - id: unity_setup
-        uses: firebase/firebase-unity-sdk/gha/unity@main
+        uses: firebase/firebase-unity-sdk/gha/unity@feature/retry-unity
         with:
           version: ${{ inputs.unity_version }}
           platforms: ${{ inputs.unity_platform_name }}

--- a/.github/workflows/build_linux.yml
+++ b/.github/workflows/build_linux.yml
@@ -84,7 +84,7 @@ jobs:
           sudo apt install openssl
 
       - id: unity_setup
-        uses: firebase/firebase-unity-sdk/gha/unity@feature/retry-unity
+        uses: ./gha/unity
         timeout-minutes: 30
         with:
           version: ${{ inputs.unity_version }}

--- a/.github/workflows/build_linux.yml
+++ b/.github/workflows/build_linux.yml
@@ -85,6 +85,7 @@ jobs:
 
       - id: unity_setup
         uses: firebase/firebase-unity-sdk/gha/unity@feature/retry-unity
+        timeout-minutes: 30
         with:
           version: ${{ inputs.unity_version }}
           platforms: ${{ inputs.unity_platform_name }}

--- a/.github/workflows/build_macos.yml
+++ b/.github/workflows/build_macos.yml
@@ -98,7 +98,7 @@ jobs:
           echo "OPENSSL_ROOT_DIR=$(brew --prefix openssl --installed)" >> $GITHUB_ENV
 
       - id: unity_setup
-        uses: firebase/firebase-unity-sdk/gha/unity@main
+        uses: firebase/firebase-unity-sdk/gha/unity@feature/retry-unity
         with:
           version: ${{ inputs.unity_version }}
           platforms: ${{ inputs.unity_platform_name }}

--- a/.github/workflows/build_macos.yml
+++ b/.github/workflows/build_macos.yml
@@ -98,7 +98,7 @@ jobs:
           echo "OPENSSL_ROOT_DIR=$(brew --prefix openssl --installed)" >> $GITHUB_ENV
 
       - id: unity_setup
-        uses: firebase/firebase-unity-sdk/gha/unity@feature/retry-unity
+        uses: ./gha/unity
         timeout-minutes: 30
         with:
           version: ${{ inputs.unity_version }}

--- a/.github/workflows/build_macos.yml
+++ b/.github/workflows/build_macos.yml
@@ -99,6 +99,7 @@ jobs:
 
       - id: unity_setup
         uses: firebase/firebase-unity-sdk/gha/unity@feature/retry-unity
+        timeout-minutes: 30
         with:
           version: ${{ inputs.unity_version }}
           platforms: ${{ inputs.unity_platform_name }}

--- a/.github/workflows/build_tvos.yml
+++ b/.github/workflows/build_tvos.yml
@@ -109,7 +109,7 @@ jobs:
           pod repo add cocoapods https://github.com/CocoaPods/Specs.git
 
       - id: unity_setup
-        uses: firebase/firebase-unity-sdk/gha/unity@feature/retry-unity
+        uses: ./gha/unity
         timeout-minutes: 30
         with:
           version: ${{ inputs.unity_version }}

--- a/.github/workflows/build_tvos.yml
+++ b/.github/workflows/build_tvos.yml
@@ -110,6 +110,7 @@ jobs:
 
       - id: unity_setup
         uses: firebase/firebase-unity-sdk/gha/unity@feature/retry-unity
+        timeout-minutes: 30
         with:
           version: ${{ inputs.unity_version }}
           platforms: ${{ inputs.unity_platform_name }}

--- a/.github/workflows/build_tvos.yml
+++ b/.github/workflows/build_tvos.yml
@@ -109,7 +109,7 @@ jobs:
           pod repo add cocoapods https://github.com/CocoaPods/Specs.git
 
       - id: unity_setup
-        uses: firebase/firebase-unity-sdk/gha/unity@main
+        uses: firebase/firebase-unity-sdk/gha/unity@feature/retry-unity
         with:
           version: ${{ inputs.unity_version }}
           platforms: ${{ inputs.unity_platform_name }}

--- a/.github/workflows/build_windows.yml
+++ b/.github/workflows/build_windows.yml
@@ -90,7 +90,7 @@ jobs:
           choco install openssl -r
 
       - id: unity_setup
-        uses: firebase/firebase-unity-sdk/gha/unity@main
+        uses: firebase/firebase-unity-sdk/gha/unity@feature/retry-unity
         with:
           version: ${{ inputs.unity_version }}
           platforms: ${{ inputs.unity_platform_name }}

--- a/.github/workflows/build_windows.yml
+++ b/.github/workflows/build_windows.yml
@@ -90,7 +90,7 @@ jobs:
           choco install openssl -r
 
       - id: unity_setup
-        uses: firebase/firebase-unity-sdk/gha/unity@feature/retry-unity
+        uses: ./gha/unity
         timeout-minutes: 30
         with:
           version: ${{ inputs.unity_version }}

--- a/.github/workflows/build_windows.yml
+++ b/.github/workflows/build_windows.yml
@@ -91,6 +91,7 @@ jobs:
 
       - id: unity_setup
         uses: firebase/firebase-unity-sdk/gha/unity@feature/retry-unity
+        timeout-minutes: 30
         with:
           version: ${{ inputs.unity_version }}
           platforms: ${{ inputs.unity_platform_name }}

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -167,7 +167,6 @@ jobs:
       xcodeVersion: "13.3.1"
     steps:
       - id: matrix_info
-        shell: bash
         run: |
           echo "info=${{ matrix.unity_version }}-${{matrix.os}}-${{ matrix.platform }}-${{ matrix.ios_sdk }}" >> $GITHUB_OUTPUT
           echo "artifact_suffix=${{ matrix.unity_version }}-${{matrix.os}}-${{ matrix.ios_sdk }}" >> $GITHUB_OUTPUT
@@ -345,7 +344,6 @@ jobs:
       matrix: ${{ fromJson(needs.check_and_prepare.outputs.playmode_matrix) }}
     steps:
       - id: matrix_info
-        shell: bash
         run: |
           echo "info=${{ matrix.unity_version }}-${{matrix.os}}-Playmode-github_runner-${{ matrix.os }}" >> $GITHUB_OUTPUT
       - uses: actions/checkout@v3
@@ -447,7 +445,6 @@ jobs:
       matrix: ${{ fromJson(needs.check_and_prepare.outputs.test_matrix) }}
     steps:
       - id: matrix_info
-        shell: bash
         run: |
           echo "info=${{ matrix.unity_version }}-${{matrix.build_os}}-${{ matrix.platform }}-${{ matrix.test_device }}-${{ matrix.test_os }}" >> $GITHUB_OUTPUT
           echo "artifact_path=testapps-${{ matrix.platform }}-${{ matrix.unity_version }}-${{matrix.build_os}}-${{ matrix.ios_sdk }}" >> $GITHUB_OUTPUT

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -184,7 +184,8 @@ jobs:
         if: runner.os == 'macOS'
         run: sudo xcode-select -s /Applications/Xcode_${{ env.xcodeVersion }}.app/Contents/Developer
       - id: unity_setup
-        uses: firebase/firebase-unity-sdk/gha/unity@main
+        uses: firebase/firebase-unity-sdk/gha/unity@feature/retry-unity
+        timeout-minutes: 30
         with:
           version: ${{ matrix.unity_version }}
           platforms: ${{ matrix.platform }}
@@ -227,7 +228,7 @@ jobs:
       - name: Return Unity license
         # Always returns true, even when job failed or canceled. But will not run when a critical failure prevents the task from running. 
         if: always()
-        uses: firebase/firebase-unity-sdk/gha/unity@main
+        uses: firebase/firebase-unity-sdk/gha/unity@feature/retry-unity
         with:
           version: ${{ matrix.unity_version }}
           release_license: "true"
@@ -357,6 +358,7 @@ jobs:
           pip install -r scripts/gha/requirements.txt
       - id: unity_setup
         uses: firebase/firebase-unity-sdk/gha/unity@feature/retry-unity
+        timeout-minutes: 30
         with:
           version: ${{ matrix.unity_version }}
           username: ${{ secrets.UNITY_USERNAME }}

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -184,7 +184,7 @@ jobs:
         if: runner.os == 'macOS'
         run: sudo xcode-select -s /Applications/Xcode_${{ env.xcodeVersion }}.app/Contents/Developer
       - id: unity_setup
-        uses: firebase/firebase-unity-sdk/gha/unity@feature/retry-unity
+        uses: ./gha/unity
         timeout-minutes: 30
         with:
           version: ${{ matrix.unity_version }}
@@ -228,7 +228,7 @@ jobs:
       - name: Return Unity license
         # Always returns true, even when job failed or canceled. But will not run when a critical failure prevents the task from running. 
         if: always()
-        uses: firebase/firebase-unity-sdk/gha/unity@feature/retry-unity
+        uses: ./gha/unity
         with:
           version: ${{ matrix.unity_version }}
           release_license: "true"
@@ -357,7 +357,7 @@ jobs:
         run: |
           pip install -r scripts/gha/requirements.txt
       - id: unity_setup
-        uses: firebase/firebase-unity-sdk/gha/unity@feature/retry-unity
+        uses: ./gha/unity
         timeout-minutes: 30
         with:
           version: ${{ matrix.unity_version }}
@@ -397,7 +397,7 @@ jobs:
       - name: Return Unity license
         # Always returns true, even when job failed or canceled. But will not run when a critical failure prevents the task from running. 
         if: always()
-        uses: firebase/firebase-unity-sdk/gha/unity@feature/retry-unity
+        uses: ./gha/unity
         with:
           version: ${{ matrix.unity_version }}
           release_license: "true"

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -167,6 +167,7 @@ jobs:
       xcodeVersion: "13.3.1"
     steps:
       - id: matrix_info
+        shell: bash
         run: |
           echo "info=${{ matrix.unity_version }}-${{matrix.os}}-${{ matrix.platform }}-${{ matrix.ios_sdk }}" >> $GITHUB_OUTPUT
           echo "artifact_suffix=${{ matrix.unity_version }}-${{matrix.os}}-${{ matrix.ios_sdk }}" >> $GITHUB_OUTPUT
@@ -344,6 +345,7 @@ jobs:
       matrix: ${{ fromJson(needs.check_and_prepare.outputs.playmode_matrix) }}
     steps:
       - id: matrix_info
+        shell: bash
         run: |
           echo "info=${{ matrix.unity_version }}-${{matrix.os}}-Playmode-github_runner-${{ matrix.os }}" >> $GITHUB_OUTPUT
       - uses: actions/checkout@v3
@@ -445,6 +447,7 @@ jobs:
       matrix: ${{ fromJson(needs.check_and_prepare.outputs.test_matrix) }}
     steps:
       - id: matrix_info
+        shell: bash
         run: |
           echo "info=${{ matrix.unity_version }}-${{matrix.build_os}}-${{ matrix.platform }}-${{ matrix.test_device }}-${{ matrix.test_os }}" >> $GITHUB_OUTPUT
           echo "artifact_path=testapps-${{ matrix.platform }}-${{ matrix.unity_version }}-${{matrix.build_os}}-${{ matrix.ios_sdk }}" >> $GITHUB_OUTPUT

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -356,7 +356,7 @@ jobs:
         run: |
           pip install -r scripts/gha/requirements.txt
       - id: unity_setup
-        uses: firebase/firebase-unity-sdk/gha/unity@main
+        uses: firebase/firebase-unity-sdk/gha/unity@feature/retry-unity
         with:
           version: ${{ matrix.unity_version }}
           username: ${{ secrets.UNITY_USERNAME }}
@@ -395,7 +395,7 @@ jobs:
       - name: Return Unity license
         # Always returns true, even when job failed or canceled. But will not run when a critical failure prevents the task from running. 
         if: always()
-        uses: firebase/firebase-unity-sdk/gha/unity@main
+        uses: firebase/firebase-unity-sdk/gha/unity@feature/retry-unity
         with:
           version: ${{ matrix.unity_version }}
           release_license: "true"

--- a/gha/unity/action.yml
+++ b/gha/unity/action.yml
@@ -33,6 +33,7 @@ outputs:
 
 runs:
   using: 'composite'
+  timeout-minutes: 30
   steps:
     - name: Return Unity license
       if: inputs.release_license
@@ -65,7 +66,6 @@ runs:
     - id: unity_installation
       name: Install Unity
       if: inputs.release_license == ''
-      timeout-minutes: 30
       shell: bash
       run: |
         if [[ -n "${{ inputs.platforms }}" ]]; then

--- a/gha/unity/action.yml
+++ b/gha/unity/action.yml
@@ -33,7 +33,6 @@ outputs:
 
 runs:
   using: 'composite'
-  timeout-minutes: 30
   steps:
     - name: Return Unity license
       if: inputs.release_license

--- a/gha/unity/action.yml
+++ b/gha/unity/action.yml
@@ -65,18 +65,15 @@ runs:
     - id: unity_installation
       name: Install Unity
       if: inputs.release_license == ''
-      uses: nick-invision/retry@v2
-      with:
-        timeout_minutes: 12
-        max_attempts: 2
-        shell: bash
-        command: |
-          if [[ -n "${{ inputs.platforms }}" ]]; then
-            additional_flags+=(--platforms ${{ inputs.platforms }})
-          fi
-          unity_info=$( python $GITHUB_ACTION_PATH/unity_installer.py --install --version ${{ inputs.version }} ${additional_flags[*]} )
-          echo "UNITY_ROOT_DIR=$(cut -d',' -f2 <<< ${unity_info})" >> $GITHUB_ENV
-          echo "unity_version=$(cut -d',' -f1 <<< ${unity_info})" >> $GITHUB_OUTPUT
+      timeout-minutes: 30
+      shell: bash
+      run: |
+        if [[ -n "${{ inputs.platforms }}" ]]; then
+          additional_flags+=(--platforms ${{ inputs.platforms }})
+        fi
+        unity_info=$( python $GITHUB_ACTION_PATH/unity_installer.py --install --version ${{ inputs.version }} ${additional_flags[*]} )
+        echo "UNITY_ROOT_DIR=$(cut -d',' -f2 <<< ${unity_info})" >> $GITHUB_ENV
+        echo "unity_version=$(cut -d',' -f1 <<< ${unity_info})" >> $GITHUB_OUTPUT
     - name: Activate Unity license
       if: inputs.release_license == '' && inputs.username != '' && inputs.password != '' && inputs.serial_ids != ''
       shell: bash


### PR DESCRIPTION
### Description
The retry GHA crashes: https://github.com/firebase/firebase-unity-sdk/actions/runs/3403341336/jobs/5659808612
https://github.com/firebase/firebase-unity-sdk/actions/runs/3408235068/jobs/5668638748

Now, retry unity installation process in the Python script.

[replace this line]: # (Describe your changes in detail.)
***
### Testing
Packaging SDK:
https://github.com/firebase/firebase-unity-sdk/actions/runs/3414744845
https://github.com/firebase/firebase-unity-sdk/actions/runs/3414745614
https://github.com/firebase/firebase-unity-sdk/actions/runs/3414751012
Integration Test:
https://github.com/firebase/firebase-unity-sdk/actions/runs/3414748683
https://github.com/firebase/firebase-unity-sdk/actions/runs/3414747456

In all workflow runs, the unity installation passed with only 1 attempt. (unity been installed ~21 times).
Please share me the information if the unity installation fails again. Thanks
```
I1107 22:58:09.281040 4483421696 unity_installer.py:218] run_with_retry: ['/Users/runner/hostedtoolcache/Ruby/2.6.10/x64/bin/u3d', 'install', '--trace', '--verbose', '2020.3.34f1', '-p', 'Unity,Android'] (attempt 1 of 3)
```

[replace this line]: # (Describe your testing in detail.)
***

### Type of Change
Place an `x` the applicable box:
- [ ] Bug fix. Add the issue # below if applicable.
- [ ] New feature. A non-breaking change which adds functionality.
- [x] Other, such as a build process or documentation change.
***

