### PR TITLE
Uninstall platforms;android-33-ext4 when building testapps 

### DIFF
--- a/scripts/gha/build_testapps.py
+++ b/scripts/gha/build_testapps.py
@@ -536,10 +536,14 @@ def patch_android_env(unity_version):
     try:
       # This is a bug from Unity: 
       # https://issuetracker.unity3d.com/issues/android-android-build-fails-when-targeting-sdk-31-and-using-build-tools-31-dot-0-0
-      _run([sdkmanager_path, "--uninstall", "build-tools;31.0.0"], check=False)
+      _run([sdkmanager_path, "--uninstall", "build-tools;31.0.0"], check=True)
       logging.info("Uninstall Android build tool 31.0.0")
     except Exception as e:
       logging.info(str(e))
+
+  # check if android 33 is intalled
+  logging.info("Checking for platforms;android-33")
+  _run([sdkmanager_path, "--list_installed"], check=True)
 
   try:
     # The platform android-33 includes libraries that were built with Java 11, and require a newer version of gradle
@@ -547,9 +551,27 @@ def patch_android_env(unity_version):
     # If this continues to be a problem, this logic might need to be smarter, to remove all versions newer than 32,
     # but currently the GitHub runners have 33 as their max.
     logging.info("Uninstall Android platform android-33")
-    _run([sdkmanager_path, "--uninstall", "platforms;android-33"], check=False)
+    _run([sdkmanager_path, "--uninstall", "platforms;android-33"], check=True)
   except Exception as e:
     logging.exception("Failed to uninstall Android platform android-33")
+
+  # after single uninstall, check if android 33 is intalled
+  logging.info("Checking for platforms;android-33")
+  _run([sdkmanager_path, "--list_installed"], check=True)
+
+  try:
+    # The platform android-33 includes libraries that were built with Java 11, and require a newer version of gradle
+    # than Unity comes with. Note this only happens when using minification.
+    # If this continues to be a problem, this logic might need to be smarter, to remove all versions newer than 32,
+    # but currently the GitHub runners have 33 as their max.
+    logging.info("Uninstall Android platform android-33-ext4")
+    _run([sdkmanager_path, "--uninstall", "platforms;android-33-ext4"], check=True)
+  except Exception as e:
+    logging.exception("Failed to uninstall Android platform android-33-ext4")
+  
+  # after uninstalls, check if android 33 is intalled
+  logging.info("Checking for platforms;android-33")
+  _run([sdkmanager_path, "--list_installed"], check=True)
     
   os.environ["UNITY_ANDROID_SDK"]=os.environ["ANDROID_HOME"]
   os.environ["UNITY_ANDROID_NDK"]=os.environ["ANDROID_NDK_HOME"]

--- a/scripts/gha/build_testapps.py
+++ b/scripts/gha/build_testapps.py
@@ -536,14 +536,10 @@ def patch_android_env(unity_version):
     try:
       # This is a bug from Unity: 
       # https://issuetracker.unity3d.com/issues/android-android-build-fails-when-targeting-sdk-31-and-using-build-tools-31-dot-0-0
-      _run([sdkmanager_path, "--uninstall", "build-tools;31.0.0"], check=True)
+      _run([sdkmanager_path, "--uninstall", "build-tools;31.0.0"], check=False)
       logging.info("Uninstall Android build tool 31.0.0")
     except Exception as e:
       logging.info(str(e))
-
-  # check if android 33 is intalled
-  logging.info("Checking for platforms;android-33")
-  _run([sdkmanager_path, "--list_installed"], check=True)
 
   try:
     # The platform android-33 includes libraries that were built with Java 11, and require a newer version of gradle
@@ -551,28 +547,17 @@ def patch_android_env(unity_version):
     # If this continues to be a problem, this logic might need to be smarter, to remove all versions newer than 32,
     # but currently the GitHub runners have 33 as their max.
     logging.info("Uninstall Android platform android-33")
-    _run([sdkmanager_path, "--uninstall", "platforms;android-33"], check=True)
+    _run([sdkmanager_path, "--uninstall", "platforms;android-33", "platforms;android-33-ext4"], check=False)
   except Exception as e:
     logging.exception("Failed to uninstall Android platform android-33")
 
-  # after single uninstall, check if android 33 is intalled
-  logging.info("Checking for platforms;android-33")
-  _run([sdkmanager_path, "--list_installed"], check=True)
-
   try:
-    # The platform android-33 includes libraries that were built with Java 11, and require a newer version of gradle
-    # than Unity comes with. Note this only happens when using minification.
-    # If this continues to be a problem, this logic might need to be smarter, to remove all versions newer than 32,
-    # but currently the GitHub runners have 33 as their max.
-    logging.info("Uninstall Android platform android-33-ext4")
-    _run([sdkmanager_path, "--uninstall", "platforms;android-33-ext4"], check=True)
+    # List the installed packages to make it easier to notice if any incompatible packages are present.
+    logging.info("Listing installed sdks")
+    _run([sdkmanager_path, "--list_installed"], check=False)
   except Exception as e:
-    logging.exception("Failed to uninstall Android platform android-33-ext4")
-  
-  # after uninstalls, check if android 33 is intalled
-  logging.info("Checking for platforms;android-33")
-  _run([sdkmanager_path, "--list_installed"], check=True)
-    
+    logging.info(str(e))
+
   os.environ["UNITY_ANDROID_SDK"]=os.environ["ANDROID_HOME"]
   os.environ["UNITY_ANDROID_NDK"]=os.environ["ANDROID_NDK_HOME"]
   os.environ["UNITY_ANDROID_JDK"]=os.environ["JAVA_HOME"]


### PR DESCRIPTION
### Description
> Provide details of the change, and generalize the change in the PR title above.
Uninstalls both platforms;android-33 and platforms;android-33-ext4 instead of just platforms;android-33

Without this change build_testapps was failing the minify with proguard step for build-2020-windows-latest-Android-NA: [example](https://github.com/firebase/firebase-unity-sdk/actions/runs/3947076744/jobs/6755492933#logs)
***
### Testing
> Describe how you've tested these changes.
***
Ran the build_testapps workflow [without](https://github.com/firebase/firebase-unity-sdk/actions/runs/3961567058/jobs/6787161653) and [with](https://github.com/firebase/firebase-unity-sdk/actions/runs/3961935913/jobs/6787979051) this change.
Added list_installed to the script so that the installed platforms is logged and verified that android-33-ext4 was still installed even after uninstalling android-33
### Type of Change
Place an `x` the applicable box:
- [ ] Bug fix. Add the issue # below if applicable.
- [ ] New feature. A non-breaking change which adds functionality.
- [x] Other, such as a build process or documentation change.
***

