### PR TITLE
Use find_program to get python in cmake

### DIFF
--- a/.github/workflows/build_linux.yml
+++ b/.github/workflows/build_linux.yml
@@ -83,6 +83,10 @@ jobs:
         run: |
           sudo apt install openssl
 
+      - name: Install FUSE
+        run: |
+          sudo apt install libfuse2
+
       - id: unity_setup
         uses: ./gha/unity
         timeout-minutes: 30

--- a/.github/workflows/build_linux.yml
+++ b/.github/workflows/build_linux.yml
@@ -83,10 +83,6 @@ jobs:
         run: |
           sudo apt install openssl
 
-      - name: Install FUSE
-        run: |
-          sudo apt install libfuse2
-
       - id: unity_setup
         uses: ./gha/unity
         timeout-minutes: 30

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -146,6 +146,12 @@ else()
   set(DESKTOP OFF)
 endif()
 
+# Define the Python executable before including the subprojects
+find_program(FIREBASE_PYTHON_EXECUTABLE
+  NAMES python3 python
+  REQUIRED
+)
+
 include(FindPkgConfig)
 include(android_dependencies)
 include(build_universal)

--- a/cmake/build_aar.cmake
+++ b/cmake/build_aar.cmake
@@ -45,7 +45,7 @@ function(build_aar LIBRARY_NAME LIBRARY_TARGET PROGUARD_TARGET
 
   add_custom_command(
     OUTPUT "${OUTPUT_AAR}"
-    COMMAND python "${FIREBASE_SOURCE_DIR}/aar_builder/build_aar.py"
+    COMMAND ${FIREBASE_PYTHON_EXECUTABLE} "${FIREBASE_SOURCE_DIR}/aar_builder/build_aar.py"
       "--output_file=${OUTPUT_AAR}"
       "--library_file=$<TARGET_FILE:${LIBRARY_TARGET}>"
       "--architecture=${ANDROID_ABI}"

--- a/cmake/firebase_swig.cmake
+++ b/cmake/firebase_swig.cmake
@@ -202,13 +202,13 @@ macro(firebase_swig_add_library name)
     OUTPUT ${UNITY_SWIG_CS_FIX_FILE}
     DEPENDS ${UNITY_SWIG_CS_GEN_FILE}
     COMMAND
-      python
+      ${FIREBASE_PYTHON_EXECUTABLE}
         ${CMAKE_CURRENT_LIST_DIR}/../swig_commenter.py
         --input=\"${all_cpp_header_files}\"
         --output=\"${UNITY_SWIG_CS_GEN_FILE}\"
         --namespace_prefix=\"Firebase\"
     COMMAND
-      python
+      ${FIREBASE_PYTHON_EXECUTABLE}
         ${FIREBASE_SWIG_FIX_PY}
         --language=csharp
         --in_file=\"${UNITY_SWIG_CS_GEN_FILE}\"
@@ -233,7 +233,7 @@ macro(firebase_swig_add_library name)
     OUTPUT ${UNITY_SWIG_CPP_FIX_FILE}
     DEPENDS ${UNITY_SWIG_CPP_GEN_FILE}
     COMMAND
-      python
+      ${FIREBASE_PYTHON_EXECUTABLE}
         ${FIREBASE_SWIG_FIX_PY}
         --language=cpp
         --in_file=\"${UNITY_SWIG_CPP_GEN_FILE}\"


### PR DESCRIPTION
### Description
> Provide details of the change, and generalize the change in the PR title above.

Use find_program to get the python executable, since it can either by python or python3.
***
### Testing
> Describe how you've tested these changes.

https://github.com/firebase/firebase-unity-sdk/actions/runs/3577495692
***

### Type of Change
Place an `x` the applicable box:
- [ ] Bug fix. Add the issue # below if applicable.
- [ ] New feature. A non-breaking change which adds functionality.
- [x] Other, such as a build process or documentation change.
***

