### PR TITLE
Rollup EDM4U version to 1.2.176

### DIFF
--- a/cmake/firebase_unity_version.cmake
+++ b/cmake/firebase_unity_version.cmake
@@ -21,7 +21,7 @@ set(FIREBASE_IOS_POD_VERSION "10.7.0"
     CACHE STRING "The version of the top-level Firebase Cocoapod to use.")
 
 # https://github.com/googlesamples/unity-jar-resolver
-set(FIREBASE_UNITY_JAR_RESOLVER_VERSION "1.2.175"
+set(FIREBASE_UNITY_JAR_RESOLVER_VERSION "1.2.176"
    CACHE STRING
   "Version tag of Play Services Resolver to download and use (no trailing .0)"
 )

--- a/unity_packer/exports.json
+++ b/unity_packer/exports.json
@@ -146,7 +146,7 @@
         "manifest" : {
           "unity": "2018.1",
           "dependencies": {
-            "com.google.external-dependency-manager" : "1.2.175"
+            "com.google.external-dependency-manager" : "1.2.176"
           }
         }
       }


### PR DESCRIPTION
### Description
> Provide details of the change, and generalize the change in the PR title above.

Rollup EDM4U version to 1.2.176 which includes the many fixes in Android resolver. More detail [here](https://github.com/googlesamples/unity-jar-resolver/releases/tag/v1.2.176)
***
### Testing
> Describe how you've tested these changes.


N/A


***

### Type of Change
Place an `x` the applicable box:
- [ ] Bug fix. Add the issue # below if applicable.
- [ ] New feature. A non-breaking change which adds functionality.
- [x] Other, such as a build process or documentation change.
***

