### PR TITLE
Fix tvOS iTests - Use UNITY_TVOS and disable Storage filesystem tests

### DIFF
--- a/auth/testapp/Assets/Firebase/Sample/Auth/UIHandler.cs
+++ b/auth/testapp/Assets/Firebase/Sample/Auth/UIHandler.cs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#if UNITY_IOS
+#if (UNITY_IOS || UNITY_TVOS)
 using UnityEngine.SocialPlatforms.GameCenter;
 #endif
 
@@ -350,7 +350,7 @@ namespace Firebase.Sample.Auth {
     }
 
     public void AuthenticateToGameCenter() {
-      #if UNITY_IOS
+      #if (UNITY_IOS || UNITY_TVOS)
         Social.localUser.Authenticate(success => {
           Debug.Log("Game Center Initialization Complete - Result: " + success);
         });

--- a/crashlytics/testapp/Assets/Firebase/Sample/Crashlytics/UIHandlerAutomated.cs
+++ b/crashlytics/testapp/Assets/Firebase/Sample/Crashlytics/UIHandlerAutomated.cs
@@ -90,7 +90,7 @@ namespace Firebase.Sample.Crashlytics {
       bool result = (bool)isInitializedMethodInfo.Invoke(impl, new object[] {});
       DebugLog("Crashlytics.impl.isSDKInitialized(): " + result);
 
-#if UNITY_ANDROID || UNITY_IOS
+#if (UNITY_IOS || UNITY_TVOS || UNITY_ANDROID)
       return result;
 #else
       // The desktop stub implementation returns false, so expect that.

--- a/database/testapp/Assets/Firebase/Sample/Database/UIHandlerAutomated.cs
+++ b/database/testapp/Assets/Firebase/Sample/Database/UIHandlerAutomated.cs
@@ -24,10 +24,10 @@ namespace Firebase.Sample.Database {
     // Database URL
     private string databaseUrl = "REPLACE_WITH_YOUR_DATABASE_URL";
 
-#if !(UNITY_IOS || UNITY_ANDROID) || UNITY_EDITOR
+#if !(UNITY_IOS || UNITY_TVOS || UNITY_ANDROID) || UNITY_EDITOR
     // Manually create the default app on desktop so that it's possible to specify the database URL.
     private FirebaseApp defaultApp;
-#endif  // !(UNITY_IOS || UNITY_ANDROID) || UNITY_EDITOR
+#endif  // !(UNITY_IOS || UNITY_TVOS || UNITY_ANDROID) || UNITY_EDITOR
 
     static Thread mainThread = null;
 
@@ -69,13 +69,13 @@ namespace Firebase.Sample.Database {
         TestQueryEqualToString,
         TestQueryEqualToDouble,
         TestQueryEqualToBool,
-#if !UNITY_IOS
+#if !(UNITY_IOS || UNITY_TVOS)
         // TODO(b/129906113) These tests don't work on iOS, and are removed
         // until they are fixed.
         TestQueryEqualToStringAndKey,
         TestQueryEqualToDoubleAndKey,
         TestQueryEqualToBoolAndKey,
-#endif  // !UNITY_IOS
+#endif  // !(UNITY_IOS || UNITY_TVOS)
         TestQueryLimitToFirst,
         TestQueryLimitToLast,
         TestQueryOrderByChild,
@@ -116,21 +116,21 @@ namespace Firebase.Sample.Database {
 
     // Create the default FirebaseApp on non-mobile platforms.
     private void CreateDefaultApp() {
-#if !(UNITY_IOS || UNITY_ANDROID) || UNITY_EDITOR
+#if !(UNITY_IOS || UNITY_TVOS || UNITY_ANDROID) || UNITY_EDITOR
       defaultApp = FirebaseApp.Create(new AppOptions { DatabaseUrl = new Uri(databaseUrl) });
       if (!loggedOnceCreateDefaultApp) {
         DebugLog(String.Format("Default app created with database url {0}",
                                 defaultApp.Options.DatabaseUrl));
         loggedOnceCreateDefaultApp = true;
       }
-#endif  // !(UNITY_IOS || UNITY_ANDROID) || UNITY_EDITOR
+#endif  // !(UNITY_IOS || UNITY_TVOS || UNITY_ANDROID) || UNITY_EDITOR
     }
 
     // Remove all reference to the default FirebaseApp.
     private void DestroyDefaultApp() {
-#if !(UNITY_IOS || UNITY_ANDROID) || UNITY_EDITOR
+#if !(UNITY_IOS || UNITY_TVOS || UNITY_ANDROID) || UNITY_EDITOR
       defaultApp = null;
-#endif  // !(UNITY_IOS || UNITY_ANDROID) || UNITY_EDITOR
+#endif  // !(UNITY_IOS || UNITY_TVOS || UNITY_ANDROID) || UNITY_EDITOR
     }
 
     protected override void InitializeFirebase() {
@@ -398,13 +398,13 @@ namespace Firebase.Sample.Database {
         reference.ChildChanged += childChangedListener;
         reference.ChildMoved += childMovedListener;
         reference.ChildRemoved += childRemovedListener;
-#if (UNITY_IOS || UNITY_ANDROID)
+#if (UNITY_IOS || UNITY_TVOS || UNITY_ANDROID)
         // The desktop implementation will currently fail if exceptions are thrown in child
         reference.ChildAdded += childAddedListenerThrowException;
         reference.ChildChanged += childChangedListenerThrowException;
         reference.ChildMoved += childMovedListenerThrowException;
         reference.ChildRemoved += childRemovedListenerThrowException;
-#endif  // #if (UNITY_IOS || UNITY_ANDROID)
+#endif  // #if (UNITY_IOS || UNITY_TVOS || UNITY_ANDROID)
       }
 
       public bool AllGood { get; private set; }

--- a/dynamic_links/testapp/Assets/Firebase/Sample/DynamicLinks/UIHandlerAutomated.cs
+++ b/dynamic_links/testapp/Assets/Firebase/Sample/DynamicLinks/UIHandlerAutomated.cs
@@ -33,7 +33,7 @@ namespace Firebase.Sample.DynamicLinks {
       Func<Task>[] tests = {
         TestCreateLongLinkAsync,
 // TODO(b/264533368) Enable theses tests when the issue has been fixed.
-#if (false)  // (UNITY_ANDROID || UNITY_IOS)
+#if (false)  // (UNITY_IOS || UNITY_TVOS || UNITY_ANDROID)
         // Link shortening does not work on desktop builds, so only test that for mobile.
         TestCreateShortLinkAsync,
         TestCreateUnguessableShortLinkAsync,

--- a/dynamic_links/testapp/Assets/Firebase/Sample/DynamicLinks/UIHandlerAutomated.cs
+++ b/dynamic_links/testapp/Assets/Firebase/Sample/DynamicLinks/UIHandlerAutomated.cs
@@ -33,7 +33,7 @@ namespace Firebase.Sample.DynamicLinks {
       Func<Task>[] tests = {
         TestCreateLongLinkAsync,
 // TODO(b/264533368) Enable theses tests when the issue has been fixed.
-#if (false)  // (UNITY_IOS || UNITY_TVOS || UNITY_ANDROID)
+#if (false)  // (UNITY_ANDROID || UNITY_IOS)
         // Link shortening does not work on desktop builds, so only test that for mobile.
         TestCreateShortLinkAsync,
         TestCreateUnguessableShortLinkAsync,

--- a/messaging/testapp/Assets/Firebase/Sample/Messaging/UIHandlerAutomated.cs
+++ b/messaging/testapp/Assets/Firebase/Sample/Messaging/UIHandlerAutomated.cs
@@ -38,18 +38,18 @@ namespace Firebase.Sample.Messaging {
       Func<Task>[] tests = {
         // Disable these tests on desktop, as desktop never receives a token, and so WaitForToken
         // (called by all of these tests) stalls forever.
-#if (UNITY_IOS || UNITY_ANDROID)
+#if (UNITY_IOS || UNITY_TVOS || UNITY_ANDROID)
         MakeTest(TestWaitForToken),
-#if !UNITY_IOS
+#if !(UNITY_IOS || UNITY_TVOS)
         // TODO(b/130674454) This test times out on iOS, disabling until fixed.
         MakeTest(TestSendPlaintextMessageToDevice),
-#endif // !UNITY_IOS
+#endif // !(UNITY_IOS || UNITY_TVOS)
         MakeTest(TestSendJsonMessageToDevice),
         MakeTest(TestSendJsonMessageToSubscribedTopic),
-#else  // (UNITY_IOS || UNITY_ANDROID)
+#else  // (UNITY_IOS || UNITY_TVOS || UNITY_ANDROID)
         // Run a vacuous test. Should be removed if/when desktop platforms get a real test.
         MakeTest(TestDummy),
-#endif // (UNITY_IOS || UNITY_ANDROID)
+#endif // (UNITY_IOS || UNITY_TVOS || UNITY_ANDROID)
         // TODO(varconst): a more involved test to check that resubscribing works
         MakeTest(TestGetTokenAsync),
         MakeTest(TestDeleteTokenAsync),
@@ -58,18 +58,18 @@ namespace Firebase.Sample.Messaging {
       string[] customTests = {
         // Disable these tests on desktop, as desktop never receives a token, and so WaitForToken
         // (called by all of these tests) stalls forever.
-#if (UNITY_IOS || UNITY_ANDROID)
+#if (UNITY_IOS || UNITY_TVOS || UNITY_ANDROID)
         "TestWaitForToken",
-#if !UNITY_IOS
+#if !(UNITY_IOS || UNITY_TVOS)
         // TODO(b/130674454) This test times out on iOS, disabling until fixed.
         "TestSendPlaintextMessageToDevice",
-#endif // !UNITY_IOS
+#endif // !(UNITY_IOS || UNITY_TVOS)
         "TestSendJsonMessageToDevice",
         "TestSendJsonMessageToSubscribedTopic",
-#else  // (UNITY_IOS || UNITY_ANDROID)
+#else  // #if (UNITY_IOS || UNITY_TVOS || UNITY_ANDROID)
         // Run a vacuous test. Should be removed if/when desktop platforms get a real test.
         "TestDummy",
-#endif // (UNITY_IOS || UNITY_ANDROID)
+#endif // (UNITY_IOS || UNITY_TVOS || UNITY_ANDROID)
         // TODO(varconst): a more involved test to check that resubscribing works
         "TestGetTokenAsync",
         "TestDeleteTokenAsync",

--- a/scripts/gha/integration_testing/XcodeCapabilities.cs
+++ b/scripts/gha/integration_testing/XcodeCapabilities.cs
@@ -48,7 +48,7 @@
  * for reference.
  */
 
-#if UNITY_IOS
+#if (UNITY_IOS || UNITY_TVOS)
 using System.Collections;
 using System.Collections.Generic;
 using System.Linq;

--- a/storage/testapp/Assets/Firebase/Sample/Storage/UIHandlerAutomated.cs
+++ b/storage/testapp/Assets/Firebase/Sample/Storage/UIHandlerAutomated.cs
@@ -17,12 +17,12 @@ namespace Firebase.Sample.Storage {
 
     private Firebase.Sample.AutomatedTestRunner testRunner;
 
-#if !(UNITY_IOS || UNITY_ANDROID) || UNITY_EDITOR
+#if !(UNITY_IOS || UNITY_TVOS || UNITY_ANDROID) || UNITY_EDITOR
     // Storage bucket (without the scheme) extracted from MyStorageBucket.
     private string storageBucket;
     // Manually create the default app on desktop so that it's possible to specify the storage bucket.
     private FirebaseApp defaultApp;
-#endif  // !(UNITY_IOS || UNITY_ANDROID) || UNITY_EDITOR
+#endif  // !(UNITY_IOS || UNITY_TVOS || UNITY_ANDROID) || UNITY_EDITOR
 
     // Metadata to upload to the test file.
     private string METADATA_STRING_NON_CUSTOM_ONLY =
@@ -173,22 +173,22 @@ namespace Firebase.Sample.Storage {
 
     // Create the default FirebaseApp on non-mobile platforms.
     private void CreateDefaultApp() {
-#if !(UNITY_IOS || UNITY_ANDROID) || UNITY_EDITOR
+#if !(UNITY_IOS || UNITY_TVOS || UNITY_ANDROID) || UNITY_EDITOR
       defaultApp = FirebaseApp.Create(new AppOptions { StorageBucket = storageBucket });
       Debug.Log(String.Format("Default app created with storage bucket {0}",
                               defaultApp.Options.StorageBucket));
-#endif  // !(UNITY_IOS || UNITY_ANDROID) || UNITY_EDITOR
+#endif  // !(UNITY_IOS || UNITY_TVOS || UNITY_ANDROID) || UNITY_EDITOR
     }
 
     // Remove all reference to the default FirebaseApp.
     private void DestroyDefaultApp() {
-#if !(UNITY_IOS || UNITY_ANDROID) || UNITY_EDITOR
+#if !(UNITY_IOS || UNITY_TVOS || UNITY_ANDROID) || UNITY_EDITOR
       defaultApp = null;
-#endif  // !(UNITY_IOS || UNITY_ANDROID) || UNITY_EDITOR
+#endif  // !(UNITY_IOS || UNITY_TVOS || UNITY_ANDROID) || UNITY_EDITOR
     }
 
     protected override void InitializeFirebase() {
-#if !(UNITY_IOS || UNITY_ANDROID) || UNITY_EDITOR
+#if !(UNITY_IOS || UNITY_TVOS || UNITY_ANDROID) || UNITY_EDITOR
       storageBucket = (new Uri(MyStorageBucket)).Host;
 #endif
       CreateDefaultApp();

--- a/storage/testapp/Assets/Firebase/Sample/Storage/UIHandlerAutomated.cs
+++ b/storage/testapp/Assets/Firebase/Sample/Storage/UIHandlerAutomated.cs
@@ -117,12 +117,18 @@ namespace Firebase.Sample.Storage {
         TestUploadBytesSmallFileThenUpdateMetadata,
         TestUploadStreamLargeFile,
         TestUploadStreamSmallFile,
+#if !(UNITY_TVOS)
+        // Tests which require file access don't work on tvOS.
         TestUploadFromFileLargeFile,
         TestUploadFromFileSmallFile,
+#endif
         TestUploadFromNonExistantFile,
         TestUploadBytesWithCancelation,
         TestUploadStreamWithCancelation,
+#if !(UNITY_TVOS)
+        // Tests which require file access don't work on tvOS.
         TestUploadFromFileWithCancelation,
+#endif
         TestUploadSmallFileGetDownloadUrl,
         TestGetDownloadUrlNonExistantFile,
         TestUploadSmallFileGetMetadata,
@@ -137,9 +143,12 @@ namespace Firebase.Sample.Storage {
         TestUploadSmallFileAndDownloadUsingStreamCallback,
         TestUploadLargeFileAndDownloadUsingStreamCallback,
         TestUploadLargeFileAndDownloadUsingStreamCallbackWithCancelation,
+#if !(UNITY_TVOS)
+        // Tests which require file access don't work on tvOS.
         TestUploadSmallFileAndDownloadToFile,
         TestUploadLargeFileAndDownloadToFile,
         TestUploadLargeFileAndDownloadToFileWithCancelation,
+#endif
       };
 
       testRunner = AutomatedTestRunner.CreateTestRunner(


### PR DESCRIPTION
### Description
> Provide details of the change, and generalize the change in the PR title above.

Fixes to the Storage, Database, Crashlytics and Messaging tests. These testapps has variable behavior based on the target device, and use `UNITY_IOS` or `UNITY_ANDROID` preprocessors to toggle off certain tests. These preprocessor definitions are automatically defined for us by Unity when building for the applicable platforms.

This change adds `UNITY_TVOS` where appropriate and makes it use the same tests & code as `UNITY_IOS`.

Additionally the Storage tests that download to disk have been disabled since tvOS does not have a dependable file system to test against.

Flaky tests that failed in CI were Installations, Messaging, and Functions. When verifying these tests locally on tvOS simulators, both Installations and Functions pass. Messaging has the same error result as our tests iOS on simulators, which I also verifed locally.

***
### Testing
> Describe how you've tested these changes.

[Integration Test CI](https://github.com/firebase/firebase-unity-sdk/actions/runs/3904948152)

***

### Type of Change
Place an `x` the applicable box:
- [ ] Bug fix. Add the issue # below if applicable.
- [ ] New feature. A non-breaking change which adds functionality.
- [X] Other, such as a build process or documentation change.
***

