### PR TITLE
Disable Session Id test on Android

### DIFF
--- a/analytics/testapp/Assets/Firebase/Sample/Analytics/UIHandlerAutomated.cs
+++ b/analytics/testapp/Assets/Firebase/Sample/Analytics/UIHandlerAutomated.cs
@@ -196,6 +196,12 @@ namespace Firebase.Sample.Analytics {
     }
 
     Task TestGetSessionId() {
+      // Session ID has problems when running on the Android test infrastructure,
+      // as it depends on play services, which is not guaranteed to be updated.
+      if (Application.platform == RuntimePlatform.Android) {
+        return Task.CompletedTask;
+      }
+
       // Depending on platform, GetSessionId needs a few seconds for Analytics
       // to initialize (especially on iOS simulator). Pause for 5 seconds before
       // running this test.

--- a/analytics/testapp/Assets/Firebase/Sample/Analytics/UIHandlerAutomated.cs
+++ b/analytics/testapp/Assets/Firebase/Sample/Analytics/UIHandlerAutomated.cs
@@ -198,6 +198,8 @@ namespace Firebase.Sample.Analytics {
     Task TestGetSessionId() {
       // Session ID has problems when running on the Android test infrastructure,
       // as it depends on play services, which is not guaranteed to be updated.
+      // There is better logic to check this in the C++ tests, which we will just
+      // rely on to test the general logic.
       if (Application.platform == RuntimePlatform.Android) {
         return Task.CompletedTask;
       }

--- a/analytics/testapp/Assets/Firebase/Sample/Analytics/UIHandlerAutomated.cs
+++ b/analytics/testapp/Assets/Firebase/Sample/Analytics/UIHandlerAutomated.cs
@@ -31,7 +31,7 @@ namespace Firebase.Sample.Analytics {
         TestAnalyticsGroupJoinDoesNotThrow,
         TestAnalyticsLevelUpDoesNotThrow,
         TestGetSessionId,
-	TestAnalyticsSetConsentDoesNotThrow,
+        TestAnalyticsSetConsentDoesNotThrow,
         TestInstanceIdChangeAfterReset,
         TestResetAnalyticsData,
         // Temporarily disabled until this test is deflaked. b/143603151
@@ -201,28 +201,28 @@ namespace Firebase.Sample.Analytics {
       // running this test.
       var tcs = new TaskCompletionSource<bool>();
       Task.Delay(TimeSpan.FromSeconds(5)).ContinueWithOnMainThread(task_ => {
-	  base.DisplaySessionId().ContinueWithOnMainThread(task => {
-	      if (task.IsCanceled) {			      	 
-		      tcs.TrySetException(new Exception("Unexpectedly canceled"));
-	      } else if (task.IsFaulted) {
-          // Session ID has problems when running on the Android test infrastructure,
-          // as it depends on play services, which is not guaranteed to be updated.
-          // There is better logic to check this in the C++ tests, which we will just
-          // rely on to test the general logic.
-          if (Application.platform == RuntimePlatform.Android) {
-            DebugLog("GetSessionId got an exception, but that might be expected on Android");
-            DebugLog("Exception: " + task.Exception);
+        base.DisplaySessionId().ContinueWithOnMainThread(task => {
+          if (task.IsCanceled) {
+            tcs.TrySetException(new Exception("Unexpectedly canceled"));
+          } else if (task.IsFaulted) {
+            // Session ID has problems when running on the Android test infrastructure,
+            // as it depends on play services, which is not guaranteed to be updated.
+            // There is better logic to check this in the C++ tests, which we will just
+            // rely on to test the general logic.
+            if (Application.platform == RuntimePlatform.Android) {
+              DebugLog("GetSessionId got an exception, but that might be expected on Android");
+              DebugLog("Exception: " + task.Exception);
+              tcs.TrySetResult(true);
+              return;
+            }
+            tcs.TrySetException(task.Exception);
+          } else if (task.Result == 0) {
+            tcs.TrySetException(new Exception("Zero ID returned"));
+          } else {
             tcs.TrySetResult(true);
-            return;
           }
-          tcs.TrySetException(task.Exception);
-	      } else if (task.Result == 0) {
-		      tcs.TrySetException(new Exception("Zero ID returned"));
-	      } else {
-		      tcs.TrySetResult(true);
-	      }
-	    });
-	});
+        });
+      });
       return tcs.Task;
     }
 


### PR DESCRIPTION
### Description
> Provide details of the change, and generalize the change in the PR title above.

The session id test on Android can randomly fail due to the test infrastructure having potentially old versions of Play Services.  Disable the test on Android, and just rely on the combination of the C++ tests, and the other platforms to guarantee that it is calling into the C++ layer correctly.
***
### Testing
> Describe how you've tested these changes.

https://github.com/firebase/firebase-unity-sdk/actions/runs/4379166466
***

### Type of Change
Place an `x` the applicable box:
- [x] Bug fix. Add the issue # below if applicable.
- [ ] New feature. A non-breaking change which adds functionality.
- [ ] Other, such as a build process or documentation change.
***

