### PR TITLE
Add retry to the Storage testapp

### DIFF
--- a/storage/testapp/Assets/Firebase/Sample/Storage/UIHandlerAutomated.cs
+++ b/storage/testapp/Assets/Firebase/Sample/Storage/UIHandlerAutomated.cs
@@ -144,7 +144,8 @@ namespace Firebase.Sample.Storage {
 
       testRunner = AutomatedTestRunner.CreateTestRunner(
         testsToRun: tests,
-        logFunc: DebugLog
+        logFunc: DebugLog,
+        maxAttempts: 3
       );
 
       mainThreadDispatcher = gameObject.AddComponent<MainThreadDispatcher>();


### PR DESCRIPTION
### Description
> Provide details of the change, and generalize the change in the PR title above.

The Storage testapp is a bit flakey due to the amount of uploads and downloads it does. Add the new generic retry logic, so that it will retry tests that fail a few times.
***
### Testing
> Describe how you've tested these changes.

https://github.com/firebase/firebase-unity-sdk/actions/runs/4028762567
***

### Type of Change
Place an `x` the applicable box:
- [ ] Bug fix. Add the issue # below if applicable.
- [ ] New feature. A non-breaking change which adds functionality.
- [x] Other, such as a build process or documentation change.
***

