### PR TITLE
Remove Strawberry Perl in the Windows build

### DIFF
--- a/.github/workflows/build_windows.yml
+++ b/.github/workflows/build_windows.yml
@@ -108,6 +108,12 @@ jobs:
         shell: bash
         run: |
           rm C:/msys64/mingw64/lib/libz*
+
+      # Strawberry Perl has zlib within, so we also remove it
+      - name: Remove Strawberry
+        shell: bash
+        run: |
+          rm -r C:/Strawberry
       
       - name: Build SDK (Windows)
         timeout-minutes: 90


### PR DESCRIPTION
### Description
> Provide details of the change, and generalize the change in the PR title above.

The Windows runners recently had Strawberry Perl added, which is causing conflicts when the build searches for zlib. Remove the directory, since we don't depend on it at all.
***
### Testing
> Describe how you've tested these changes.

https://github.com/firebase/firebase-unity-sdk/actions/runs/3568935389
***

### Type of Change
Place an `x` the applicable box:
- [ ] Bug fix. Add the issue # below if applicable.
- [ ] New feature. A non-breaking change which adds functionality.
- [x] Other, such as a build process or documentation change.
***

