### PR TITLE
Initial change for Auth Google/IO changes to just fix the compiler error

### DIFF
--- a/auth/src/PhoneAuthProvider.cs
+++ b/auth/src/PhoneAuthProvider.cs
@@ -59,19 +59,6 @@ namespace Firebase.Auth {
 ///       send an SMS. Credential is automatically created and passed to
 ///       the app via @ref VerificationCompleted.
 public sealed class PhoneAuthProvider : global::System.IDisposable {
-  /// Maximum value of `autoVerifyTimeOutMs` in @ref VerifyPhoneNumber.
-  /// @ref VerifyPhoneNumber will automatically clamp values to this amount.
-  ///
-  /// @deprecated This value is no longer used to clamp
-  /// `autoVerifyTimeOutMs` in @ref VerifyPhoneNumber. The range is
-  /// determined by the underlying SDK, ex. <a href="/docs/reference/android/com/google/firebase/auth/PhoneAuthOptions.Builder"><code>PhoneAuthOptions.Build</code> in Android SDK</a>
-  [System.Obsolete("PhoneAuthProvider.MaxTimeoutMs is deprecated. This value no longer affects PhoneAuthProvider.VerifyPhoneNumber()")]
-  public static uint MaxTimeoutMs {
-    get {
-      return PhoneAuthProviderInternal.kMaxTimeoutMs;
-    }
-  }
-
   /// Callback used when phone number auto-verification succeeded.
   public delegate void VerificationCompleted(Credential credential);
   /// Callback used when phone number verification fails.

--- a/auth/src/swig/auth.i
+++ b/auth/src/swig/auth.i
@@ -483,8 +483,8 @@ static CppInstanceManager<Auth> g_auth_instances;
   /// platforms. On other platforms this method will return a Future with a
   /// preset error code: kAuthErrorUnimplemented.
   ///
-  /// @deprecated This function is deprecated in favor of `Task<AuthResult>`
-  /// return type. Please use
+  /// @deprecated This method is deprecated in favor of methods that return
+  /// `Task<AuthResult>`. Please use
   /// `Task<AuthResult> SignInWithProviderAsync(FederatedAuthProvider)` instead.
   [System.ObsoleteAttribute("Please use `Task<AuthResult> SignInWithProviderAsync(FederatedAuthProvider)` instead", false)]
   public System.Threading.Tasks.Task<SignInResult> SignInWithProviderAsync_DEPRECATED(
@@ -812,8 +812,8 @@ static CppInstanceManager<Auth> g_auth_instances;
   /// An error is returned, if the token is invalid, expired or otherwise
   /// not accepted by the server.
   ///
-  /// @deprecated This function is deprecated in favor of `Task<AuthResult>`
-  /// return type. Please use
+  /// @deprecated This method is deprecated in favor of methods that return
+  /// `Task<AuthResult>`. Please use
   /// `Task<AuthResult> SignInWithCustomTokenAsync(string)` instead.
   [System.ObsoleteAttribute("Please use `Task<AuthResult> SignInWithCustomTokenAsync(string)` instead", false)]
   public System.Threading.Tasks.Task<FirebaseUser> SignInWithCustomTokenAsync_DEPRECATED(
@@ -832,8 +832,8 @@ static CppInstanceManager<Auth> g_auth_instances;
   /// An error is returned, if the token is invalid, expired or otherwise not
   /// accepted by the server.
   ///
-  /// @deprecated This function is deprecated in favor of `Task<AuthResult>`
-  /// return type. Please use
+  /// @deprecated This method is deprecated in favor of methods that return
+  /// `Task<AuthResult>`. Please use
   /// `Task<AuthResult> SignInWithCredentialAsync(Credential)` instead.
   [System.ObsoleteAttribute("Please use `Task<AuthResult> SignInWithCredentialAsync(Credential)` instead", false)]
   public System.Threading.Tasks.Task<FirebaseUser> SignInWithCredentialAsync_DEPRECATED(
@@ -859,8 +859,8 @@ static CppInstanceManager<Auth> g_auth_instances;
   /// An error is returned if the token is invalid, expired, or otherwise not
   /// accepted by the server.
   ///
-  /// @deprecated This function is deprecated in favor of `Task<AuthResult>`
-  /// return type. Please use
+  /// @deprecated This method is deprecated in favor of methods that return
+  /// `Task<AuthResult>`. Please use
   /// `Task<AuthResult> SignInAndRetrieveDataWithCredentialAsync(Credential)`
   /// instead.
   [System.ObsoleteAttribute("Please use `Task<AuthResult> SignInAndRetrieveDataWithCredentialAsync(Credential)` instead", false)]
@@ -896,8 +896,8 @@ static CppInstanceManager<Auth> g_auth_instances;
   ///  }
   /// @endcode
   ///
-  /// @deprecated This function is deprecated in favor of `Task<AuthResult>`
-  /// return type. Please use
+  /// @deprecated This method is deprecated in favor of methods that return
+  /// `Task<AuthResult>`. Please use
   /// `Task<AuthResult> SignInAnonymouslyAsync()` instead.
   [System.ObsoleteAttribute("Please use `Task<AuthResult> SignInAnonymouslyAsync()` instead", false)]
   public System.Threading.Tasks.Task<FirebaseUser> SignInAnonymouslyAsync_DEPRECATED() {
@@ -914,8 +914,8 @@ static CppInstanceManager<Auth> g_auth_instances;
   /// An error is returned if the password is wrong or otherwise not accepted
   /// by the server.
   ///
-  /// @deprecated This function is deprecated in favor of `Task<AuthResult>`
-  /// return type. Please use `Task<AuthResult> SignInAnonymouslyAsync()`
+  /// @deprecated This method is deprecated in favor of methods that return
+  /// `Task<AuthResult>`. Please use `Task<AuthResult> SignInAnonymouslyAsync()`
   /// instead.
   [System.ObsoleteAttribute("Please use `Task<AuthResult> SignInWithEmailAndPasswordAsync(string, string)` instead", false)]
   public System.Threading.Tasks.Task<FirebaseUser> SignInWithEmailAndPasswordAsync_DEPRECATED(
@@ -936,8 +936,8 @@ static CppInstanceManager<Auth> g_auth_instances;
   /// An error is returned when account creation is unsuccessful
   /// (due to another existing account, invalid password, etc.).
   ///
-  /// @deprecated This function is deprecated in favor of `Task<AuthResult>`
-  /// return type. Please use
+  /// @deprecated This method is deprecated in favor of methods that return
+  /// `Task<AuthResult>`. Please use
   /// `Task<AuthResult> CreateUserWithEmailAndPasswordAsync(string, string)`
   /// instead.
   [System.ObsoleteAttribute("Please use `Task<AuthResult> CreateUserWithEmailAndPasswordAsync(string, string)` instead", false)]
@@ -1135,8 +1135,8 @@ static CppInstanceManager<Auth> g_auth_instances;
   /// platforms. On other platforms this method will return a Future with a
   /// preset error code: kAuthErrorUnimplemented.
   ///
-  /// @deprecated This function is deprecated in favor of `Task<AuthResult>`
-  /// return type. Please use
+  /// @deprecated This method is deprecated in favor of methods that return
+  /// `Task<AuthResult>`. Please use
   /// `Task<AuthResult> ReauthenticateWithProviderAsync(FederatedAuthProvider)`
   /// instead.
   [System.ObsoleteAttribute("Please use `Task<AuthResult> ReauthenticateWithProviderAsync(FederatedAuthProvider)` instead", false)]
@@ -1164,8 +1164,8 @@ static CppInstanceManager<Auth> g_auth_instances;
   /// platforms. On other platforms this method will return a Future with a
   /// preset error code: kAuthErrorUnimplemented.
   ///
-  /// @deprecated This function is deprecated in favor of `Task<AuthResult>`
-  /// return type. Please use
+  /// @deprecated This method is deprecated in favor of methods that return
+  /// `Task<AuthResult>`. Please use
   /// `Task<AuthResult> LinkWithProviderAsync(FederatedAuthProvider)`
   /// instead.
   [System.ObsoleteAttribute("Please use `Task<AuthResult> LinkWithProviderAsync(FederatedAuthProvider)` instead", false)]
@@ -1375,8 +1375,8 @@ class PhoneAuthListenerImpl
   virtual void OnVerificationCompleted(Credential credential) {
     // Both `OnVerificationCompleted(Credential) and
     // OnVerificationCompleted(PhoneAuthCredential) will be triggered. We
-    // should support both delegates but the user needs to choose to use
-    // only one of them.
+    // support both delegates but the user needs to choose to use only one of
+    // them.
     if (g_verification_completed_callback) {
       firebase::callback::AddCallback(
           new firebase::callback::CallbackValue2<int, Credential>(
@@ -1387,8 +1387,8 @@ class PhoneAuthListenerImpl
   virtual void OnVerificationCompleted(PhoneAuthCredential credential) {
     // Both `OnVerificationCompleted(Credential) and
     // OnVerificationCompleted(PhoneAuthCredential) will be triggered. We
-    // should support both delegates but the user needs to choose to use
-    // only one of them.
+    // support both delegates but the user needs to choose to use only one of
+    // them.
 
     // TODO(IO2023): Add hooks to new PhoneAuthCredential. Need new delegates.
   }

--- a/auth/src/swig/auth.i
+++ b/auth/src/swig/auth.i
@@ -288,14 +288,14 @@ static CppInstanceManager<Auth> g_auth_instances;
     std::vector< std::string > * "StringList";
 
 // Don't expose UserInfoInterfaceList externally.
-%typemap(csclassmodifiers) std::vector<firebase::auth::UserInfoInterface*> "internal class"
-%template(UserInfoInterfaceList) std::vector<firebase::auth::UserInfoInterface*>;
+%typemap(csclassmodifiers) std::vector<firebase::auth::UserInfoInterface> "internal class"
+%template(UserInfoInterfaceList) std::vector<firebase::auth::UserInfoInterface>;
 // All outputs of UserInfoInterfaceList should be IEnumerable<IUserInfo>
 %typemap(cstype,
          out="global::System.Collections.Generic.IEnumerable<IUserInfo>")
-  std::vector<firebase::auth::UserInfoInterface*>&
+  std::vector<firebase::auth::UserInfoInterface>*
   "UserInfoInterfaceList";
-%typemap(csvarout) std::vector<firebase::auth::UserInfoInterface*>& %{
+%typemap(csvarout) std::vector<firebase::auth::UserInfoInterface>* %{
   get {
     // Convert the UserInfoInterfaceList into a List<IUserInfo>, as we don't
     // expose UserInfoInterface, which inherites from the public IUserInfo.
@@ -308,6 +308,13 @@ static CppInstanceManager<Auth> g_auth_instances;
     return newList;
   }
 %}
+
+%typemap(csclassmodifiers) firebase::auth::PhoneAuthOptions "public sealed class";
+%rename(ForceResendingToken) firebase::auth::PhoneAuthOptions::force_resending_token;
+%rename(PhoneNumber) firebase::auth::PhoneAuthOptions::phone_number;
+%rename(TimeoutInMilliseconds) firebase::auth::PhoneAuthOptions::timeout_milliseconds;
+// Ignore UIParent for now. Always use default Activity/UIView
+%ignore firebase::auth::PhoneAuthOptions::ui_parent;
 
 %SWIG_FUTURE(Future_User, FirebaseUser, internal, firebase::auth::User *,
              FirebaseException)
@@ -406,21 +413,20 @@ static CppInstanceManager<Auth> g_auth_instances;
 
 // The following methods need to be overridden to return a customized proxy to
 // each C++ object.
-%rename(SignInWithCustomTokenInternal)
-  firebase::auth::Auth::SignInWithCustomToken;
-%rename(SignInWithCredentialInternal)
-  firebase::auth::Auth::SignInWithCredential;
-%rename(SignInAndRetrieveDataWithCredentialInternal)
-  firebase::auth::Auth::SignInAndRetrieveDataWithCredential;
-%rename(SignInAnonymouslyInternal)
-  firebase::auth::Auth::SignInAnonymously;
-%rename(SignInWithEmailAndPasswordInternal)
-  firebase::auth::Auth::SignInWithEmailAndPassword;
-%rename(CreateUserWithEmailAndPasswordInternal)
-  firebase::auth::Auth::CreateUserWithEmailAndPassword;
-
-%rename(SignInWithProviderInternal)
-  firebase::auth::Auth::SignInWithProvider;
+%rename(SignInWithCustomTokenInternalAsync_DEPRECATED)
+  firebase::auth::Auth::SignInWithCustomToken_DEPRECATED;
+%rename(SignInWithCredentialInternalAsync_DEPRECATED)
+  firebase::auth::Auth::SignInWithCredential_DEPRECATED;
+%rename(SignInAndRetrieveDataWithCredentialInternalAsync_DEPRECATED)
+  firebase::auth::Auth::SignInAndRetrieveDataWithCredential_DEPRECATED;
+%rename(SignInAnonymouslyInternalAsync_DEPRECATED)
+  firebase::auth::Auth::SignInAnonymously_DEPRECATED;
+%rename(SignInWithEmailAndPasswordInternalAsync_DEPRECATED)
+  firebase::auth::Auth::SignInWithEmailAndPassword_DEPRECATED;
+%rename(CreateUserWithEmailAndPasswordInternalAsync_DEPRECATED)
+  firebase::auth::Auth::CreateUserWithEmailAndPassword_DEPRECATED;
+%rename(SignInWithProviderInternalAsync_DEPRECATED)
+  firebase::auth::Auth::SignInWithProvider_DEPRECATED;
 
 %extend firebase::auth::Auth {
   // Get a C++ instance and increment the reference count to it
@@ -476,12 +482,17 @@ static CppInstanceManager<Auth> g_auth_instances;
   /// @note: This operation is supported only on iOS, tvOS and Android
   /// platforms. On other platforms this method will return a Future with a
   /// preset error code: kAuthErrorUnimplemented.
-  public System.Threading.Tasks.Task<SignInResult> SignInWithProviderAsync(
+  ///
+  /// @deprecated This function is deprecated in favor of `Task<AuthResult>`
+  /// return type. Please use
+  /// `Task<AuthResult> SignInWithProviderAsync(FederatedAuthProvider)` instead.
+  [System.ObsoleteAttribute("Please use `Task<AuthResult> SignInWithProviderAsync(FederatedAuthProvider)` instead", false)]
+  public System.Threading.Tasks.Task<SignInResult> SignInWithProviderAsync_DEPRECATED(
       FederatedAuthProvider provider) {
     ThrowIfNull();
     var taskCompletionSource =
         new System.Threading.Tasks.TaskCompletionSource<SignInResult>();
-    SignInWithProviderInternalAsync(provider).ContinueWith(task => {
+    SignInWithProviderInternalAsync_DEPRECATED(provider).ContinueWith(task => {
         CompleteSignInResultTask(task, taskCompletionSource);
       });
     return taskCompletionSource.Task;
@@ -800,12 +811,17 @@ static CppInstanceManager<Auth> g_auth_instances;
   ///
   /// An error is returned, if the token is invalid, expired or otherwise
   /// not accepted by the server.
-  public System.Threading.Tasks.Task<FirebaseUser> SignInWithCustomTokenAsync(
+  ///
+  /// @deprecated This function is deprecated in favor of `Task<AuthResult>`
+  /// return type. Please use
+  /// `Task<AuthResult> SignInWithCustomTokenAsync(string)` instead.
+  [System.ObsoleteAttribute("Please use `Task<AuthResult> SignInWithCustomTokenAsync(string)` instead", false)]
+  public System.Threading.Tasks.Task<FirebaseUser> SignInWithCustomTokenAsync_DEPRECATED(
       string token) {
     ThrowIfNull();
     var taskCompletionSource =
         new System.Threading.Tasks.TaskCompletionSource<FirebaseUser>();
-    SignInWithCustomTokenInternalAsync(token).ContinueWith(task => {
+    SignInWithCustomTokenInternalAsync_DEPRECATED(token).ContinueWith(task => {
         CompleteFirebaseUserTask(task, taskCompletionSource);
       });
     return taskCompletionSource.Task;
@@ -815,12 +831,17 @@ static CppInstanceManager<Auth> g_auth_instances;
   ///
   /// An error is returned, if the token is invalid, expired or otherwise not
   /// accepted by the server.
-  public System.Threading.Tasks.Task<FirebaseUser> SignInWithCredentialAsync(
+  ///
+  /// @deprecated This function is deprecated in favor of `Task<AuthResult>`
+  /// return type. Please use
+  /// `Task<AuthResult> SignInWithCredentialAsync(Credential)` instead.
+  [System.ObsoleteAttribute("Please use `Task<AuthResult> SignInWithCredentialAsync(Credential)` instead", false)]
+  public System.Threading.Tasks.Task<FirebaseUser> SignInWithCredentialAsync_DEPRECATED(
       Credential credential) {
     ThrowIfNull();
     var taskCompletionSource =
         new System.Threading.Tasks.TaskCompletionSource<FirebaseUser>();
-    SignInWithCredentialInternalAsync(credential).ContinueWith(task => {
+    SignInWithCredentialInternalAsync_DEPRECATED(credential).ContinueWith(task => {
         CompleteFirebaseUserTask(task, taskCompletionSource);
       });
     return taskCompletionSource.Task;
@@ -837,12 +858,18 @@ static CppInstanceManager<Auth> g_auth_instances;
   ///
   /// An error is returned if the token is invalid, expired, or otherwise not
   /// accepted by the server.
+  ///
+  /// @deprecated This function is deprecated in favor of `Task<AuthResult>`
+  /// return type. Please use
+  /// `Task<AuthResult> SignInAndRetrieveDataWithCredentialAsync(Credential)`
+  /// instead.
+  [System.ObsoleteAttribute("Please use `Task<AuthResult> SignInAndRetrieveDataWithCredentialAsync(Credential)` instead", false)]
   public System.Threading.Tasks.Task<SignInResult>
-      SignInAndRetrieveDataWithCredentialAsync(Credential credential) {
+      SignInAndRetrieveDataWithCredentialAsync_DEPRECATED(Credential credential) {
     ThrowIfNull();
     var taskCompletionSource =
         new System.Threading.Tasks.TaskCompletionSource<SignInResult>();
-    SignInAndRetrieveDataWithCredentialInternalAsync(credential).ContinueWith(
+    SignInAndRetrieveDataWithCredentialInternalAsync_DEPRECATED(credential).ContinueWith(
         task => { CompleteSignInResultTask(task, taskCompletionSource); });
     return taskCompletionSource.Task;
   }
@@ -868,11 +895,16 @@ static CppInstanceManager<Auth> g_auth_instances;
   ///    });
   ///  }
   /// @endcode
-  public System.Threading.Tasks.Task<FirebaseUser> SignInAnonymouslyAsync() {
+  ///
+  /// @deprecated This function is deprecated in favor of `Task<AuthResult>`
+  /// return type. Please use
+  /// `Task<AuthResult> SignInAnonymouslyAsync()` instead.
+  [System.ObsoleteAttribute("Please use `Task<AuthResult> SignInAnonymouslyAsync()` instead", false)]
+  public System.Threading.Tasks.Task<FirebaseUser> SignInAnonymouslyAsync_DEPRECATED() {
     ThrowIfNull();
     var taskCompletionSource =
         new System.Threading.Tasks.TaskCompletionSource<FirebaseUser>();
-    SignInAnonymouslyInternalAsync().ContinueWith(task => {
+    SignInAnonymouslyInternalAsync_DEPRECATED().ContinueWith(task => {
         CompleteFirebaseUserTask(task, taskCompletionSource);
       });
     return taskCompletionSource.Task;
@@ -881,12 +913,17 @@ static CppInstanceManager<Auth> g_auth_instances;
   /// Signs in using provided email address and password.
   /// An error is returned if the password is wrong or otherwise not accepted
   /// by the server.
-  public System.Threading.Tasks.Task<FirebaseUser> SignInWithEmailAndPasswordAsync(
+  ///
+  /// @deprecated This function is deprecated in favor of `Task<AuthResult>`
+  /// return type. Please use `Task<AuthResult> SignInAnonymouslyAsync()`
+  /// instead.
+  [System.ObsoleteAttribute("Please use `Task<AuthResult> SignInWithEmailAndPasswordAsync(string, string)` instead", false)]
+  public System.Threading.Tasks.Task<FirebaseUser> SignInWithEmailAndPasswordAsync_DEPRECATED(
       string email, string password) {
     ThrowIfNull();
     var taskCompletionSource =
         new System.Threading.Tasks.TaskCompletionSource<FirebaseUser>();
-    SignInWithEmailAndPasswordInternalAsync(email, password).ContinueWith(
+    SignInWithEmailAndPasswordInternalAsync_DEPRECATED(email, password).ContinueWith(
         task => {
           CompleteFirebaseUserTask(task, taskCompletionSource);
         });
@@ -898,12 +935,18 @@ static CppInstanceManager<Auth> g_auth_instances;
   ///
   /// An error is returned when account creation is unsuccessful
   /// (due to another existing account, invalid password, etc.).
+  ///
+  /// @deprecated This function is deprecated in favor of `Task<AuthResult>`
+  /// return type. Please use
+  /// `Task<AuthResult> CreateUserWithEmailAndPasswordAsync(string, string)`
+  /// instead.
+  [System.ObsoleteAttribute("Please use `Task<AuthResult> CreateUserWithEmailAndPasswordAsync(string, string)` instead", false)]
   public System.Threading.Tasks.Task<FirebaseUser>
-      CreateUserWithEmailAndPasswordAsync(string email, string password) {
+      CreateUserWithEmailAndPasswordAsync_DEPRECATED(string email, string password) {
     ThrowIfNull();
     var taskCompletionSource =
         new System.Threading.Tasks.TaskCompletionSource<FirebaseUser>();
-    CreateUserWithEmailAndPasswordInternalAsync(email, password).ContinueWith(
+    CreateUserWithEmailAndPasswordInternalAsync_DEPRECATED(email, password).ContinueWith(
         task => {
           CompleteFirebaseUserTask(task, taskCompletionSource);
         });
@@ -975,7 +1018,8 @@ static CppInstanceManager<Auth> g_auth_instances;
 
 %typemap(csclassmodifiers) firebase::auth::User::UserProfile
   "public sealed class";
-%typemap(csclassmodifiers) firebase::auth::Credential "public sealed class";
+%typemap(csclassmodifiers) firebase::auth::Credential "public class";
+%typemap(csclassmodifiers) firebase::auth::PhoneAuthCredential "public sealed class";
 
 %typemap(csclassmodifiers) firebase::auth::FederatedAuthProvider "public class";
 
@@ -1090,12 +1134,18 @@ static CppInstanceManager<Auth> g_auth_instances;
   /// @note: This operation is supported only on iOS, tvOS and Android
   /// platforms. On other platforms this method will return a Future with a
   /// preset error code: kAuthErrorUnimplemented.
+  ///
+  /// @deprecated This function is deprecated in favor of `Task<AuthResult>`
+  /// return type. Please use
+  /// `Task<AuthResult> ReauthenticateWithProviderAsync(FederatedAuthProvider)`
+  /// instead.
+  [System.ObsoleteAttribute("Please use `Task<AuthResult> ReauthenticateWithProviderAsync(FederatedAuthProvider)` instead", false)]
   public System.Threading.Tasks.Task<SignInResult>
-      ReauthenticateWithProviderAsync(FederatedAuthProvider provider) {
+      ReauthenticateWithProviderAsync_DEPRECATED(FederatedAuthProvider provider) {
     ThrowIfNull();
     var taskCompletionSource =
         new System.Threading.Tasks.TaskCompletionSource<SignInResult>();
-    ReauthenticateWithProviderInternalAsync(provider).ContinueWith(task => {
+    ReauthenticateWithProviderInternalAsync_DEPRECATED(provider).ContinueWith(task => {
         CompleteSignInResultTask(task, taskCompletionSource);
       });
     return taskCompletionSource.Task;
@@ -1113,12 +1163,18 @@ static CppInstanceManager<Auth> g_auth_instances;
   /// @note: This operation is supported only on iOS, tvOS and Android
   /// platforms. On other platforms this method will return a Future with a
   /// preset error code: kAuthErrorUnimplemented.
-  public System.Threading.Tasks.Task<SignInResult> LinkWithProviderAsync(
+  ///
+  /// @deprecated This function is deprecated in favor of `Task<AuthResult>`
+  /// return type. Please use
+  /// `Task<AuthResult> LinkWithProviderAsync(FederatedAuthProvider)`
+  /// instead.
+  [System.ObsoleteAttribute("Please use `Task<AuthResult> LinkWithProviderAsync(FederatedAuthProvider)` instead", false)]
+  public System.Threading.Tasks.Task<SignInResult> LinkWithProviderAsync_DEPRECATED(
       FederatedAuthProvider provider) {
     ThrowIfNull();
     var taskCompletionSource =
         new System.Threading.Tasks.TaskCompletionSource<SignInResult>();
-    LinkWithProviderInternalAsync(provider).ContinueWith(task => {
+    LinkWithProviderInternalAsync_DEPRECATED(provider).ContinueWith(task => {
         CompleteSignInResultTask(task, taskCompletionSource);
       });
     return taskCompletionSource.Task;
@@ -1155,10 +1211,10 @@ static CppInstanceManager<Auth> g_auth_instances;
   %}
 
 // Rename User Federated Auth methods
-%rename(ReauthenticateWithProviderInternal)
-  firebase::auth::User::ReauthenticateWithProvider;
-%rename(LinkWithProviderInternal)
-  firebase::auth::User::LinkWithProvider;
+%rename(ReauthenticateWithProviderInternalAsync_DEPRECATED)
+  firebase::auth::User::ReauthenticateWithProvider_DEPRECATED;
+%rename(LinkWithProviderInternalAsync_DEPRECATED)
+  firebase::auth::User::LinkWithProvider_DEPRECATED;
 
 // Rename token retrieval method.
 // NOTE: This is not a property as it is an asynchronous operation.
@@ -1192,8 +1248,8 @@ static CppInstanceManager<Auth> g_auth_instances;
 // Deprecated method that conflicts with the CurrentUser property.
 %ignore firebase::auth::Auth::CurrentUser;
 // Make basic getters use C# Properties instead.
-%attribute(firebase::auth::Auth, firebase::auth::User *,
-           CurrentUserInternal, current_user);
+%attributeval(firebase::auth::Auth, firebase::auth::User,
+              CurrentUserInternal, current_user);
 
 %attributestring(firebase::auth::Credential, std::string, Provider, provider);
 
@@ -1205,8 +1261,8 @@ static CppInstanceManager<Auth> g_auth_instances;
 %attributeval(firebase::auth::User, firebase::auth::UserMetadata, Metadata, metadata);
 %attributestring(firebase::auth::User, std::string, PhoneNumber, phone_number);
 %attributestring(firebase::auth::User, std::string, PhotoUrlInternal, photo_url);
-%attribute(firebase::auth::User,
-  std::vector<firebase::auth::UserInfoInterface*>&, ProviderData, provider_data);
+%attributeval(firebase::auth::User,
+  std::vector<firebase::auth::UserInfoInterface>, ProviderData, provider_data);
 %attributestring(firebase::auth::User, std::string, ProviderId, provider_id);
 %attributestring(firebase::auth::User, std::string, UserId, uid);
 
@@ -1317,11 +1373,24 @@ class PhoneAuthListenerImpl
   virtual ~PhoneAuthListenerImpl() {}
 
   virtual void OnVerificationCompleted(Credential credential) {
+    // Both `OnVerificationCompleted(Credential) and
+    // OnVerificationCompleted(PhoneAuthCredential) will be triggered. We
+    // should support both delegates but the user needs to choose to use
+    // only one of them.
     if (g_verification_completed_callback) {
       firebase::callback::AddCallback(
           new firebase::callback::CallbackValue2<int, Credential>(
               callback_id_, credential, VerificationCompleted));
     }
+  }
+
+  virtual void OnVerificationCompleted(PhoneAuthCredential credential) {
+    // Both `OnVerificationCompleted(Credential) and
+    // OnVerificationCompleted(PhoneAuthCredential) will be triggered. We
+    // should support both delegates but the user needs to choose to use
+    // only one of them.
+
+    // TODO(IO2023): Add hooks to new PhoneAuthCredential. Need new delegates.
   }
 
   virtual void OnVerificationFailed(const std::string& error) {

--- a/swig_post_process.py
+++ b/swig_post_process.py
@@ -320,9 +320,16 @@ class RenameAsyncMethods(SWIGPostProcessingInterface):
           # If the function name already ends with Async or is GetTask
           # (since it's from a Future result class) don't replace it.
           function_name = m.groups()[1]
-          if function_name.endswith('Async') or function_name == 'GetTask':
+          if (function_name.endswith('Async') or
+              function_name.endswith('Async_DEPRECATED') or
+              function_name == 'GetTask'):
             break
+          is_deprecated = function_name.endswith('_DEPRECATED')
           line = regexp.sub(r'\g<1>\g<2>Async\g<3>', line)
+          if function_name.endswith('_DEPRECATED'):
+            # Swap the location of 'Async' and '_DEPRECATED'
+            line = line.replace('_DEPRECATEDAsync', 'Async_DEPRECATED')
+
           break
       output.append(line)
     return '\n'.join(output)
@@ -512,7 +519,7 @@ class StaticFunctionKInitRemoval(SWIGPostProcessingInterface):
                         line[match.end(2):]])
       output.append(line)
     return '\n'.join(output)
-    
+
 class DynamicToReinterpretCast(SWIGPostProcessingInterface):
   """Changes the use of dynamic_cast in SWIG generated code to reinterpret_cast.
 


### PR DESCRIPTION
### Description
> Provide details of the change, and generalize the change in the PR title above.

Initial change to make sure Unity SDK can compile against C++ Auth feature branch.

Integration test is expected to be broken since it is pointing to C++ main and Unity integration test is not update.

This change includes:
- Update SWIG postprocess to rename deprecated functions which returns a `Task`
- Remove `PhoneAuthProvider.MaxTimeoutMs`
- Wire the following function to new C++ impl
  - `Firebase.Auth.FirebaseAuth.CurrentUser`
  - `Firebase.Auth.FirebaseUser.ProviderData`
- Deprecated the following function
  - Firebase.Auth.FirebaseAuth.SignInWithCustomTokenAsync_DEPRECATED
  - Firebase.Auth.FirebaseAuth.SignInWithCredentialAsync_DEPRECATED
  - Firebase.Auth.FirebaseAuth.SignInAndRetrieveDataWithCredentialAsync_DEPRECATED
  - Firebase.Auth.FirebaseAuth.SignInAnonymouslyAsync_DEPRECATED
  - Firebase.Auth.FirebaseAuth.SignInWithEmailAndPasswordAsync_DEPRECATED
  - Firebase.Auth.FirebaseAuth.CreateUserWithEmailAndPasswordAsync_DEPRECATED
  - Firebase.Auth.FirebaseAuth.SignInWithProviderAsync_DEPRECATED
  - Firebase.Auth.FirebaseUser.ReauthenticateWithProviderAsync_DEPRECATED
  - Firebase.Auth.FirebaseUser.LinkWithProviderAsync_DEPRECATED
- Added C# impl for new `PhoneAuthOptions` class
- Placeholder impl for `PhoneAuthListenerImpl.OnVerificationCompleted(PhoneAuthCredential)`

***
### Testing
> Describe how you've tested these changes.


Only build locally using 
```
python scripts/build_scripts/build_zips.py --platform=android --apis=auth
```
***

### Type of Change
Place an `x` the applicable box:
- [ ] Bug fix. Add the issue # below if applicable.
- [x] New feature. A non-breaking change which adds functionality.
- [ ] Other, such as a build process or documentation change.
***

