### PR TITLE
Add new required Python package for EDM4U

### DIFF
--- a/scripts/gha/requirements.txt
+++ b/scripts/gha/requirements.txt
@@ -4,3 +4,4 @@ pyyaml
 pytz
 requests
 PyGithub
+packaging


### PR DESCRIPTION
### Description
> Provide details of the change, and generalize the change in the PR title above.

EDM4U removed the deprecated use of `distutil` and migrated to `packaging`. Add this as a required Python package.

***
### Testing
> Describe how you've tested these changes.


Local test
***

### Type of Change
Place an `x` the applicable box:
- [x] Bug fix. Add the issue # below if applicable.
- [ ] New feature. A non-breaking change which adds functionality.
- [ ] Other, such as a build process or documentation change.
***

