### PR TITLE
Fix LogHeartbeatInternal

### DIFF
--- a/app/src/swig/app.i
+++ b/app/src/swig/app.i
@@ -158,6 +158,15 @@ static App *AppGetOrCreateInstance(const AppOptions *options,
   return instance;
 }
 
+// Log a heartbeat only if the current platform is desktop platforms.
+static void LogHeartbeatForDesktop(App* app) {
+#if FIREBASE_PLATFORM_DESKTOP
+    // Only need to call LogHeartbeat on desktop, since native mobile SDKs
+    // Will handle heartbeat logging internally.
+    app->LogHeartbeat();
+#endif  // FIREBASE_PLATFORM_DESKTOP
+}
+
 // Decrease the reference count for the app. When the reference count reaches
 // 0, the App will be deleted.
 static void AppReleaseReference(App* app) {
@@ -862,11 +871,11 @@ static firebase::AppOptions* AppOptionsLoadFromJsonConfig(const char* config) {
         }
         // TODO(smiles): Improve error code passing from C++ to C# so that
         // we don't need to parse magic strings from the error message.
-        
+
         if (errorMessage.IndexOf("Please verify the AAR") >= 0) {
           errorMessage += "\n" + Firebase.ErrorMessages.DependencyNotFoundErrorMessage;
         }
-        
+
         //         util_android.cc)
         throw new Firebase.InitializationException(initResult, errorMessage);
       } catch (System.Exception exception) {
@@ -1318,11 +1327,7 @@ namespace callback {
 
  %csmethodmodifiers LogHeartbeatInternal(App* app) "internal";
   static void LogHeartbeatInternal(App* app) {
-#if FIREBASE_PLATFORM_DESKTOP
-    // Only need to call LogHeartbeat on desktop, since native mobile SDKs
-    // Will handle heartbeat logging internally.
-    app->LogHeartbeat();
-#endif  // FIREBASE_PLATFORM_DESKTOP
+    firebase::LogHeartbeatForDesktop(app);
   }
 
   %csmethodmodifiers AppSetDefaultConfigPath(const char* path) "internal";


### PR DESCRIPTION

### Description
> Provide details of the change, and generalize the change in the PR title above.

When Swig generating "%csmethodmodifiers" code block, instead of keeping all preprocesser directives like "#if FIREBASE_PLATFORM_DESKTOP", it seem to preprocess the block directly and remove codes.

In this case, Swig would consider FIREBASE_PLATFORM_DESKTOP never defined and remove the entire block in the generated code, regardless the current build target platform.

The fix is to move the preprocesser directives to a separate C++ function.

***
### Testing
> Describe how you've tested these changes.


This can be easily verified with
```
python scripts/build_scripts/build_zips.py --platform=macos --apis=auth
```

***

### Type of Change
Place an `x` the applicable box:
- [x] Bug fix. Add the issue # below if applicable.
- [ ] New feature. A non-breaking change which adds functionality.
- [ ] Other, such as a build process or documentation change.
***

