### PR TITLE
Enable tvOS Nightly

### DIFF
--- a/.github/workflows/build_starter.yml
+++ b/.github/workflows/build_starter.yml
@@ -24,7 +24,7 @@ on:
         required: false
       platforms:
         description: 'Test Platforms of Android,iOS,Windows,macOS,Linux,Playmode'
-        default: 'Android,iOS,Windows,macOS,Linux,Playmode'
+        default: 'Android,iOS,tvOS,Windows,macOS,Linux,Playmode'
         required: true
       apis:
         description: 'CSV of apis to build and test'

--- a/.github/workflows/build_starter.yml
+++ b/.github/workflows/build_starter.yml
@@ -253,7 +253,7 @@ jobs:
 
   trigger_reusable_package:
     name: package ${{ needs.check_and_prepare.outputs.release_label }}
-    needs: [check_and_prepare, build_android, build_ios, build_linux, build_macos, build_windows, decide_build_branch]
+    needs: [check_and_prepare, build_android, build_ios, build_tvos, build_linux, build_macos, build_windows, decide_build_branch]
     uses: ./.github/workflows/package.yml
     if: (needs.check_and_prepare.outputs.should_trigger_package == 'true') && !cancelled() && !failure()
     with:

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -14,7 +14,7 @@ on:
         description: 'Build OS (value: windows-latest, macos-latest. Left empty will use macos-latest for iOS platform, windows-latest for the rest)'
       platforms:
         description: 'CSV of Android,iOS,Windows,macOS,Linux,Playmode'
-        default: 'Android,iOS,Windows,macOS,Linux,Playmode'
+        default: 'Android,iOS,tvOS,Windows,macOS,Linux,Playmode'
         required: true
       apis:
         description: 'CSV of apis to build and test'

--- a/scripts/gha/print_matrix_configuration.py
+++ b/scripts/gha/print_matrix_configuration.py
@@ -59,13 +59,12 @@ WINDOWS_RUNNER = "windows-latest"
 MACOS_RUNNER = "macos-latest"
 LINUX_RUNNER = "ubuntu-latest"
 
-# TODO @drsanta add TVOS to the platforms once the integration tests can be run on tvOS.
 PARAMETERS = {
   "integration_tests": {
     "matrix": {
       "unity_versions": ["2020"],
       "build_os": [""],
-      "platforms": [WINDOWS, MACOS, LINUX, ANDROID, IOS, PLAYMODE],
+      "platforms": [WINDOWS, MACOS, LINUX, ANDROID, IOS, TVOS, PLAYMODE],
       "mobile_devices": ["android_target", "ios_target", "simulator_target", "tvos_simulator"],
       "mobile_test_on": ["real"],
 
@@ -171,8 +170,10 @@ def filter_non_desktop_platform(platform):
 
 
 def filter_build_platforms(platforms):
+  print("FilterBuildPlatforms: " + platforms)
   build_platforms = []
   build_platforms.extend(filter_non_desktop_platform(platforms))
+  print("build_platforms: ", build_platforms)
   # testapps from different desktop platforms are built in one job.
   desktop_platforms = ','.join(list(filter(lambda p: p in platforms, [WINDOWS, MACOS, LINUX])))
   if desktop_platforms:
@@ -205,13 +206,14 @@ def get_testapp_build_matrix(matrix_type, unity_versions, platforms, build_os, i
   #   "os":"macos-latest",
   #   "ios_sdk":"real"
   # }
-
+  print("Matrix type: " + matrix_type)
   if matrix_type: unity_versions = get_value("integration_tests", matrix_type, "unity_versions")
   if matrix_type: platforms = filter_build_platforms(get_value("integration_tests", matrix_type, "platforms"))
   else: platforms = filter_build_platforms(platforms)
   if matrix_type: build_os = get_value("integration_tests", matrix_type, "build_os")
   if matrix_type: ios_sdk = get_value("integration_tests", matrix_type, "mobile_test_on")
 
+  print("Final platforms: ", platforms)
   # generate base matrix: combinations of (unity_versions, platforms, build_os)
   l = list(itertools.product(unity_versions, platforms, build_os))
   if not l: return ""
@@ -233,6 +235,7 @@ def get_testapp_build_matrix(matrix_type, unity_versions, platforms, build_os, i
     else:
       # for Desktop, Android platforms, set value "NA" for ios_sdk setting
       matrix["include"].append({"unity_version": unity_version, "platform": platform, "os": os, "ios_sdk": "NA"})
+  print("final matrix: ", matrix)      
   return matrix
 
 

--- a/scripts/gha/print_matrix_configuration.py
+++ b/scripts/gha/print_matrix_configuration.py
@@ -170,10 +170,8 @@ def filter_non_desktop_platform(platform):
 
 
 def filter_build_platforms(platforms):
-  print("FilterBuildPlatforms: " + platforms)
   build_platforms = []
   build_platforms.extend(filter_non_desktop_platform(platforms))
-  print("build_platforms: ", build_platforms)
   # testapps from different desktop platforms are built in one job.
   desktop_platforms = ','.join(list(filter(lambda p: p in platforms, [WINDOWS, MACOS, LINUX])))
   if desktop_platforms:
@@ -206,14 +204,13 @@ def get_testapp_build_matrix(matrix_type, unity_versions, platforms, build_os, i
   #   "os":"macos-latest",
   #   "ios_sdk":"real"
   # }
-  print("Matrix type: " + matrix_type)
+
   if matrix_type: unity_versions = get_value("integration_tests", matrix_type, "unity_versions")
   if matrix_type: platforms = filter_build_platforms(get_value("integration_tests", matrix_type, "platforms"))
   else: platforms = filter_build_platforms(platforms)
   if matrix_type: build_os = get_value("integration_tests", matrix_type, "build_os")
   if matrix_type: ios_sdk = get_value("integration_tests", matrix_type, "mobile_test_on")
 
-  print("Final platforms: ", platforms)
   # generate base matrix: combinations of (unity_versions, platforms, build_os)
   l = list(itertools.product(unity_versions, platforms, build_os))
   if not l: return ""
@@ -235,7 +232,6 @@ def get_testapp_build_matrix(matrix_type, unity_versions, platforms, build_os, i
     else:
       # for Desktop, Android platforms, set value "NA" for ios_sdk setting
       matrix["include"].append({"unity_version": unity_version, "platform": platform, "os": os, "ios_sdk": "NA"})
-  print("final matrix: ", matrix)      
   return matrix
 
 


### PR DESCRIPTION
### Description
> Provide details of the change, and generalize the change in the PR title above.

Update build system to build tvOS by default.
Change also extends the expanded matrix mode to include tvOS.

***
### Testing
> Describe how you've tested these changes.

[Unity Build](https://github.com/firebase/firebase-unity-sdk/actions/runs/3962594440) -> [Integration Test CI](https://github.com/firebase/firebase-unity-sdk/actions/runs/3968213187)
***

### Type of Change
Place an `x` the applicable box:
- [ ] Bug fix. Add the issue # below if applicable.
- [ ] New feature. A non-breaking change which adds functionality.
- [X] Other, such as a build process or documentation change.
***

