### PR TITLE
Add automatic retry to the Firestore tests

### DIFF
--- a/firestore/testapp/Assets/Firebase/Sample/Firestore/UIHandlerAutomated.cs
+++ b/firestore/testapp/Assets/Firebase/Sample/Firestore/UIHandlerAutomated.cs
@@ -177,7 +177,8 @@ namespace Firebase.Sample.Firestore {
 
       testRunner = AutomatedTestRunner.CreateTestRunner(
         testsToRun: testFilter.Length > 0 ? testFilter : tests,
-        logFunc: LogInBatches
+        logFunc: LogInBatches,
+        maxAttempts: 3
       );
 
       Debug.Log("NOTE: Some API calls report failures using UnityEngine.Debug.LogError which will " +


### PR DESCRIPTION
### Description
> Provide details of the change, and generalize the change in the PR title above.

Add a default retry to the Firestore tests, so that if a test fails, it will retry up to 3 times. Note that the logs will reflect when a test retries, with a warning.
***
### Testing
> Describe how you've tested these changes.

https://github.com/firebase/firebase-unity-sdk/actions/runs/4380372493
***

### Type of Change
Place an `x` the applicable box:
- [ ] Bug fix. Add the issue # below if applicable.
- [ ] New feature. A non-breaking change which adds functionality.
- [x] Other, such as a build process or documentation change.
***

