### PR TITLE
Pin to Ubuntu 20 runner

### DIFF
--- a/.github/workflows/build_linux.yml
+++ b/.github/workflows/build_linux.yml
@@ -38,7 +38,7 @@ on:
 jobs:
   build_desktop:
     name: build-linux-unity${{inputs.unity_version}}-CPP${{ inputs.firebase_cpp_sdk_version }}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     strategy:
       fail-fast: false
       


### PR DESCRIPTION
### Description
> Provide details of the change, and generalize the change in the PR title above.

Ubuntu latest has been having issues installing Unity, with errors around FUSE. To unblock things, pin to Ubuntu 20, which does not have this issue.
***
### Testing
> Describe how you've tested these changes.

https://github.com/firebase/firebase-unity-sdk/actions/runs/3567558433
***

### Type of Change
Place an `x` the applicable box:
- [ ] Bug fix. Add the issue # below if applicable.
- [ ] New feature. A non-breaking change which adds functionality.
- [x] Other, such as a build process or documentation change.
***

