### PR TITLE
Firestore Testapp build fix: add tvos to macOS host unity installations

### DIFF
--- a/gha/unity/unity_installer.py
+++ b/gha/unity/unity_installer.py
@@ -92,7 +92,7 @@ UNITY_SETTINGS = {
     },
     _MACOS: {
       "version": "2020.3.34f1",
-      "modules": {"Default": ["Unity"], "Android": ["android"], "iOS": ["ios"], "tvOS": ["appletv"], "Windows": ["windows-mono"], "macOS": ["ios"], "Linux": ["linux-mono"], "Playmode": None},
+      "modules": {"Default": ["Unity"], "Android": ["android"], "iOS": ["ios", "appletv"], "tvOS": ["appletv"], "Windows": ["windows-mono"], "macOS": ["ios"], "Linux": ["linux-mono"], "Playmode": None},
     },
     _LINUX: {
       "version": "2020.3.40f1",


### PR DESCRIPTION
### Description
> Provide details of the change, and generalize the change in the PR title above.

The Firestore app fails to build for iOS on CI without the addition of the Unity tvOS build support module. This is true on the `main` branch's [nightly CI run](https://github.com/firebase/firebase-unity-sdk/actions/runs/3512709226/jobs/5884706944).

I could not reproduce this locally. I uninstalled all versions of Unity on my machine to wipe out tvOS support on my host build machine. I then installed Unity and added the modules for macOS, Linux, Android and iOS build support. Building the testapp using command line tools succeeds. I also built the Firebase testapp via the Unit Editor, and that succeeded both the project export and the project compilation for simulators.

Finaly I checked to see if this build error was introduced when we added tvOS support to EDM4U by [rolling back our dependency to 1.2.172](https://github.com/firebase/firebase-unity-sdk/commit/d5d981f9aa6067e630aac799d178f07277f9f0eb), the version before any tvOS changes were made. This also [failed to build Firestore](https://github.com/firebase/firebase-unity-sdk/actions/runs/3514546740) so this problem doesn't seem to be related to those EDM4U changes.

***
### Testing
> Describe how you've tested these changes.

[Integration Test CI](https://github.com/firebase/firebase-unity-sdk/actions/runs/3508756492). Builds but there are still flakes that fail when the tests execute.
***

### Type of Change
Place an `x` the applicable box:
- [ ] Bug fix. Add the issue # below if applicable.
- [ ] New feature. A non-breaking change which adds functionality.
- [X] Other, such as a build process or documentation change.
***

