### PR TITLE
Uninstall platforms;android-33-ext5 when building testapps

### DIFF
--- a/scripts/gha/build_testapps.py
+++ b/scripts/gha/build_testapps.py
@@ -547,7 +547,8 @@ def patch_android_env(unity_version):
     # If this continues to be a problem, this logic might need to be smarter, to remove all versions newer than 32,
     # but currently the GitHub runners have 33 as their max.
     logging.info("Uninstall Android platform android-33")
-    _run([sdkmanager_path, "--uninstall", "platforms;android-33", "platforms;android-33-ext4"], check=False)
+    _run([sdkmanager_path, "--uninstall",
+          "platforms;android-33", "platforms;android-33-ext4", "platforms;android-33-ext5"], check=False)
   except Exception as e:
     logging.exception("Failed to uninstall Android platform android-33")
 


### PR DESCRIPTION
### Description
This is effectively the same as #604, but for another extension of android 33.
Without this change build_testapps fails the minify with proguard step for build-2020-windows-latest-Android-NA: example: https://github.com/firebase/firebase-unity-sdk/actions/runs/4559389559/jobs/8043295718

### Testing
This is the same fix as for a previous version of the same issue.
***

### Type of Change
Place an `x` the applicable box:
- [ ] Bug fix. Add the issue # below if applicable.
- [ ] New feature. A non-breaking change which adds functionality.
- [x] Other, such as a build process or documentation change.
***

