### PR TITLE
Fix build_testapp scripts for desktop targets

### DIFF
--- a/scripts/gha/integration_testing/build_testapps.json
+++ b/scripts/gha/integration_testing/build_testapps.json
@@ -6,7 +6,7 @@
       "captial_name": "Analytics",
       "bundle_id": "com.google.firebase.unity.analytics.testapp",
       "testapp_path": "analytics/testapp",
-      "platforms": ["Android", "Playmode", "iOS", "tvOS", "Desktop"],
+      "platforms": ["Android", "Playmode", "iOS", "tvOS", "Windows", "macOS", "Linux"],
       "plugins": [
         "FirebaseAnalytics.unitypackage"
       ],
@@ -23,7 +23,7 @@
       "captial_name": "Auth",
       "bundle_id": "com.google.FirebaseUnityAuthTestApp.dev",
       "testapp_path": "auth/testapp",
-      "platforms": ["Android", "Playmode", "iOS", "tvOS", "Desktop"],
+      "platforms": ["Android", "Playmode", "iOS", "tvOS", "Windows", "macOS", "Linux"],
       "plugins": [
         "FirebaseAuth.unitypackage"
       ],
@@ -41,7 +41,7 @@
       "captial_name": "Crashlytics",
       "bundle_id": "com.google.firebase.unity.crashlytics.testapp",
       "testapp_path": "crashlytics/testapp",
-      "platforms": ["Android", "Playmode", "iOS", "tvOS", "Desktop"],
+      "platforms": ["Android", "Playmode", "iOS", "tvOS", "Windows", "macOS", "Linux"],
       "plugins": [
         "FirebaseCrashlytics.unitypackage"
       ],
@@ -58,7 +58,7 @@
       "captial_name": "Database",
       "bundle_id": "com.google.firebase.unity.database.testapp",
       "testapp_path": "database/testapp",
-      "platforms": ["Android", "Playmode", "iOS", "tvOS", "Desktop"],
+      "platforms": ["Android", "Playmode", "iOS", "tvOS", "Windows", "macOS", "Linux"],
       "plugins": [
         "FirebaseDatabase.unitypackage"
       ],
@@ -76,7 +76,7 @@
       "captial_name": "DynamicLinks",
       "bundle_id": "com.google.FirebaseUnityDynamicLinksTestApp.dev",
       "testapp_path": "dynamic_links/testapp",
-      "platforms": ["Android", "Playmode", "iOS", "Desktop"],
+      "platforms": ["Android", "Playmode", "iOS", "Windows", "macOS", "Linux"],
       "plugins": [
         "FirebaseDynamicLinks.unitypackage"
       ],
@@ -94,7 +94,7 @@
       "captial_name": "Firestore",
       "bundle_id": "com.google.firebase.firestore.unity.testapp",
       "testapp_path": "firestore/testapp",
-      "platforms": ["Android", "Playmode", "iOS", "tvOS", "Desktop"],
+      "platforms": ["Android", "Playmode", "iOS", "tvOS", "Windows", "macOS", "Linux"],
       "plugins": [
         "FirebaseFirestore.unitypackage",
         "FirebaseAuth.unitypackage"
@@ -133,7 +133,7 @@
       "captial_name": "Installations",
       "bundle_id": "com.google.firebase.unity.fis.testapp",
       "testapp_path": "installations/testapp",
-      "platforms": ["Android", "Playmode", "iOS", "tvOS", "Desktop"],
+      "platforms": ["Android", "Playmode", "iOS", "tvOS", "Windows", "macOS", "Linux"],
       "plugins": [
         "FirebaseInstallations.unitypackage"
       ],
@@ -150,7 +150,7 @@
       "captial_name": "Messaging",
       "bundle_id": "com.google.FirebaseUnityMessagingTestApp.dev",
       "testapp_path": "messaging/testapp",
-      "platforms": ["Android", "Playmode", "iOS", "tvOS", "Desktop"],
+      "platforms": ["Android", "Playmode", "iOS", "tvOS", "Windows", "macOS", "Linux"],
       "plugins": [
         "FirebaseMessaging.unitypackage"
       ],
@@ -168,7 +168,7 @@
       "captial_name": "RemoteConfig",
       "bundle_id": "com.google.firebase.unity.remoteconfig.testapp",
       "testapp_path": "remote_config/testapp",
-      "platforms": ["Android", "Playmode", "iOS", "tvOS", "Desktop"],
+      "platforms": ["Android", "Playmode", "iOS", "tvOS", "Windows", "macOS", "Linux"],
       "plugins": [
         "FirebaseRemoteConfig.unitypackage"
       ],
@@ -185,7 +185,7 @@
       "captial_name": "Storage",
       "bundle_id": "com.google.firebase.unity.storage.testapp",
       "testapp_path": "storage/testapp",
-      "platforms": ["Android", "Playmode", "iOS", "tvOS", "Desktop"],
+      "platforms": ["Android", "Playmode", "iOS", "tvOS", "Windows", "macOS", "Linux"],
       "plugins": [
         "FirebaseStorage.unitypackage"
       ],


### PR DESCRIPTION
### Description
> Provide details of the change, and generalize the change in the PR title above.

I introduced a bug in our build system with PR #599 where I added an explicit list of build targets for each SDK's testapp. In this change I errantly listed "Desktop" as a possible target, but really desktop is either "Windows, "Linux", or "macOS".

This PR fixes the issue by expanding Desktop entries to those values.

***
### Testing
[Integration Test CI](https://github.com/firebase/firebase-unity-sdk/actions/runs/3959268929)

***

### Type of Change
Place an `x` the applicable box:
- [ ] Bug fix. Add the issue # below if applicable.
- [ ] New feature. A non-breaking change which adds functionality.
- [X] Other, such as a build process or documentation change.
***

