### PR TITLE
Mark LogExceptionAsFatal as internal.

### DIFF
--- a/crashlytics/src/Crashlytics.cs
+++ b/crashlytics/src/Crashlytics.cs
@@ -122,7 +122,7 @@ namespace Firebase.Crashlytics {
     /// <param name="exception">
     /// The exception to log as fatal.
     /// </param>
-    public static void LogExceptionAsFatal(Exception exception) {
+    internal static void LogExceptionAsFatal(Exception exception) {
       PlatformAccessor.Impl.LogExceptionAsFatal(exception);
     }
 


### PR DESCRIPTION
Mark LogExceptionAsFatal as internal.

This method is not intended for developers to call directly. https://firebase.google.com/docs/crashlytics/customize-crash-reports?platform=unity#log-excepts