### PR TITLE
Remove deprecated Messaging calls

### DIFF
--- a/docs/readme.md
+++ b/docs/readme.md
@@ -69,6 +69,10 @@ Support
 
 Release Notes
 -------------
+### 11.0.0
+- Changes
+    - Messaging: Remove deprecated calls `Send`, `Subscribe`, and `Unsubscribe`.
+
 ### 10.7.0
 - Changes
     - General: Update to Firebase C++ SDK version 10.7.0.

--- a/messaging/src/swig/messaging.i
+++ b/messaging/src/swig/messaging.i
@@ -543,39 +543,6 @@ void* NotificationCopyAndroidNotificationParams(void* notification) {
   }
 #endif  // DOXYGEN
 
-#if DOXYGEN
-  /// @brief Subscribe to receive all messages to the specified topic.
-  ///
-  /// Subscribes an app instance to a topic, enabling it to receive messages sent to that topic.
-  ///
-  /// Call this function from the main thread. FCM is not thread safe.
-  ///
-  /// @param[in] topic The name of the topic to subscribe. Must match the following regular expression: `[a-zA-Z0-9-_.~%]{1,900}`.
-  [System.Obsolete("FirebaseMessaging.Subscribe is deprecated. Please use FirebaseMessaging.SubscribeAsync() instead")]
-  public static void Subscribe(string topic);
-#else
-  [System.Obsolete("FirebaseMessaging.Subscribe is deprecated. Please use FirebaseMessaging.SubscribeAsync() instead")]
-  public static void Subscribe(string topic) {
-    SubscribeAsync(topic);
-  }
-#endif
-
-#if DOXYGEN
-  /// @brief Unsubscribe from a topic.
-  ///
-  /// Unsubscribes an app instance from a topic, stopping it from receiving any further messages sent to that topic.
-  ///
-  /// Call this function from the main thread. FCM is not thread safe.
-  ///
-  /// @param[in] topic The name of the topic to unsubscribe from. Must match the following regular expression: `[a-zA-Z0-9-_.~%]{1,900}`.
-  [System.Obsolete("FirebaseMessaging.Unsubscribe is deprecated. Please use FirebaseMessaging.UnsubscribeAsync() instead")]
-  public static void Unsubscribe(string topic);
-#else
-  [System.Obsolete("FirebaseMessaging.Unsubscribe is deprecated. Please use FirebaseMessaging.UnsubscribeAsync() instead")]
-  public static void Unsubscribe(string topic) {
-    UnsubscribeAsync(topic);
-  }
-#endif
 %}
 
 %typemap(cscode) firebase::messaging::Message %{
@@ -694,9 +661,6 @@ void* NotificationCopyAndroidNotificationParams(void* notification) {
     "internal"
 %csmethodmodifiers firebase::messaging::DeleteToken()
     "internal"
-
-%csmethodmodifiers firebase::messaging::Send(const Message&)
-    "[System.Obsolete(\"FirebaseMessaging.Send is deprecated and will be removed in a future version.\")]\n  "
 
 // Messaging has a lot of read-only properties, so make all immutable
 // and call out the mutable ones.


### PR DESCRIPTION
### Description
> Provide details of the change, and generalize the change in the PR title above.

Remove calls from messaging that have been deprecated for several years now.
***
### Testing
> Describe how you've tested these changes.

Builds locally.
***

### Type of Change
Place an `x` the applicable box:
- [ ] Bug fix. Add the issue # below if applicable.
- [ ] New feature. A non-breaking change which adds functionality.
- [x] Other, such as a build process or documentation change.
***

