### PR TITLE
Fix typo in RC Config Settings

### DIFF
--- a/docs/readme.md
+++ b/docs/readme.md
@@ -71,6 +71,9 @@ Release Notes
 - Changes
     - General (Android): Update to Firebase Android BoM version 31.1.1.
     - General (iOS): Update to Firebase Cocoapods version 10.3.0.
+    - Remote Config: Added `ConfigSettings.MinimumFetchIntervalInMilliseconds`,
+      which should be used instead of `MinimumFetchInternalInMilliseconds`. The
+      old one is considered deprecated, and will be removed with the next major release.
 
 ### 10.2.0
 - Changes

--- a/remote_config/src/ConfigSettings.cs
+++ b/remote_config/src/ConfigSettings.cs
@@ -30,19 +30,28 @@ namespace Firebase.RemoteConfig {
     /// @note Fetches less than duration seconds after the last fetch from the
     /// Firebase Remote Config server would use values returned during the last
     /// fetch. Default is 12 hours.
-    public ulong MinimumFetchInternalInMilliseconds { get; set; }
+    public ulong MinimumFetchIntervalInMilliseconds { get; set; }
+
+    /// The minimum interval between successive fetch calls.
+    ///
+    /// @deprecated Use MinimumFetchIntervalInMilliseconds instead. This will be
+    /// removed in the next major release.
+    public ulong MinimumFetchInternalInMilliseconds {
+      get { return MinimumFetchIntervalInMilliseconds; }
+      set { MinimumFetchIntervalInMilliseconds = value; }
+    }
 
     internal static ConfigSettings FromInternal(ConfigSettingsInternal csInternal) {
       return new ConfigSettings {
         FetchTimeoutInMilliseconds = csInternal.fetch_timeout_in_milliseconds,
-        MinimumFetchInternalInMilliseconds = csInternal.minimum_fetch_interval_in_milliseconds
+        MinimumFetchIntervalInMilliseconds = csInternal.minimum_fetch_interval_in_milliseconds
       };
     }
 
     internal static ConfigSettingsInternal ToInternal(ConfigSettings cs) {
       ConfigSettingsInternal csInternal = new ConfigSettingsInternal();
       csInternal.fetch_timeout_in_milliseconds = cs.FetchTimeoutInMilliseconds;
-      csInternal.minimum_fetch_interval_in_milliseconds = cs.MinimumFetchInternalInMilliseconds;
+      csInternal.minimum_fetch_interval_in_milliseconds = cs.MinimumFetchIntervalInMilliseconds;
       return csInternal;
     }
   }


### PR DESCRIPTION
### Description
> Provide details of the change, and generalize the change in the PR title above.

Remote Config had a typo in the Config Settings, MinimumFetchInternalInMilliseconds should be Interval (v instead of n).  Add the correct property, and deprecate the old one.
***
### Testing
> Describe how you've tested these changes.

Building locally, and https://github.com/firebase/firebase-unity-sdk/actions/runs/3690833620
***

### Type of Change
Place an `x` the applicable box:
- [x] Bug fix. Add the issue # below if applicable.
- [ ] New feature. A non-breaking change which adds functionality.
- [ ] Other, such as a build process or documentation change.
***

