### PR TITLE
Temporarily remove tvOS from print_matrix_configuration.py

### DIFF
--- a/scripts/gha/print_matrix_configuration.py
+++ b/scripts/gha/print_matrix_configuration.py
@@ -65,7 +65,7 @@ PARAMETERS = {
     "matrix": {
       "unity_versions": ["2020"],
       "build_os": [""],
-      "platforms": [WINDOWS, MACOS, LINUX, ANDROID, IOS, TVOS, PLAYMODE],
+      "platforms": [WINDOWS, MACOS, LINUX, ANDROID, IOS, PLAYMODE],
       "mobile_devices": ["android_target", "ios_target", "simulator_target", "tvos_simulator"],
       "mobile_test_on": ["real"],
 


### PR DESCRIPTION
### Description
> Provide details of the change, and generalize the change in the PR title above.

`print_matrix_configuration.py` output tvOS as a platform when the expanded matrix flag is set in the Integration Test workflow. However, the Unity Build does not yet incoroporate tvOS into the .unitypackages, so the Integration Test CI fails when attempting to run the tvOS testapp.

***
### Testing
> Describe how you've tested these changes.

[Unity Build CI](https://github.com/firebase/firebase-unity-sdk/actions/runs/3847795608)
[Integration Test CI](https://github.com/firebase/firebase-unity-sdk/actions/runs/3848456660)

Test failures are due to other testapp failures on mobile.

***

### Type of Change
Place an `x` the applicable box:
- [ ] Bug fix. Add the issue # below if applicable.
- [ ] New feature. A non-breaking change which adds functionality.
- [X] Other, such as a build process or documentation change.
***

