### PR TITLE
Fix set `$GITHUB_OUTPUT` not working on Windows Runners

### DIFF
--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -167,6 +167,7 @@ jobs:
       xcodeVersion: "13.3.1"
     steps:
       - id: matrix_info
+        shell: bash
         run: |
           echo "info=${{ matrix.unity_version }}-${{matrix.os}}-${{ matrix.platform }}-${{ matrix.ios_sdk }}" >> $GITHUB_OUTPUT
           echo "artifact_suffix=${{ matrix.unity_version }}-${{matrix.os}}-${{ matrix.ios_sdk }}" >> $GITHUB_OUTPUT
@@ -343,6 +344,7 @@ jobs:
       matrix: ${{ fromJson(needs.check_and_prepare.outputs.playmode_matrix) }}
     steps:
       - id: matrix_info
+        shell: bash
         run: |
           echo "info=${{ matrix.unity_version }}-${{matrix.os}}-Playmode-github_runner-${{ matrix.os }}" >> $GITHUB_OUTPUT
       - uses: actions/checkout@v3
@@ -443,6 +445,7 @@ jobs:
       matrix: ${{ fromJson(needs.check_and_prepare.outputs.test_matrix) }}
     steps:
       - id: matrix_info
+        shell: bash
         run: |
           echo "info=${{ matrix.unity_version }}-${{matrix.build_os}}-${{ matrix.platform }}-${{ matrix.test_device }}-${{ matrix.test_os }}" >> $GITHUB_OUTPUT
           echo "artifact_path=testapps-${{ matrix.platform }}-${{ matrix.unity_version }}-${{matrix.build_os}}-${{ matrix.ios_sdk }}" >> $GITHUB_OUTPUT


### PR DESCRIPTION
### Description
Set output has issues on Windows machine. Fixing it by forcing `shell: bash`.

[replace this line]: # (Describe your changes in detail.)
***
### Testing
Without forcing bash shell:
https://github.com/firebase/firebase-unity-sdk/actions/runs/3415401417/jobs/5684492872#step:19:3
```
Run actions/upload-artifact@v3
  with:
    name: testapps-Linux-
    path: testapps-/Linux
```

Forcing bash shell:
https://github.com/firebase/firebase-unity-sdk/actions/runs/3415447402/jobs/5684589423#step:19:3
```
Run actions/upload-artifact@v3
  with:
    name: testapps-Linux-2020-windows-latest-NA
    path: testapps-2020-windows-latest-Windows,macOS,Linux-NA/Linux
```
***

### Type of Change
Place an `x` the applicable box:
- [x] Bug fix. Add the issue # below if applicable.
- [ ] New feature. A non-breaking change which adds functionality.
- [ ] Other, such as a build process or documentation change.
***

