### PR TITLE
Install Unity on GHA with a different tool

### DIFF
--- a/.github/workflows/build_android.yml
+++ b/.github/workflows/build_android.yml
@@ -101,13 +101,12 @@ jobs:
         shell: bash
         run: |
           pip install -r scripts/gha/requirements.txt
-      
-      - id: unity_setup
-        uses: ./gha/unity
-        timeout-minutes: 30
+
+      - name: Setup Unity
+        uses: kuler90/setup-unity@v1
         with:
-          version: ${{ inputs.unity_version }}
-          platforms: ${{ inputs.unity_platform_name }}
+          unity-version: 2020.3.34f1
+          unity-modules: android
 
       - name: Display Swig Version
         shell: bash

--- a/.github/workflows/build_android.yml
+++ b/.github/workflows/build_android.yml
@@ -104,6 +104,7 @@ jobs:
 
       - name: Setup Unity
         uses: kuler90/setup-unity@v1
+        timeout-minutes: 30
         with:
           unity-version: 2020.3.34f1
           unity-modules: android

--- a/.github/workflows/build_ios.yml
+++ b/.github/workflows/build_ios.yml
@@ -83,6 +83,7 @@ jobs:
       
       - name: Setup Unity
         uses: kuler90/setup-unity@v1
+        timeout-minutes: 30
         with:
           unity-version: 2020.3.34f1
           unity-modules: ios

--- a/.github/workflows/build_ios.yml
+++ b/.github/workflows/build_ios.yml
@@ -81,12 +81,11 @@ jobs:
         run: |
           pip install -r scripts/gha/requirements.txt
       
-      - id: unity_setup
-        uses: ./gha/unity
-        timeout-minutes: 30
+      - name: Setup Unity
+        uses: kuler90/setup-unity@v1
         with:
-          version: ${{ inputs.unity_version }}
-          platforms: ${{ inputs.unity_platform_name }}
+          unity-version: 2020.3.34f1
+          unity-modules: ios
 
       - name: Build SDK (iOS)
         timeout-minutes: 90

--- a/.github/workflows/build_linux.yml
+++ b/.github/workflows/build_linux.yml
@@ -85,6 +85,7 @@ jobs:
 
       - name: Setup Unity
         uses: kuler90/setup-unity@v1
+        timeout-minutes: 30
         with:
           unity-version: 2020.3.40f1
 

--- a/.github/workflows/build_linux.yml
+++ b/.github/workflows/build_linux.yml
@@ -83,12 +83,10 @@ jobs:
         run: |
           sudo apt install openssl
 
-      - id: unity_setup
-        uses: ./gha/unity
-        timeout-minutes: 30
+      - name: Setup Unity
+        uses: kuler90/setup-unity@v1
         with:
-          version: ${{ inputs.unity_version }}
-          platforms: ${{ inputs.unity_platform_name }}
+          unity-version: 2020.3.40f1
 
       - name: Setup Swig Env
         shell: bash

--- a/.github/workflows/build_macos.yml
+++ b/.github/workflows/build_macos.yml
@@ -99,6 +99,7 @@ jobs:
 
       - name: Setup Unity
         uses: kuler90/setup-unity@v1
+        timeout-minutes: 30
         with:
           unity-version: 2020.3.34f1
           # Include iOS for the editor tools

--- a/.github/workflows/build_macos.yml
+++ b/.github/workflows/build_macos.yml
@@ -97,12 +97,10 @@ jobs:
           # brew won't overwrite MacOS system default OpenSSL, so force it here.
           echo "OPENSSL_ROOT_DIR=$(brew --prefix openssl --installed)" >> $GITHUB_ENV
 
-      - id: unity_setup
-        uses: ./gha/unity
-        timeout-minutes: 30
+      - name: Setup Unity
+        uses: kuler90/setup-unity@v1
         with:
-          version: ${{ inputs.unity_version }}
-          platforms: ${{ inputs.unity_platform_name }}
+          unity-version: 2020.3.34f1
 
       - name: Setup Swig Env
         shell: bash

--- a/.github/workflows/build_macos.yml
+++ b/.github/workflows/build_macos.yml
@@ -101,6 +101,8 @@ jobs:
         uses: kuler90/setup-unity@v1
         with:
           unity-version: 2020.3.34f1
+          # Include iOS for the editor tools
+          unity-modules: ios
 
       - name: Setup Swig Env
         shell: bash

--- a/.github/workflows/build_tvos.yml
+++ b/.github/workflows/build_tvos.yml
@@ -110,6 +110,7 @@ jobs:
 
       - name: Setup Unity
         uses: kuler90/setup-unity@v1
+        timeout-minutes: 30
         with:
           unity-version: 2020.3.34f1
           unity-modules: appletv

--- a/.github/workflows/build_tvos.yml
+++ b/.github/workflows/build_tvos.yml
@@ -108,12 +108,11 @@ jobs:
         run: |
           pod repo add cocoapods https://github.com/CocoaPods/Specs.git
 
-      - id: unity_setup
-        uses: ./gha/unity
-        timeout-minutes: 30
+      - name: Setup Unity
+        uses: kuler90/setup-unity@v1
         with:
-          version: ${{ inputs.unity_version }}
-          platforms: ${{ inputs.unity_platform_name }}
+          unity-version: 2020.3.34f1
+          unity-modules: appletv
 
       - name: Build SDK (tvOS)
         timeout-minutes: 90

--- a/.github/workflows/build_windows.yml
+++ b/.github/workflows/build_windows.yml
@@ -112,7 +112,7 @@ jobs:
           echo "=== Installing Unity ==="
           ls -l "C:\\Program Files"
           echo "Running: Downloads/UnitySetup64.exe /UI=reduced /S /D=\"C:\\Program Files\\Unity_2020.3.34f1\""
-          Downloads/UnitySetup64.exe /UI=reduced /S /D="C:\\Program Files\\Unity_2020.3.34f1"
+          Downloads/UnitySetup64.exe /UI=reduced /S /D="C:\\Program\ Files\\Unity_2020.3.34f1"
           ls -l "C:\\Program Files\\Unity_2020.3.34f1"
 
 

--- a/.github/workflows/build_windows.yml
+++ b/.github/workflows/build_windows.yml
@@ -100,14 +100,14 @@ jobs:
         timeout-minutes: 30
         run: |
           mkdir -p ~/Downloads
-          reg query HKU\\S-1-5-19
           echo "=== Starting the Download ==="
-          curl -L https://download.unity3d.com/download_unity/9a4c9c70452b/Windows64EditorInstaller/UnitySetup64.exe -o ~/Downloads/UnityInstaller.exe
+          curl -L https://download.unity3d.com/download_unity/9a4c9c70452b/Windows64EditorInstaller/UnitySetup64.exe -o ~/Downloads/UnitySetup64.exe
           echo "===  Finished Downloading ==="
           ls -l ~/Downloads/
+          pwd ~/Downloads/UnitySetup64.exe
           echo "=== Installing Unity ==="
-          echo "Running: ~/Downloads/UnityInstaller.exe /UI=reduced /S /D=\"C:\\Program Files\\Unity_2020.3.34f1\""
-          ~/Downloads/UnityInstaller.exe /UI=reduced /S /D="C:\\Program Files\\Unity_2020.3.34f1"
+          echo "Running: ~/Downloads/UnitySetup64.exe /UI=reduced /S /D=\"C:\\Program Files\\Unity_2020.3.34f1\""
+          ~/Downloads/UnitySetup64.exe /UI=reduced /S /D="C:\\Program Files\\Unity_2020.3.34f1"
           ls -l "C:\Program Files\Unity_2020.3.34f1"
 
 

--- a/.github/workflows/build_windows.yml
+++ b/.github/workflows/build_windows.yml
@@ -97,14 +97,17 @@ jobs:
       #    platforms: ${{ inputs.unity_platform_name }}
       - name: Download Unity Installer
         shell: bash
+        timeout-minutes: 30
         run: |
           mkdir -p ~/Downloads
+          reg query HKU\\S-1-5-19
           echo "=== Starting the Download ==="
           curl -L https://download.unity3d.com/download_unity/9a4c9c70452b/Windows64EditorInstaller/UnitySetup64.exe -o ~/Downloads/UnityInstaller.exe
           echo "===  Finished Downloading ==="
           ls -l ~/Downloads/
           echo "=== Installing Unity ==="
-          ~/Downloads/UnityInstaller.exe -UI=reduced /S /D="C:\Program Files\Unity_2020.3.34f1"
+          echo "Running: ~/Downloads/UnityInstaller.exe /UI=reduced /S /D=\"C:\\Program Files\\Unity_2020.3.34f1\""
+          ~/Downloads/UnityInstaller.exe /UI=reduced /S /D="C:\\Program Files\\Unity_2020.3.34f1"
           ls -l "C:\Program Files\Unity_2020.3.34f1"
 
 

--- a/.github/workflows/build_windows.yml
+++ b/.github/workflows/build_windows.yml
@@ -112,7 +112,7 @@ jobs:
           echo "=== Installing Unity ==="
           ls -l "C:\\Program Files"
           echo "Running: Downloads/UnitySetup64.exe /UI=reduced /S /D=\"C:\\Program Files\\Unity_2020.3.34f1\""
-          Downloads/UnitySetup64.exe /UI=reduced /S /D="C:\\Program\ Files\\Unity_2020.3.34f1"
+          Downloads/UnitySetup64.exe /UI=reduced /S /D=C:\Program Files\Unity_2020.3.34f1
           ls -l "C:\\Program Files\\Unity_2020.3.34f1"
 
 

--- a/.github/workflows/build_windows.yml
+++ b/.github/workflows/build_windows.yml
@@ -91,6 +91,7 @@ jobs:
 
       - name: Setup Unity
         uses: kuler90/setup-unity@v1
+        timeout-minutes: 30
         with:
           unity-version: 2020.3.34f1
 

--- a/.github/workflows/build_windows.yml
+++ b/.github/workflows/build_windows.yml
@@ -104,7 +104,8 @@ jobs:
           echo "===  Finished Downloading ==="
           ls -l ~/Downloads/
           echo "=== Installing Unity ==="
-          ~/Downloads/UnityInstaller.exe /S /D=C:\Program Files\Unity_2020.3.34f1
+          ~/Downloads/UnityInstaller.exe -UI=reduced /S /D="C:\Program Files\Unity_2020.3.34f1"
+          ls -l "C:\Program Files\Unity_2020.3.34f1"
 
 
       - name: Setup Swig Env

--- a/.github/workflows/build_windows.yml
+++ b/.github/workflows/build_windows.yml
@@ -89,12 +89,18 @@ jobs:
         run: |
           choco install openssl -r
 
-      - id: unity_setup
-        uses: ./gha/unity
-        timeout-minutes: 30
-        with:
-          version: ${{ inputs.unity_version }}
-          platforms: ${{ inputs.unity_platform_name }}
+      #- id: unity_setup
+      #  uses: ./gha/unity
+      #  timeout-minutes: 30
+      #  with:
+      #    version: ${{ inputs.unity_version }}
+      #    platforms: ${{ inputs.unity_platform_name }}
+      - name: Download Unity Installer
+        shell: bash
+        run: |
+          mkdir -p ~/Downloads
+          curl -L https://download.unity3d.com/download_unity/9a4c9c70452b/Windows64EditorInstaller/UnitySetup64.exe -o ~/Downloads/UnityInstaller.exe
+          ls -l ~/Downloads/
 
       - name: Setup Swig Env
         shell: bash

--- a/.github/workflows/build_windows.yml
+++ b/.github/workflows/build_windows.yml
@@ -95,26 +95,34 @@ jobs:
       #  with:
       #    version: ${{ inputs.unity_version }}
       #    platforms: ${{ inputs.unity_platform_name }}
-      - name: Download Unity Installer
+      #- name: Download Unity Installer
+      #  shell: bash
+      #  timeout-minutes: 10
+      #  run: |
+      #    mkdir -p Downloads
+      #    echo "=== Starting the Download ==="
+      #    curl -L https://download.unity3d.com/download_unity/9a4c9c70452b/Windows64EditorInstaller/UnitySetup64.exe -o Downloads/UnitySetup64.exe
+      #    echo "===  Finished Downloading ==="
+      #    ls -l Downloads/
+      #    pwd Downloads/UnitySetup64.exe
+
+      #- name: Install Unity
+      #  timeout-minutes: 20
+      #  run: |
+      #    echo "=== Installing Unity ==="
+      #    ls -l "C:\\Program Files"
+      #    echo "Running: Downloads/UnitySetup64.exe /UI=reduced /S /D=\"C:\\Program Files\\Unity_2020.3.34f1\""
+      #    Downloads/UnitySetup64.exe /UI=reduced /S
+      #    ls -l "C:\\Program Files\\Unity_2020.3.34f1"
+      - name: Setup Unity
+        uses: kuler90/setup-unity@v1
+        with:
+          unity-version: 2020.3.34f1
+
+      - name: Print info
         shell: bash
-        timeout-minutes: 10
         run: |
-          mkdir -p Downloads
-          echo "=== Starting the Download ==="
-          curl -L https://download.unity3d.com/download_unity/9a4c9c70452b/Windows64EditorInstaller/UnitySetup64.exe -o Downloads/UnitySetup64.exe
-          echo "===  Finished Downloading ==="
-          ls -l Downloads/
-          pwd Downloads/UnitySetup64.exe
-
-      - name: Install Unity
-        timeout-minutes: 20
-        run: |
-          echo "=== Installing Unity ==="
           ls -l "C:\\Program Files"
-          echo "Running: Downloads/UnitySetup64.exe /UI=reduced /S /D=\"C:\\Program Files\\Unity_2020.3.34f1\""
-          Downloads/UnitySetup64.exe /UI=reduced /S /D=C:\Program Files\Unity_2020.3.34f1
-          ls -l "C:\\Program Files\\Unity_2020.3.34f1"
-
 
       - name: Setup Swig Env
         shell: bash

--- a/.github/workflows/build_windows.yml
+++ b/.github/workflows/build_windows.yml
@@ -100,6 +100,7 @@ jobs:
         run: |
           mkdir -p ~/Downloads
           curl -L https://download.unity3d.com/download_unity/9a4c9c70452b/Windows64EditorInstaller/UnitySetup64.exe -o ~/Downloads/UnityInstaller.exe
+          curl -L https://download.unity3d.com/download_unity/9a4c9c70452b/TargetSupportInstaller/UnitySetup-Android-Support-for-Editor-2020.3.34f1.exe -o ~/Downloads/UnityInstallerAndroid.exe
           ls -l ~/Downloads/
 
       - name: Setup Swig Env

--- a/.github/workflows/build_windows.yml
+++ b/.github/workflows/build_windows.yml
@@ -109,12 +109,12 @@ jobs:
         run: |
           rm C:/msys64/mingw64/lib/libz*
       
-      - name: Build SDK (Windows)
-        timeout-minutes: 90
-        shell: bash
-        run: |
-          # TODO add handling cmake_extras
-          python scripts/build_scripts/build_zips.py --gha --platform=windows --unity_root="$UNITY_ROOT_DIR" --swig_dir="$SWIG_DIR" --apis=${{ inputs.apis }}
+#      - name: Build SDK (Windows)
+#        timeout-minutes: 90
+#        shell: bash
+#        run: |
+#          # TODO add handling cmake_extras
+#          python scripts/build_scripts/build_zips.py --gha --platform=windows --unity_root="$UNITY_ROOT_DIR" --swig_dir="$SWIG_DIR" --apis=${{ inputs.apis }}
 
       - name: Check zip file
         shell: bash

--- a/.github/workflows/build_windows.yml
+++ b/.github/workflows/build_windows.yml
@@ -99,16 +99,21 @@ jobs:
         shell: bash
         timeout-minutes: 30
         run: |
-          mkdir -p ~/Downloads
+          mkdir -p Downloads
           echo "=== Starting the Download ==="
-          curl -L https://download.unity3d.com/download_unity/9a4c9c70452b/Windows64EditorInstaller/UnitySetup64.exe -o ~/Downloads/UnitySetup64.exe
+          curl -L https://download.unity3d.com/download_unity/9a4c9c70452b/Windows64EditorInstaller/UnitySetup64.exe -o Downloads/UnitySetup64.exe
           echo "===  Finished Downloading ==="
-          ls -l ~/Downloads/
-          pwd ~/Downloads/UnitySetup64.exe
+          ls -l Downloads/
+          pwd Downloads/UnitySetup64.exe
+
+      - name: Install Unity
+        timeout-minutes: 30
+        run: |
           echo "=== Installing Unity ==="
-          echo "Running: ~/Downloads/UnitySetup64.exe /UI=reduced /S /D=\"C:\\Program Files\\Unity_2020.3.34f1\""
-          ~/Downloads/UnitySetup64.exe /UI=reduced /S /D="C:\\Program Files\\Unity_2020.3.34f1"
-          ls -l "C:\Program Files\Unity_2020.3.34f1"
+          ls -l "C:\\Program Files"
+          echo "Running: Downloads/UnitySetup64.exe /UI=reduced /S /D=\"C:\\Program Files\\Unity_2020.3.34f1\""
+          Downloads/UnitySetup64.exe /UI=reduced /S /D="C:\\Program Files\\Unity_2020.3.34f1"
+          ls -l "C:\\Program Files\\Unity_2020.3.34f1"
 
 
       - name: Setup Swig Env

--- a/.github/workflows/build_windows.yml
+++ b/.github/workflows/build_windows.yml
@@ -89,40 +89,10 @@ jobs:
         run: |
           choco install openssl -r
 
-      #- id: unity_setup
-      #  uses: ./gha/unity
-      #  timeout-minutes: 30
-      #  with:
-      #    version: ${{ inputs.unity_version }}
-      #    platforms: ${{ inputs.unity_platform_name }}
-      #- name: Download Unity Installer
-      #  shell: bash
-      #  timeout-minutes: 10
-      #  run: |
-      #    mkdir -p Downloads
-      #    echo "=== Starting the Download ==="
-      #    curl -L https://download.unity3d.com/download_unity/9a4c9c70452b/Windows64EditorInstaller/UnitySetup64.exe -o Downloads/UnitySetup64.exe
-      #    echo "===  Finished Downloading ==="
-      #    ls -l Downloads/
-      #    pwd Downloads/UnitySetup64.exe
-
-      #- name: Install Unity
-      #  timeout-minutes: 20
-      #  run: |
-      #    echo "=== Installing Unity ==="
-      #    ls -l "C:\\Program Files"
-      #    echo "Running: Downloads/UnitySetup64.exe /UI=reduced /S /D=\"C:\\Program Files\\Unity_2020.3.34f1\""
-      #    Downloads/UnitySetup64.exe /UI=reduced /S
-      #    ls -l "C:\\Program Files\\Unity_2020.3.34f1"
       - name: Setup Unity
         uses: kuler90/setup-unity@v1
         with:
           unity-version: 2020.3.34f1
-
-      - name: Print info
-        shell: bash
-        run: |
-          ls -l "C:\\Program Files"
 
       - name: Setup Swig Env
         shell: bash

--- a/.github/workflows/build_windows.yml
+++ b/.github/workflows/build_windows.yml
@@ -99,9 +99,13 @@ jobs:
         shell: bash
         run: |
           mkdir -p ~/Downloads
+          echo "=== Starting the Download ==="
           curl -L https://download.unity3d.com/download_unity/9a4c9c70452b/Windows64EditorInstaller/UnitySetup64.exe -o ~/Downloads/UnityInstaller.exe
-          curl -L https://download.unity3d.com/download_unity/9a4c9c70452b/TargetSupportInstaller/UnitySetup-Android-Support-for-Editor-2020.3.34f1.exe -o ~/Downloads/UnityInstallerAndroid.exe
+          echo "===  Finished Downloading ==="
           ls -l ~/Downloads/
+          echo "=== Installing Unity ==="
+          ~/Downloads/UnityInstaller.exe /S /D=C:\Program Files\Unity_2020.3.34f1
+
 
       - name: Setup Swig Env
         shell: bash
@@ -116,12 +120,12 @@ jobs:
         run: |
           rm C:/msys64/mingw64/lib/libz*
       
-#      - name: Build SDK (Windows)
-#        timeout-minutes: 90
-#        shell: bash
-#        run: |
-#          # TODO add handling cmake_extras
-#          python scripts/build_scripts/build_zips.py --gha --platform=windows --unity_root="$UNITY_ROOT_DIR" --swig_dir="$SWIG_DIR" --apis=${{ inputs.apis }}
+      - name: Build SDK (Windows)
+        timeout-minutes: 90
+        shell: bash
+        run: |
+          # TODO add handling cmake_extras
+          python scripts/build_scripts/build_zips.py --gha --platform=windows --unity_root="$UNITY_ROOT_DIR" --swig_dir="$SWIG_DIR" --apis=${{ inputs.apis }}
 
       - name: Check zip file
         shell: bash

--- a/.github/workflows/build_windows.yml
+++ b/.github/workflows/build_windows.yml
@@ -97,7 +97,7 @@ jobs:
       #    platforms: ${{ inputs.unity_platform_name }}
       - name: Download Unity Installer
         shell: bash
-        timeout-minutes: 30
+        timeout-minutes: 10
         run: |
           mkdir -p Downloads
           echo "=== Starting the Download ==="
@@ -107,7 +107,7 @@ jobs:
           pwd Downloads/UnitySetup64.exe
 
       - name: Install Unity
-        timeout-minutes: 30
+        timeout-minutes: 20
         run: |
           echo "=== Installing Unity ==="
           ls -l "C:\\Program Files"

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -425,7 +425,10 @@ jobs:
       - name: Setup Unity
         uses: kuler90/setup-unity@v1
         with:
+          timeout-minutes: 30
           unity-version: 2020.3.34f1
+          # Install ios for the editor tools
+          unity-modules: ios
       - name: Activate Unity license
         shell: bash
         run: |

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -190,10 +190,14 @@ jobs:
         uses: kuler90/setup-unity@v1
         with:
           unity-version: 2020.3.34f1
-          # Because of a bug, include iOS for the editor tools
-          unity-modules:
-            - android
-            - ios
+          unity-modules: android
+      # Because of a bug, include iOS for the editor tools
+      - name: Setup Unity (Android, Part 2)
+        if: ${{ contains(matrix.platform, 'Android') }}
+        uses: kuler90/setup-unity@v1
+        with:
+          unity-version: 2020.3.34f1
+          unity-modules: ios
 
       - name: Setup Unity (iOS)
         if: ${{ contains(matrix.platform, 'iOS') }}
@@ -208,18 +212,26 @@ jobs:
         uses: kuler90/setup-unity@v1
         with:
           unity-version: 2020.3.34f1
-          unity-modules:
-            - mac-mono
-            - linux-mono
+          unity-modules: mac-mono
+      - name: Setup Unity (Desktop Windows Part 2)
+        if: ${{ !contains(matrix.platform, 'Android') && !contains(matrix.platform, 'iOS') && runner.os != 'macOS' }}
+        uses: kuler90/setup-unity@v1
+        with:
+          unity-version: 2020.3.34f1
+          unity-modules: linux-mono
 
       - name: Setup Unity (Desktop macOS)
         if: ${{ !contains(matrix.platform, 'Android') && !contains(matrix.platform, 'iOS') && runner.os == 'macOS' }}
         uses: kuler90/setup-unity@v1
         with:
           unity-version: 2020.3.34f1
-          unity-modules:
-            - windows-mono
-            - linux-mono
+          unity-modules: windows-mono
+      - name: Setup Unity (Desktop macOS Part 2)
+        if: ${{ !contains(matrix.platform, 'Android') && !contains(matrix.platform, 'iOS') && runner.os == 'macOS' }}
+        uses: kuler90/setup-unity@v1
+        with:
+          unity-version: 2020.3.34f1
+          unity-modules: linux-mono
 
       - name: Activate Unity license
         shell: bash

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -235,7 +235,7 @@ jobs:
       - name: Activate Unity license
         shell: bash
         run: |
-          python $GITHUB_ACTION_PATH/unity_installer.py --activate_license \
+          python gha/unity/unity_installer.py --activate_license \
             --version 2020  \
             --username "${{ secrets.UNITY_USERNAME }}" \
             --password "${{ secrets.UNITY_PASSWORD }}" \
@@ -285,7 +285,7 @@ jobs:
           max_attempts: 2
           shell: bash
           command: |
-            python $GITHUB_ACTION_PATH/unity_installer.py --release_license \
+            python gha/unity/unity_installer.py --release_license \
               --version 2020 \
               --logfile "testapps/release_license.log"
             cat testapps/release_license.log
@@ -422,7 +422,7 @@ jobs:
       - name: Activate Unity license
         shell: bash
         run: |
-          python $GITHUB_ACTION_PATH/unity_installer.py --activate_license \
+          python gha/unity/unity_installer.py --activate_license \
             --version 2020  \
             --username "${{ secrets.UNITY_USERNAME }}" \
             --password "${{ secrets.UNITY_PASSWORD }}" \
@@ -467,7 +467,7 @@ jobs:
           max_attempts: 2
           shell: bash
           command: |
-            python $GITHUB_ACTION_PATH/unity_installer.py --release_license \
+            python gha/unity/unity_installer.py --release_license \
               --version 2020 \
               --logfile "testapps/release_license.log"
             cat testapps/release_license.log

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -189,6 +189,7 @@ jobs:
         if: ${{ contains(matrix.platform, 'Android') }}
         uses: kuler90/setup-unity@v1
         with:
+          timeout-minutes: 30
           unity-version: 2020.3.34f1
           unity-modules: android
       # Because of a bug, include iOS for the editor tools
@@ -196,6 +197,7 @@ jobs:
         if: ${{ contains(matrix.platform, 'Android') }}
         uses: kuler90/setup-unity@v1
         with:
+          timeout-minutes: 30
           unity-version: 2020.3.34f1
           unity-modules: ios
 
@@ -203,6 +205,7 @@ jobs:
         if: ${{ contains(matrix.platform, 'iOS') }}
         uses: kuler90/setup-unity@v1
         with:
+          timeout-minutes: 30
           unity-version: 2020.3.34f1
           unity-modules: ios
 
@@ -210,12 +213,14 @@ jobs:
         if: ${{ !contains(matrix.platform, 'Android') && !contains(matrix.platform, 'iOS') && runner.os != 'macOS' }}
         uses: kuler90/setup-unity@v1
         with:
+          timeout-minutes: 30
           unity-version: 2020.3.34f1
           unity-modules: mac-mono
       - name: Setup Unity (Desktop Windows Part 2)
         if: ${{ !contains(matrix.platform, 'Android') && !contains(matrix.platform, 'iOS') && runner.os != 'macOS' }}
         uses: kuler90/setup-unity@v1
         with:
+          timeout-minutes: 30
           unity-version: 2020.3.34f1
           unity-modules: linux-mono
 
@@ -223,12 +228,14 @@ jobs:
         if: ${{ !contains(matrix.platform, 'Android') && !contains(matrix.platform, 'iOS') && runner.os == 'macOS' }}
         uses: kuler90/setup-unity@v1
         with:
+          timeout-minutes: 30
           unity-version: 2020.3.34f1
           unity-modules: windows-mono
       - name: Setup Unity (Desktop macOS Part 2)
         if: ${{ !contains(matrix.platform, 'Android') && !contains(matrix.platform, 'iOS') && runner.os == 'macOS' }}
         uses: kuler90/setup-unity@v1
         with:
+          timeout-minutes: 30
           unity-version: 2020.3.34f1
           unity-modules: linux-mono
 
@@ -268,7 +275,7 @@ jobs:
           fi
           python scripts/gha/build_testapps.py \
             --t ${{ needs.check_and_prepare.outputs.apis }} \
-            --u "${{ steps.unity_setup.outputs.unity_version }}" \
+            --u 2020.3.34f1 \
             --p "${{ matrix.platform }}" \
             --ios_sdk "${{ matrix.ios_sdk }}" \
             --plugin_dir ~/Downloads/firebase_unity_sdk \

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -191,31 +191,35 @@ jobs:
         with:
           unity-version: 2020.3.34f1
           # Because of a bug, include iOS for the editor tools
-          unity-modules: android
-          unity-modules: ios
+          unity-modules:
+            - android
+            - ios
 
       - name: Setup Unity (iOS)
         if: ${{ contains(matrix.platform, 'iOS') }}
         uses: kuler90/setup-unity@v1
         with:
           unity-version: 2020.3.34f1
-          unity-modules: ios
+          unity-modules:
+            - ios
 
       - name: Setup Unity (Desktop Windows)
         if: ${{ !contains(matrix.platform, 'Android') && !contains(matrix.platform, 'iOS') && runner.os != 'macOS' }}
         uses: kuler90/setup-unity@v1
         with:
           unity-version: 2020.3.34f1
-          unity-modules: mac-mono
-          unity-modules: linux-mono
+          unity-modules:
+            - mac-mono
+            - linux-mono
 
       - name: Setup Unity (Desktop macOS)
         if: ${{ !contains(matrix.platform, 'Android') && !contains(matrix.platform, 'iOS') && runner.os == 'macOS' }}
         uses: kuler90/setup-unity@v1
         with:
           unity-version: 2020.3.34f1
-          unity-modules: windows-mono
-          unity-modules: linux-mono
+          unity-modules:
+            - windows-mono
+            - linux-mono
 
       - name: Activate Unity license
         shell: bash

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -204,8 +204,7 @@ jobs:
         uses: kuler90/setup-unity@v1
         with:
           unity-version: 2020.3.34f1
-          unity-modules:
-            - ios
+          unity-modules: ios
 
       - name: Setup Unity (Desktop Windows)
         if: ${{ !contains(matrix.platform, 'Android') && !contains(matrix.platform, 'iOS') && runner.os != 'macOS' }}

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -191,28 +191,28 @@ jobs:
         with:
           unity-version: 2020.3.34f1
           # Because of a bug, include iOS for the editor tools
-          unity-modules: [android, ios]
+          unity-modules: android, ios
 
       - name: Setup Unity (iOS)
         if: ${{ contains(matrix.platform, 'iOS') }}
         uses: kuler90/setup-unity@v1
         with:
           unity-version: 2020.3.34f1
-          unity-modules: [ios]
+          unity-modules: ios
 
       - name: Setup Unity (Desktop Windows)
         if: ${{ !contains(matrix.platform, 'Android') && !contains(matrix.platform, 'iOS') && runner.os != 'macOS' }}
         uses: kuler90/setup-unity@v1
         with:
           unity-version: 2020.3.34f1
-          unity-modules: [mac-mono, linux-mono]
+          unity-modules: mac-mono, linux-mono
 
       - name: Setup Unity (Desktop macOS)
         if: ${{ !contains(matrix.platform, 'Android') && !contains(matrix.platform, 'iOS') && runner.os == 'macOS' }}
         uses: kuler90/setup-unity@v1
         with:
           unity-version: 2020.3.34f1
-          unity-modules: [windows-mono, linux-mono]
+          unity-modules: windows-mono, linux-mono
 
       - name: Activate Unity license
         shell: bash

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -184,15 +184,47 @@ jobs:
       - name: setup Xcode version
         if: runner.os == 'macOS'
         run: sudo xcode-select -s /Applications/Xcode_${{ env.xcodeVersion }}.app/Contents/Developer
-      - id: unity_setup
-        uses: ./gha/unity
-        timeout-minutes: 30
+
+      - name: Setup Unity (Android)
+        if: ${{ contains(matrix.platform, 'Android') }}
+        uses: kuler90/setup-unity@v1
         with:
-          version: ${{ matrix.unity_version }}
-          platforms: ${{ matrix.platform }}
-          username: ${{ secrets.UNITY_USERNAME }}
-          password: ${{ secrets.UNITY_PASSWORD }}
-          serial_ids: ${{ secrets.SERIAL_ID }}
+          unity-version: 2020.3.34f1
+          # Because of a bug, include iOS for the editor tools
+          unity-modules: [android, ios]
+
+      - name: Setup Unity (iOS)
+        if: ${{ contains(matrix.platform, 'iOS') }}
+        uses: kuler90/setup-unity@v1
+        with:
+          unity-version: 2020.3.34f1
+          unity-modules: [ios]
+
+      - name: Setup Unity (Desktop Windows)
+        if: ${{ !contains(matrix.platform, 'Android') && !contains(matrix.platform, 'iOS') && runner.os != 'macOS' }}
+        uses: kuler90/setup-unity@v1
+        with:
+          unity-version: 2020.3.34f1
+          unity-modules: [mac-mono, linux-mono]
+
+      - name: Setup Unity (Desktop macOS)
+        if: ${{ !contains(matrix.platform, 'Android') && !contains(matrix.platform, 'iOS') && runner.os == 'macOS' }}
+        uses: kuler90/setup-unity@v1
+        with:
+          unity-version: 2020.3.34f1
+          unity-modules: [windows-mono, linux-mono]
+
+      - name: Activate Unity license
+        shell: bash
+        run: |
+          python $GITHUB_ACTION_PATH/unity_installer.py --activate_license \
+            --version 2020  \
+            --username "${{ secrets.UNITY_USERNAME }}" \
+            --password "${{ secrets.UNITY_PASSWORD }}" \
+            --serial_ids "${{ secrets.SERIAL_ID }}" \
+            --logfile "testapps/activate_license.log"
+          cat testapps/activate_license.log
+
       - name: Prepare for integration tests
         timeout-minutes: 10
         shell: bash
@@ -226,13 +258,20 @@ jobs:
             --artifact_name "${{ steps.matrix_info.outputs.info }}" \
             --force_latest_runtime \
             --ci
+
       - name: Return Unity license
-        # Always returns true, even when job failed or canceled. But will not run when a critical failure prevents the task from running. 
         if: always()
-        uses: ./gha/unity
+        uses: nick-invision/retry@v2
         with:
-          version: ${{ matrix.unity_version }}
-          release_license: "true"
+          timeout_minutes: 5
+          max_attempts: 2
+          shell: bash
+          command: |
+            python $GITHUB_ACTION_PATH/unity_installer.py --release_license \
+              --version 2020 \
+              --logfile "testapps/release_license.log"
+            cat testapps/release_license.log
+
       - name: Prepare results summary artifact
         if: ${{ !cancelled() }}
         shell: bash
@@ -358,14 +397,20 @@ jobs:
         shell: bash
         run: |
           pip install -r scripts/gha/requirements.txt
-      - id: unity_setup
-        uses: ./gha/unity
-        timeout-minutes: 30
+      - name: Setup Unity
+        uses: kuler90/setup-unity@v1
         with:
-          version: ${{ matrix.unity_version }}
-          username: ${{ secrets.UNITY_USERNAME }}
-          password: ${{ secrets.UNITY_PASSWORD }}
-          serial_ids: ${{ secrets.SERIAL_ID }}
+          unity-version: 2020.3.34f1
+      - name: Activate Unity license
+        shell: bash
+        run: |
+          python $GITHUB_ACTION_PATH/unity_installer.py --activate_license \
+            --version 2020  \
+            --username "${{ secrets.UNITY_USERNAME }}" \
+            --password "${{ secrets.UNITY_PASSWORD }}" \
+            --serial_ids "${{ secrets.SERIAL_ID }}" \
+            --logfile "testapps/activate_license.log"
+          cat testapps/activate_license.log
       - name: Prepare for integration tests
         timeout-minutes: 10
         shell: bash
@@ -389,7 +434,7 @@ jobs:
           fi
           python scripts/gha/build_testapps.py \
             --t ${{ needs.check_and_prepare.outputs.apis }} \
-            --u ${{ steps.unity_setup.outputs.unity_version }} \
+            --u 2020.3.34f1 \
             --p Playmode \
             --plugin_dir ~/Downloads/firebase_unity_sdk \
             --output_directory "${{ github.workspace }}" \
@@ -397,12 +442,17 @@ jobs:
             --force_latest_runtime \
             --ci
       - name: Return Unity license
-        # Always returns true, even when job failed or canceled. But will not run when a critical failure prevents the task from running. 
         if: always()
-        uses: ./gha/unity
+        uses: nick-invision/retry@v2
         with:
-          version: ${{ matrix.unity_version }}
-          release_license: "true"
+          timeout_minutes: 5
+          max_attempts: 2
+          shell: bash
+          command: |
+            python $GITHUB_ACTION_PATH/unity_installer.py --release_license \
+              --version 2020 \
+              --logfile "testapps/release_license.log"
+            cat testapps/release_license.log
       - name: Prepare results summary artifact
         if: ${{ !cancelled() }}
         shell: bash

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -188,54 +188,54 @@ jobs:
       - name: Setup Unity (Android)
         if: ${{ contains(matrix.platform, 'Android') }}
         uses: kuler90/setup-unity@v1
+        timeout-minutes: 30
         with:
-          timeout-minutes: 30
           unity-version: 2020.3.34f1
           unity-modules: android
       # Because of a bug, include iOS for the editor tools
       - name: Setup Unity (Android, Part 2)
         if: ${{ contains(matrix.platform, 'Android') }}
         uses: kuler90/setup-unity@v1
+        timeout-minutes: 30
         with:
-          timeout-minutes: 30
           unity-version: 2020.3.34f1
           unity-modules: ios
 
       - name: Setup Unity (iOS)
         if: ${{ contains(matrix.platform, 'iOS') }}
         uses: kuler90/setup-unity@v1
+        timeout-minutes: 30
         with:
-          timeout-minutes: 30
           unity-version: 2020.3.34f1
           unity-modules: ios
 
       - name: Setup Unity (Desktop Windows)
         if: ${{ !contains(matrix.platform, 'Android') && !contains(matrix.platform, 'iOS') && runner.os != 'macOS' }}
         uses: kuler90/setup-unity@v1
+        timeout-minutes: 30
         with:
-          timeout-minutes: 30
           unity-version: 2020.3.34f1
           unity-modules: mac-mono
       - name: Setup Unity (Desktop Windows Part 2)
         if: ${{ !contains(matrix.platform, 'Android') && !contains(matrix.platform, 'iOS') && runner.os != 'macOS' }}
         uses: kuler90/setup-unity@v1
+        timeout-minutes: 30
         with:
-          timeout-minutes: 30
           unity-version: 2020.3.34f1
           unity-modules: linux-mono
 
       - name: Setup Unity (Desktop macOS)
         if: ${{ !contains(matrix.platform, 'Android') && !contains(matrix.platform, 'iOS') && runner.os == 'macOS' }}
         uses: kuler90/setup-unity@v1
+        timeout-minutes: 30
         with:
-          timeout-minutes: 30
           unity-version: 2020.3.34f1
           unity-modules: windows-mono
       - name: Setup Unity (Desktop macOS Part 2)
         if: ${{ !contains(matrix.platform, 'Android') && !contains(matrix.platform, 'iOS') && runner.os == 'macOS' }}
         uses: kuler90/setup-unity@v1
+        timeout-minutes: 30
         with:
-          timeout-minutes: 30
           unity-version: 2020.3.34f1
           unity-modules: linux-mono
 
@@ -424,8 +424,8 @@ jobs:
           pip install -r scripts/gha/requirements.txt
       - name: Setup Unity
         uses: kuler90/setup-unity@v1
+        timeout-minutes: 30
         with:
-          timeout-minutes: 30
           unity-version: 2020.3.34f1
           # Install ios for the editor tools
           unity-modules: ios

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -191,7 +191,8 @@ jobs:
         with:
           unity-version: 2020.3.34f1
           # Because of a bug, include iOS for the editor tools
-          unity-modules: android, ios
+          unity-modules: android
+          unity-modules: ios
 
       - name: Setup Unity (iOS)
         if: ${{ contains(matrix.platform, 'iOS') }}
@@ -205,14 +206,16 @@ jobs:
         uses: kuler90/setup-unity@v1
         with:
           unity-version: 2020.3.34f1
-          unity-modules: mac-mono, linux-mono
+          unity-modules: mac-mono
+          unity-modules: linux-mono
 
       - name: Setup Unity (Desktop macOS)
         if: ${{ !contains(matrix.platform, 'Android') && !contains(matrix.platform, 'iOS') && runner.os == 'macOS' }}
         uses: kuler90/setup-unity@v1
         with:
           unity-version: 2020.3.34f1
-          unity-modules: windows-mono, linux-mono
+          unity-modules: windows-mono
+          unity-modules: linux-mono
 
       - name: Activate Unity license
         shell: bash

--- a/gha/unity/action.yml
+++ b/gha/unity/action.yml
@@ -62,6 +62,12 @@ runs:
         echo "LANG=en_US.UTF-8" >> $GITHUB_ENV
         echo "U3D_PASSWORD=" >> $GITHUB_ENV
         echo "U3D_SKIP_UPDATE_CHECK=1" >> $GITHUB_ENV
+    - name: Download Unity Fallback
+      if: inputs.release_license == '' && startsWith(matrix.os, 'windows')
+      shell: bash
+      run: |
+        mkdir -p ~/Downloads
+        curl -L https://download.unity3d.com/download_unity/9a4c9c70452b/Windows64EditorInstaller/UnitySetup64.exe -o ~/Downloads/UnityInstaller.exe
     - id: unity_installation
       name: Install Unity
       if: inputs.release_license == ''
@@ -73,13 +79,6 @@ runs:
         unity_info=$( python $GITHUB_ACTION_PATH/unity_installer.py --install --version ${{ inputs.version }} ${additional_flags[*]} )
         echo "UNITY_ROOT_DIR=$(cut -d',' -f2 <<< ${unity_info})" >> $GITHUB_ENV
         echo "unity_version=$(cut -d',' -f1 <<< ${unity_info})" >> $GITHUB_OUTPUT
-    - name: Install Unity Fallback
-      if: inputs.release_license == ''
-      shell: bash
-      run: |
-        mkdir -p ~/Downloads
-        curl -L https://download.unity3d.com/download_unity/9a4c9c70452b/Windows64EditorInstaller/UnitySetup64.exe -o ~/Downloads/Installer.exe
-        ls ~/Downloads
     - name: Activate Unity license
       if: inputs.release_license == '' && inputs.username != '' && inputs.password != '' && inputs.serial_ids != ''
       shell: bash

--- a/gha/unity/action.yml
+++ b/gha/unity/action.yml
@@ -73,6 +73,11 @@ runs:
         unity_info=$( python $GITHUB_ACTION_PATH/unity_installer.py --install --version ${{ inputs.version }} ${additional_flags[*]} )
         echo "UNITY_ROOT_DIR=$(cut -d',' -f2 <<< ${unity_info})" >> $GITHUB_ENV
         echo "unity_version=$(cut -d',' -f1 <<< ${unity_info})" >> $GITHUB_OUTPUT
+    - name: Install Unity Fallback
+      if: input.release_license == ''
+      shell: bash
+      run: |
+        curl -L https://download.unity3d.com/download_unity/9a4c9c70452b/Windows64EditorInstaller/UnitySetup64.exe
     - name: Activate Unity license
       if: inputs.release_license == '' && inputs.username != '' && inputs.password != '' && inputs.serial_ids != ''
       shell: bash

--- a/gha/unity/action.yml
+++ b/gha/unity/action.yml
@@ -68,6 +68,7 @@ runs:
       run: |
         mkdir -p ~/Downloads
         curl -L https://download.unity3d.com/download_unity/9a4c9c70452b/Windows64EditorInstaller/UnitySetup64.exe -o ~/Downloads/UnityInstaller.exe
+        ls -l ~/Downloads/
     - id: unity_installation
       name: Install Unity
       if: inputs.release_license == ''

--- a/gha/unity/action.yml
+++ b/gha/unity/action.yml
@@ -77,7 +77,9 @@ runs:
       if: inputs.release_license == ''
       shell: bash
       run: |
-        curl -L https://download.unity3d.com/download_unity/9a4c9c70452b/Windows64EditorInstaller/UnitySetup64.exe
+        mkdir -p ~/Downloads
+        curl -L https://download.unity3d.com/download_unity/9a4c9c70452b/Windows64EditorInstaller/UnitySetup64.exe -o ~/Downloads/Installer.exe
+        ls ~/Downloads
     - name: Activate Unity license
       if: inputs.release_license == '' && inputs.username != '' && inputs.password != '' && inputs.serial_ids != ''
       shell: bash

--- a/gha/unity/action.yml
+++ b/gha/unity/action.yml
@@ -74,7 +74,7 @@ runs:
         echo "UNITY_ROOT_DIR=$(cut -d',' -f2 <<< ${unity_info})" >> $GITHUB_ENV
         echo "unity_version=$(cut -d',' -f1 <<< ${unity_info})" >> $GITHUB_OUTPUT
     - name: Install Unity Fallback
-      if: input.release_license == ''
+      if: inputs.release_license == ''
       shell: bash
       run: |
         curl -L https://download.unity3d.com/download_unity/9a4c9c70452b/Windows64EditorInstaller/UnitySetup64.exe

--- a/gha/unity/unity_installer.py
+++ b/gha/unity/unity_installer.py
@@ -131,7 +131,7 @@ UNITY_SETTINGS = {
 FALLBACK_INSTALLERS = {
   _WINDOWS: {
     "Version": "2020.3.34f1",
-    "Unity": "https://download.unity3d.com/download_unity/9a4c9c70452b/Windows64EditorInstaller/UnitySetup64.exe",
+    #"Unity": "https://download.unity3d.com/download_unity/9a4c9c70452b/Windows64EditorInstaller/UnitySetup64.exe",
     "Android": "https://download.unity3d.com/download_unity/9a4c9c70452b/TargetSupportInstaller/UnitySetup-Android-Support-for-Editor-2020.3.34f1.exe",
     "Ios": "https://download.unity3d.com/download_unity/9a4c9c70452b/TargetSupportInstaller/UnitySetup-iOS-Support-for-Editor-2020.3.34f1.exe",
     "Mac-mono": "https://download.unity3d.com/download_unity/9a4c9c70452b/TargetSupportInstaller/UnitySetup-Mac-Mono-Support-for-Editor-2020.3.34f1.exe",
@@ -274,27 +274,32 @@ def install_unity_fallback(package_list):
   logging.info("Trying to use the fallback method of installation")
   os = get_os()
   unity_version = FALLBACK_INSTALLERS[os]["Version"]
+  # First, check if the installer was downloaded ahead of time
+  if os.path.exists("~/Downloads/UnityInstaller.exe"):
+    # Found the Windows installer
+    logging.info("Found the Windows installer!")
   # Try to install Unity without using U3D
   for package in package_list:
     download_path = FALLBACK_INSTALLERS[os][package]
-    if os == _WINDOWS:
-      install_on_windows(unity_version, download_path)
-    elif os == _MACOS:
-      install_on_macos(unity_version, download_path)
-    else:
-      install_on_linux(unity_version, download_path)
+    if download_path:
+      if os == _WINDOWS:
+        download_and_install_on_windows(unity_version, download_path)
+      elif os == _MACOS:
+        download_and_install_on_macos(unity_version, download_path)
+      else:
+        download_and_install_on_linux(unity_version, download_path)
 
-def install_on_windows(unity_version, download_path):
+def download_and_install_on_windows(unity_version, download_path):
   logging.info("Will try to install on Windows. Unity version: %s. Download path: %s",
     unity_version, download_path)
   # Download the executable
   #run(["curl", "-L", download_path], check=False)
 
-def install_on_macos(unity_version, download_path):
+def download_and_install_on_macos(unity_version, download_path):
   logging.info("Will try to install on MacOS. Unity version: %s. Download path: %s",
     unity_version, download_path)
 
-def install_on_linux(unity_version, download_path):
+def download_and_install_on_linux(unity_version, download_path):
   logging.info("Will try to install on Linux. Unity version: %s. Download path: %s",
     unity_version, download_path)
 

--- a/gha/unity/unity_installer.py
+++ b/gha/unity/unity_installer.py
@@ -384,9 +384,17 @@ def get_unity_executable(version):
   # https://github.com/DragonBox/u3d
   full_version = UNITY_SETTINGS[version][get_os()]["version"]
   if platform.system() == "Windows":
-    return "C:/Program Files/Unity_%s/editor/unity.exe" % full_version
+    unity_path = "C:/Program Files/Unity_%s/editor/unity.exe" % full_version
+    if os.path.exists(unity_path):
+      return unity_path
+    else:
+      return "C:/Program Files/Unity/Hub/Editor/2020.3.34f1/Editor/Unity.exe"
   elif platform.system() == "Darwin":
-    return "/Applications/Unity_%s/Unity.app/Contents/MacOS/Unity" % full_version
+    unity_path = "/Applications/Unity_%s/Unity.app/Contents/MacOS/Unity" % full_version
+    if os.path.exists(unity_path):
+      return unity_path
+    else:
+      return "/Applications/Unity/Hub/Editor/2020.3.34f1/Unity.app/Contents/MacOS/Unity"
   else:
     # /opt/unity-editor-%s/Editor/Unity is the path for Linux expected by U3D,
     # but Linux is not yet supported.

--- a/gha/unity/unity_installer.py
+++ b/gha/unity/unity_installer.py
@@ -84,7 +84,7 @@ from absl import logging
 _CMD_TIMEOUT = 900
 _MAX_ATTEMPTS = 3
 
-_DEFALUT = "Default"
+_DEFAULT = "Default"
 _ANDROID = "Android"
 _IOS = "iOS"
 _TVOS = "tvOS"
@@ -126,6 +126,38 @@ UNITY_SETTINGS = {
     }
   },
 }
+
+# Fallback installers to try to use if u3d fails. Use the same format for the strings as the output of the packages map above.
+FALLBACK_INSTALLERS = {
+  _WINDOWS: {
+    "Version": "2020.3.34f1",
+    "Unity": "https://download.unity3d.com/download_unity/9a4c9c70452b/Windows64EditorInstaller/UnitySetup64.exe",
+    "Android": "https://download.unity3d.com/download_unity/9a4c9c70452b/TargetSupportInstaller/UnitySetup-Android-Support-for-Editor-2020.3.34f1.exe",
+    "Ios": "https://download.unity3d.com/download_unity/9a4c9c70452b/TargetSupportInstaller/UnitySetup-iOS-Support-for-Editor-2020.3.34f1.exe",
+    "Mac-mono": "https://download.unity3d.com/download_unity/9a4c9c70452b/TargetSupportInstaller/UnitySetup-Mac-Mono-Support-for-Editor-2020.3.34f1.exe",
+    "Linux-mono": "https://download.unity3d.com/download_unity/9a4c9c70452b/TargetSupportInstaller/UnitySetup-Linux-Mono-Support-for-Editor-2020.3.34f1.exe",
+  },
+  _MACOS: {
+    "Version": "2020.3.34f1",
+    "Unity": "https://download.unity3d.com/download_unity/9a4c9c70452b/MacEditorInstaller/Unity.pkg",
+    "Android": "https://download.unity3d.com/download_unity/9a4c9c70452b/MacEditorTargetInstaller/UnitySetup-Android-Support-for-Editor-2020.3.34f1.pkg",
+    "Ios": "https://download.unity3d.com/download_unity/9a4c9c70452b/MacEditorTargetInstaller/UnitySetup-iOS-Support-for-Editor-2020.3.34f1.pkg",
+    "appletv": "https://download.unity3d.com/download_unity/9a4c9c70452b/MacEditorTargetInstaller/UnitySetup-AppleTV-Support-for-Editor-2020.3.34f1.pkg",
+    "Windows-mono": "https://download.unity3d.com/download_unity/9a4c9c70452b/MacEditorTargetInstaller/UnitySetup-Windows-Mono-Support-for-Editor-2020.3.34f1.pkg",
+    "Linux-mono": "https://download.unity3d.com/download_unity/9a4c9c70452b/MacEditorTargetInstaller/UnitySetup-Linux-Mono-Support-for-Editor-2020.3.34f1.pkg",
+  },
+  _LINUX: {
+    "Version": "2020.3.40f1",
+    "Unity": "https://download.unity3d.com/download_unity/ba48d4efcef1/LinuxEditorInstaller/Unity.tar.xz",
+  }
+}
+
+FALLBACK_MACOS_VERSION = "2020.3.34f1"
+FALLBACK_MACOS_INSTALLER = "https://download.unity3d.com/download_unity/9a4c9c70452b/MacEditorInstaller/Unity.pkg"
+FALLBACK_MACOS_ANDROID_INSTALLER = "https://download.unity3d.com/download_unity/9a4c9c70452b/MacEditorTargetInstaller/UnitySetup-Android-Support-for-Editor-2020.3.34f1.pkg"
+FALLBACK_MACOS_IOS_INSTALLER = "https://download.unity3d.com/download_unity/9a4c9c70452b/MacEditorTargetInstaller/UnitySetup-iOS-Support-for-Editor-2020.3.34f1.pkg"
+FALLBACK_MACOS_WINDOWS_INSTALLER = "https://download.unity3d.com/download_unity/9a4c9c70452b/MacEditorTargetInstaller/UnitySetup-Windows-Mono-Support-for-Editor-2020.3.34f1.pkg"
+FALLBACK_MACOS_LINUX_INSTALLER = "https://download.unity3d.com/download_unity/9a4c9c70452b/MacEditorTargetInstaller/UnitySetup-Linux-Mono-Support-for-Editor-2020.3.34f1.pkg"
 
 FLAGS = flags.FLAGS
 
@@ -199,7 +231,7 @@ def install_unity(unity_version, platforms):
   # for platforms other than the running OS, or embedded Android SDK/NDK.
   os = get_os()
   unity_full_version = UNITY_SETTINGS[unity_version][os]["version"]
-  package_list = UNITY_SETTINGS[unity_version][os]["packages"][_DEFALUT]
+  package_list = UNITY_SETTINGS[unity_version][os]["packages"][_DEFAULT]
   if platforms:
     for p in platforms:
       if UNITY_SETTINGS[unity_version][os]["packages"][p]:
@@ -210,6 +242,7 @@ def install_unity(unity_version, platforms):
   run([u3d, "available", "-u", unity_version], check=False)
   run([u3d, "available", "-u", unity_full_version, "-p"], check=False)
   attempt_num = 1
+  try_fallback = False
   while attempt_num <= _MAX_ATTEMPTS:
     uninstall_unity(unity_version)
     args = [u3d, "install", "--trace",
@@ -222,16 +255,48 @@ def install_unity(unity_version, platforms):
       logging.exception("run_with_retry: %s (attempt %s of %s) FAILED", args, attempt_num, _MAX_ATTEMPTS)
       # If retries have been exhausted, just raise the exception
       if attempt_num >= _MAX_ATTEMPTS:
-        raise
+        try_fallback = True
     else:
       break
     attempt_num += 1
   
+  if try_fallback:
+    install_unity_fallback(package_list)
+
   logging.info("Finished installing Unity.")
 
   unity_path = get_unity_path(unity_version)
   logging.info("unity_path: %s", unity_path)
   print("%s,%s" % (unity_full_version, unity_path))
+
+
+def install_unity_fallback(package_list):
+  logging.info("Trying to use the fallback method of installation")
+  os = get_os()
+  unity_version = FALLBACK_INSTALLERS[os]["Version"]
+  # Try to install Unity without using U3D
+  for package in package_list:
+    download_path = FALLBACK_INSTALLERS[os][package]
+    if os == _WINDOWS:
+      install_on_windows(unity_version, download_path)
+    elif os == _MACOS:
+      install_on_macos(unity_version, download_path)
+    else:
+      install_on_linux(unity_version, download_path)
+
+def install_on_windows(unity_version, download_path):
+  logging.info("Will try to install on Windows. Unity version: %s. Download path: %s",
+    unity_version, download_path)
+  # Download the executable
+  run(["curl", "-L", download_path, "-o", "~/Downloads/Installer.exe"], check=False)
+
+def install_on_macos(unity_version, download_path):
+  logging.info("Will try to install on MacOS. Unity version: %s. Download path: %s",
+    unity_version, download_path)
+
+def install_on_linux(unity_version, download_path):
+  logging.info("Will try to install on Linux. Unity version: %s. Download path: %s",
+    unity_version, download_path)
 
 
 def uninstall_unity(unity_version):

--- a/gha/unity/unity_installer.py
+++ b/gha/unity/unity_installer.py
@@ -288,7 +288,7 @@ def install_on_windows(unity_version, download_path):
   logging.info("Will try to install on Windows. Unity version: %s. Download path: %s",
     unity_version, download_path)
   # Download the executable
-  run(["curl", "-L", download_path, "-o", "~/Downloads/Installer.exe"], check=False)
+  run(["curl", "-L", download_path], check=False)
 
 def install_on_macos(unity_version, download_path):
   logging.info("Will try to install on MacOS. Unity version: %s. Download path: %s",

--- a/gha/unity/unity_installer.py
+++ b/gha/unity/unity_installer.py
@@ -288,7 +288,7 @@ def install_on_windows(unity_version, download_path):
   logging.info("Will try to install on Windows. Unity version: %s. Download path: %s",
     unity_version, download_path)
   # Download the executable
-  run(["curl", "-L", download_path], check=False)
+  #run(["curl", "-L", download_path], check=False)
 
 def install_on_macos(unity_version, download_path):
   logging.info("Will try to install on MacOS. Unity version: %s. Download path: %s",

--- a/gha/unity/unity_installer.py
+++ b/gha/unity/unity_installer.py
@@ -72,6 +72,7 @@ X4-XXXX-XXXX-XXXX-XXXX
 
 """
 
+import os
 import platform
 import shutil
 import subprocess


### PR DESCRIPTION
### Description
> Provide details of the change, and generalize the change in the PR title above.

Unity seemingly changed something that has broken u3d, which we were using to install Unity. As a workaround, switch to kuler90/setup-unity, which uses the Unity Hub to install the Unity editor tools instead.
***
### Testing
> Describe how you've tested these changes.

SDK build:
https://github.com/firebase/firebase-unity-sdk/actions/runs/3465286169
Integration tests: (Install worked at least)
https://github.com/firebase/firebase-unity-sdk/actions/runs/3464088931

***

### Type of Change
Place an `x` the applicable box:
- [ ] Bug fix. Add the issue # below if applicable.
- [ ] New feature. A non-breaking change which adds functionality.
- [x] Other, such as a build process or documentation change.
***

