### PR TITLE
Add tvOS to nightly builds

### DIFF
--- a/.github/workflows/build_starter.yml
+++ b/.github/workflows/build_starter.yml
@@ -99,7 +99,7 @@ jobs:
             echo "unity_branch=${{ github.event.inputs.unity_branch }}" >> $GITHUB_OUTPUT
             echo "additional_cmake_flags=${{ github.event.inputs.unity_branch }}" >> $GITHUB_OUTPUT
           else
-            echo "platform='Android,iOS,Windows,macOS,Linux,Playmode'" >> $GITHUB_OUTPUT
+            echo "platform='Android,iOS,tvOS,Windows,macOS,Linux,Playmode'" >> $GITHUB_OUTPUT
             echo "release_label=nightly-$(date "+%Y%m%d-%H%M%S")" >> $GITHUB_OUTPUT
             echo "release_version=NoVersion" >> $GITHUB_OUTPUT
             echo "apis='analytics,auth,crashlytics,database,dynamic_links,firestore,functions,installations,messaging,remote_config,storage'" >> $GITHUB_OUTPUT


### PR DESCRIPTION
### Description
> Provide details of the change, and generalize the change in the PR title above.

I checked the builds this weekend and notice that the scheduled jobs skipped tvOS. I think I found the reason why.

***
### Testing
> Describe how you've tested these changes.

[Ran Unity Build Starter](https://github.com/firebase/firebase-unity-sdk/actions/runs/3986872295) to ensure .yml syntax is correct.

***

### Type of Change
Place an `x` the applicable box:
- [ ] Bug fix. Add the issue # below if applicable.
- [ ] New feature. A non-breaking change which adds functionality.
- [X] Other, such as a build process or documentation change.
***

