### PR TITLE
fix for build windows

### DIFF
--- a/cmake/unity_mono.cmake
+++ b/cmake/unity_mono.cmake
@@ -275,6 +275,7 @@ macro(mono_add_internal name output_type)
   set(VAR_DEFINES "TRACE")
   set(VAR_OUTPUT_TYPE ${output_type})
 
+  string(APPEND VAR_REFERENCE "    <Reference Include=\"netstandard\" />\n")
   string(APPEND VAR_REFERENCE "    <Reference Include=\"System\" />\n")
   string(APPEND VAR_REFERENCE "    <Reference Include=\"System.Core\" />\n")
 

--- a/scripts/build_scripts/build_zips.py
+++ b/scripts/build_scripts/build_zips.py
@@ -771,6 +771,8 @@ def main(argv):
 
   if FLAGS.use_boringssl:
     cmake_setup_args.append("-DFIREBASE_USE_BORINGSSL=ON")
+  else:
+    cmake_setup_args.append("-DFIREBASE_USE_BORINGSSL=OFF")
 
   if is_ios_build():
     cmake_setup_args.extend(get_ios_args(source_path))


### PR DESCRIPTION
### Description
> Provide details of the change, and generalize the change in the PR title above.

- Explicitly disable boringssl to use openssl 
- Add netstandard reference to make build success
- Fix the call to `firebase::App::RegisterLibrary` which only have 2 parameter for windows platform

More details in https://github.com/firebase/firebase-unity-sdk/issues/557

***
### Testing
> Describe how you've tested these changes.

Run `python ./scripts/build_scripts/build_zips.py --use_boringssl=false --platform=windows` and got zip and dll files result properly without error

***

### Type of Change
Place an `x` the applicable box:
- [ x ] Bug fix. Add the issue # below if applicable.
- [ ] New feature. A non-breaking change which adds functionality.
- [ x ] Other, such as a build process or documentation change.
***

ps This is cmakesettings.json I need to explicitly configure in my machine

```json
{
  "configurations": [
    {
      "name": "x64-Debug",
      "generator": "Ninja",
      "configurationType": "Debug",
      "inheritEnvironments": [ "msvc_x64_x64" ],
      "buildRoot": "${projectDir}\\out\\windows_unity\\${name}",
      "installRoot": "${projectDir}\\out\\install\\${name}",
      "cmakeCommandArgs": "",
      "buildCommandArgs": "",
      "ctestCommandArgs": "",
      "variables": [
        {
          "name": "UNITY_ROOT_DIR",
          "value": "C:/Program Files/Unity/Hub/Editor/2022.2.9f1/",
          "type": "STRING"
        },
        {
          "name": "MONO_EXE",
          "value": "C:/Program Files/Unity/Hub/Editor/2022.2.9f1/Editor/Data/MonoBleedingEdge/bin/mono.exe",
          "type": "STRING"
        },
        {
          "name": "MONO_CSHARP_BUILD_EXE",
          "value": "C:/Program Files (x86)/Microsoft Visual Studio/2019/BuildTools/MSBuild/Current/Bin/MSBuild.exe",
          "type": "STRING"
        },
        {
          "name": "UNITY_MONO_EXE",
          "value": "C:/Program Files/Unity/Hub/Editor/2022.2.9f1/Editor/Data/MonoBleedingEdge/bin/mono.exe",
          "type": "STRING"
        },
        {
          "name": "UNITY_CSHARP_BUILD_EXE",
          "value": "C:/Program Files/Unity/Hub/Editor/2022.2.9f1/Editor/Data/MonoBleedingEdge/bin/xbuild.bat",
          "type": "STRING"
        },
        {
          "name": "ZLIB_INCLUDE_DIR",
          "value": "C:/Program Files (x86)/GnuWin32/include/",
          "type": "STRING"
        },
        {
          "name": "ZLIB_LIBRARY",
          "value": "C:/Program Files (x86)/GnuWin32/lib/zlib.lib",
          "type": "STRING"
        }
      ]
    }
  ]
}
```