### PR TITLE
[crashlytics ondemand fatals]fix the fatal logic

### DIFF
--- a/crashlytics/src/AndroidImpl.cs
+++ b/crashlytics/src/AndroidImpl.cs
@@ -20,6 +20,7 @@ namespace Firebase.Crashlytics
   using System;
   using System.Diagnostics;
   using System.Collections.Generic;
+  using System.Linq;
 
   using UnityEngine;
 
@@ -150,6 +151,12 @@ namespace Firebase.Crashlytics
         var currentStackTrace = System.Environment.StackTrace;
         LoggedException loggedExceptionWithCurrentStackTrace = new LoggedException(loggedException.Name, loggedException.Message, currentStackTrace);
         parsedStackTrace = loggedExceptionWithCurrentStackTrace.ParsedStackTrace;
+
+        if (parsedStackTrace.Length > 2) {
+          // remove RecordCustomException and System.Environment.StackTrace frame for fault blame on crashlytics sdk
+          var slicedParsedStackTrace = parsedStackTrace.Skip(2).Take(parsedStackTrace.Length - 2).ToArray();
+          parsedStackTrace = slicedParsedStackTrace;
+        }
       }
   
       StackFrames frames = new StackFrames();

--- a/crashlytics/src/IOSImpl.cs
+++ b/crashlytics/src/IOSImpl.cs
@@ -20,6 +20,7 @@ namespace Firebase.Crashlytics
   using System.Runtime.InteropServices;
   using System.Diagnostics;
   using System.Collections.Generic;
+  using System.Linq;
   using UnityEngine;
 
   
@@ -121,6 +122,12 @@ namespace Firebase.Crashlytics
         var currentStackTrace = System.Environment.StackTrace;
         LoggedException loggedExceptionWithCurrentStackTrace = new LoggedException(loggedException.Name, loggedException.Message, currentStackTrace);
         parsedStackTrace = loggedExceptionWithCurrentStackTrace.ParsedStackTrace;
+
+        if (parsedStackTrace.Length > 2) {
+          // remove RecordCustomException and System.Environment.StackTrace frame for fault blame on crashlytics sdk
+          var slicedParsedStackTrace = parsedStackTrace.Skip(2).Take(parsedStackTrace.Length - 2).ToArray();
+          parsedStackTrace = slicedParsedStackTrace;
+        }
       }
 
       List<Frame> frames = new List<Frame>();

--- a/crashlytics/src/IOSImpl.cs
+++ b/crashlytics/src/IOSImpl.cs
@@ -116,6 +116,13 @@ namespace Firebase.Crashlytics
     private void RecordCustomException(LoggedException loggedException, bool isOnDemand) {
       Dictionary<string, string>[] parsedStackTrace = loggedException.ParsedStackTrace;
 
+      if (isOnDemand && parsedStackTrace.Length == 0) {
+        // if for some reason we don't get stack trace from exception, we add current stack trace in
+        var currentStackTrace = System.Environment.StackTrace;
+        LoggedException loggedExceptionWithCurrentStackTrace = new LoggedException(loggedException.Name, loggedException.Message, currentStackTrace);
+        parsedStackTrace = loggedExceptionWithCurrentStackTrace.ParsedStackTrace;
+      }
+
       List<Frame> frames = new List<Frame>();
       foreach (Dictionary<string, string> frame in parsedStackTrace) {
         frames.Add(new Frame {

--- a/crashlytics/src/cpp/ios/Crashlytics_PrivateHeaders/ExceptionModel_Platform.h
+++ b/crashlytics/src/cpp/ios/Crashlytics_PrivateHeaders/ExceptionModel_Platform.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/crashlytics/src/cpp/ios/Crashlytics_PrivateHeaders/ExceptionModel_Platform.h
+++ b/crashlytics/src/cpp/ios/Crashlytics_PrivateHeaders/ExceptionModel_Platform.h
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2018 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+//
+//  Crashlytics_ExceptionModel.h
+//  Crashlytics
+//
+
+#import <FIRCrashlytics.h>
+
+@interface FIRExceptionModel (Platform)
+
+@property(nonatomic) BOOL isFatal;
+@property(nonatomic) BOOL onDemand;
+
+@end

--- a/crashlytics/src/cpp/ios/CrashlyticsiOSWrapper.m
+++ b/crashlytics/src/cpp/ios/CrashlyticsiOSWrapper.m
@@ -60,8 +60,8 @@ void CLURecordCustomException(const char *name, const char *reason, Frame *frame
 
   if (isOnDemand) {
     // For on demand exception, we log them as fatal
-    model.onDemand = isOnDemand;
-    model.isFatal = fatal;
+    model.onDemand = YES;
+    model.isFatal = YES;
     [[FIRCrashlytics crashlytics] recordOnDemandExceptionModel:model];
     return;
   }

--- a/crashlytics/src/cpp/ios/CrashlyticsiOSWrapper.m
+++ b/crashlytics/src/cpp/ios/CrashlyticsiOSWrapper.m
@@ -21,6 +21,7 @@
 #import "CrashlyticsiOSWrapper.h"
 #import "FirebaseCrashlytics.h"
 #import "./Crashlytics_PrivateHeaders/Crashlytics_Platform.h"
+#import "./Crashlytics_PrivateHeaders/ExceptionModel_Platform.h"
 
 @interface FIRCrashlytics ()
 - (BOOL)isCrashlyticsStarted;
@@ -58,6 +59,9 @@ void CLURecordCustomException(const char *name, const char *reason, Frame *frame
   model.stackTrace = framesArray;
 
   if (isOnDemand) {
+    // For on demand exception, we log them as fatal
+    model.onDemand = isOnDemand;
+    model.isFatal = fatal;
     [[FIRCrashlytics crashlytics] recordOnDemandExceptionModel:model];
     return;
   }


### PR DESCRIPTION
### Description
Fix iOS fatal for on demand
Add current stack trace if there is empty stack trace in exception

***
### Testing
Tested exception with stack trace:
https://screenshot.googleplex.com/43Grf4RVMDd5Fzn

Tested exception without stack trace:
https://screenshot.googleplex.com/BNWeCg59nHA46Lt
***

