### PR TITLE
Update C++ version and use newer Windows SDK

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,7 +16,8 @@
 
 # Higher CMake version needed for improvments in UseSwig.cmake and string join
 cmake_minimum_required (VERSION 3.13.4)
-set (CMAKE_CXX_STANDARD 11)
+set (CMAKE_CXX_STANDARD 14)
+set (CMAKE_CXX_STANDARD_REQUIRED YES) # Don't fall back to an earlier version.
 
 # Turn on virtual folders for visual studio
 set_property(GLOBAL PROPERTY USE_FOLDERS ON)

--- a/scripts/build_scripts/build_zips.py
+++ b/scripts/build_scripts/build_zips.py
@@ -433,6 +433,9 @@ def get_windows_args():
   result_args.append('-G Visual Studio 16 2019')
   result_args.append('-A x64') # TODO flexibily for x32
   result_args.append("-DFIREBASE_PYTHON_HOST_EXECUTABLE:FILEPATH=%s" % sys.executable)
+  # Use a newer version of the Windows SDK, as the default one has build issues with grpc
+  if FLAGS.gha:
+    result_args.append('-DCMAKE_SYSTEM_VERSION=10.0.20348.0')
   return result_args
 
 def get_macos_args():


### PR DESCRIPTION
### Description
> Provide details of the change, and generalize the change in the PR title above.

Update the C++ version to 14, and when doing a GHA windows build, use a newer version of the Windows SDK (the same used by the C++ repo).  This is to fix the issues with building grpc.
***
### Testing
> Describe how you've tested these changes.

https://github.com/firebase/firebase-unity-sdk/actions/runs/4801338273
***

### Type of Change
Place an `x` the applicable box:
- [ ] Bug fix. Add the issue # below if applicable.
- [ ] New feature. A non-breaking change which adds functionality.
- [x] Other, such as a build process or documentation change.
***

