### PR TITLE
Deprecating old APIs in Auth

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -153,6 +153,13 @@ else()
   set(DESKTOP OFF)
 endif()
 
+if(APPLE)
+  # GHA macOS build treats deprecation warning as error (-Werror,-Wdeprecated-declarations)
+  # This is a quick way to suppress the warning so that the build won't fail.
+  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wno-deprecated-declarations")
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-deprecated-declarations")
+endif()
+
 # Define the Python executable before including the subprojects
 find_program(FIREBASE_PYTHON_EXECUTABLE
   NAMES python3 python

--- a/auth/src/PhoneAuthProvider.cs
+++ b/auth/src/PhoneAuthProvider.cs
@@ -25,7 +25,8 @@ namespace Firebase.Auth {
 ///
 /// This class is not supported on tvOS and Desktop platforms.
 ///
-/// The verification flow results in a Credential that can be used to,
+/// The verification flow results in a @ref PhoneAuthCredential that can be
+/// used to,
 /// * Sign in to an existing phone number account/sign up with a new
 ///   phone number
 /// * Link a phone number to a current user. This provider will be added to
@@ -43,24 +44,32 @@ namespace Firebase.Auth {
 ///       phone number. App receives verification id via @ref CodeSent.
 ///     - User receives SMS and enters verification code in app's GUI.
 ///     - App uses user's verification code to call
-///       @ref PhoneAuthProvider::GetCredential.
+///       @ref PhoneAuthProvider.GetCredential.
 ///
 /// (2) SMS is automatically retrieved (Android only).
-///     - App calls @ref VerifyPhoneNumber with `timeout_ms` > 0.
+///     - App calls @ref VerifyPhoneNumber with `autoVerifyTimeOutMs` > 0.
 ///     - Auth server sends the verification code via SMS to the provided
 ///       phone number.
 ///     - SMS arrives and is automatically retrieved by the operating system.
-///       Credential is automatically created and passed to the app via
-///       @ref VerificationCompleted.
+///       @ref PhoneAuthCredential is automatically created and passed to the
+///       app via @ref VerificationCompleted.
 ///
 /// (3) Phone number is instantly verified (Android only).
 ///     - App calls @ref VerifyPhoneNumber.
 ///     - The operating system validates the phone number without having to
-///       send an SMS. Credential is automatically created and passed to
-///       the app via @ref VerificationCompleted.
+///       send an SMS. @ref PhoneAuthCredential is automatically created and
+///       passed to the app via @ref VerificationCompleted.
+///
+/// Note: Both @ref VerificationCompleted_DEPRECATED and
+/// @ref VerificationCompleted will be triggered upon completion. Developer
+/// should only use only one of them to prevent duplicated event handling.
 public sealed class PhoneAuthProvider : global::System.IDisposable {
+  /// @deprecated This is a deprecated delegate. Please use @ref
+  /// VerificationCompleted instead.
+  //
   /// Callback used when phone number auto-verification succeeded.
-  public delegate void VerificationCompleted(Credential credential);
+  [System.Obsolete("Please use `VerificationCompleted(PhoneAuthCredential)` instead", false)]
+  public delegate void VerificationCompleted_DEPRECATED(Credential credential);
   /// Callback used when phone number verification fails.
   public delegate void VerificationFailed(string error);
   /// Callback used when a verification code is sent to the given number.
@@ -73,7 +82,7 @@ public sealed class PhoneAuthProvider : global::System.IDisposable {
 
   // Class to hold the delegates the user provides to the verification flow.
   private class PhoneAuthDelegates {
-    public VerificationCompleted verificationCompleted;
+    public VerificationCompleted_DEPRECATED verificationCompleted;
     public VerificationFailed verificationFailed;
     public CodeSent codeSent;
     public CodeAutoRetrievalTimeOut timeOut;
@@ -90,7 +99,7 @@ public sealed class PhoneAuthProvider : global::System.IDisposable {
   /// when the C++ library indicates a callback.
   ///
   /// @return The unique identifier for the cached callbacks.
-  private static int SaveCallbacks(VerificationCompleted verificationCompleted,
+  private static int SaveCallbacks(VerificationCompleted_DEPRECATED verificationCompleted,
                                    VerificationFailed verificationFailed,
                                    CodeSent codeSent,
                                    CodeAutoRetrievalTimeOut timeOut) {
@@ -107,8 +116,8 @@ public sealed class PhoneAuthProvider : global::System.IDisposable {
     return uid;
   }
 
-  [MonoPInvokeCallback(typeof(PhoneAuthProviderInternal.VerificationCompletedDelegate))]
-  private static void VerificationCompletedHandler(int callbackId,
+  [MonoPInvokeCallback(typeof(PhoneAuthProviderInternal.VerificationCompletedDelegate_DEPRECATED))]
+  private static void VerificationCompleted_DEPRECATEDHandler(int callbackId,
                                                    System.IntPtr credential) {
     ExceptionAggregator.Wrap(() => {
         Credential c = new Credential(credential, true);
@@ -166,10 +175,10 @@ public sealed class PhoneAuthProvider : global::System.IDisposable {
       });
   }
 
-  private static PhoneAuthProviderInternal.VerificationCompletedDelegate
-      verificationCompletedDelegate =
-          new PhoneAuthProviderInternal.VerificationCompletedDelegate(
-              VerificationCompletedHandler);
+  private static PhoneAuthProviderInternal.VerificationCompletedDelegate_DEPRECATED
+      verificationCompletedDelegate_DEPRECATED =
+          new PhoneAuthProviderInternal.VerificationCompletedDelegate_DEPRECATED(
+              VerificationCompleted_DEPRECATEDHandler);
   private static PhoneAuthProviderInternal.VerificationFailedDelegate
       verificationFailedDelegate =
           new PhoneAuthProviderInternal.VerificationFailedDelegate(
@@ -187,13 +196,17 @@ public sealed class PhoneAuthProvider : global::System.IDisposable {
   private static void InitializeCallbacks() {
     if (!callbacksInitialized) {
       callbacksInitialized = true;
-      PhoneAuthProviderInternal.SetCallbacks(verificationCompletedDelegate,
+      PhoneAuthProviderInternal.SetCallbacks(verificationCompletedDelegate_DEPRECATED,
                                              verificationFailedDelegate,
                                              codeSentDelegate,
                                              timeOutDelegate);
     }
   }
 
+  /// @deprecated This is a deprecated method. Please use @ref
+  /// VerifyPhoneNumber(PhoneAuthOptions, VerificationCompleted, VerificationFailed, CodeSent,
+  /// CodeAutoRetrievalTimeOut) instead.
+  ///
   /// Start the phone number authentication operation.
   ///
   /// @note  The verificationCompleted callback is never invoked on iOS since auto-validation is
@@ -219,15 +232,20 @@ public sealed class PhoneAuthProvider : global::System.IDisposable {
   /// @param[in] verificationFailed Phone number verification failed with an
   ///    error. For example, quota exceeded or unknown phone number format.
   ///    Provided with a description of the error.
+  [System.Obsolete("Please use `VerifyPhoneNumber(PhoneAuthOptions, VerificationCompleted, VerificationFailed, CodeSent, CodeAutoRetrievalTimeOut)` instead", false)]
   public void VerifyPhoneNumber(string phoneNumber, uint autoVerifyTimeOutMs,
                                 ForceResendingToken forceResendingToken,
-                                VerificationCompleted verificationCompleted,
+                                VerificationCompleted_DEPRECATED verificationCompleted,
                                 VerificationFailed verificationFailed) {
     VerifyPhoneNumber(phoneNumber, autoVerifyTimeOutMs, forceResendingToken,
                       verificationCompleted, verificationFailed,
                       null, null);
   }
 
+  /// @deprecated This is a deprecated method. Please use @ref
+  /// VerifyPhoneNumber(PhoneAuthOptions, VerificationCompleted, VerificationFailed, CodeSent,
+  /// CodeAutoRetrievalTimeOut) instead.
+  ///
   /// Start the phone number authentication operation.
   ///
   /// @note  The verificationCompleted callback is never invoked on iOS since auto-validation is
@@ -257,9 +275,10 @@ public sealed class PhoneAuthProvider : global::System.IDisposable {
   ///    number. Provided with the verification id to pass along to
   ///    `GetCredential` along with the sent code, and a token to use if
   ///    the user requests another SMS message be sent.
+  [System.Obsolete("Please use `VerifyPhoneNumber(PhoneAuthOptions, VerificationCompleted, VerificationFailed, CodeSent, CodeAutoRetrievalTimeOut)` instead", false)]
   public void VerifyPhoneNumber(string phoneNumber, uint autoVerifyTimeOutMs,
                                 ForceResendingToken forceResendingToken,
-                                VerificationCompleted verificationCompleted,
+                                VerificationCompleted_DEPRECATED verificationCompleted,
                                 VerificationFailed verificationFailed,
                                 CodeSent codeSent) {
     VerifyPhoneNumber(phoneNumber, autoVerifyTimeOutMs, forceResendingToken,
@@ -267,6 +286,10 @@ public sealed class PhoneAuthProvider : global::System.IDisposable {
                       codeSent, null);
   }
 
+  /// @deprecated This is a deprecated method. Please use @ref
+  /// VerifyPhoneNumber(PhoneAuthOptions, VerificationCompleted, VerificationFailed, CodeSent,
+  /// CodeAutoRetrievalTimeOut) instead.
+  ///
   /// Start the phone number authentication operation.
   ///
   /// @note  The verificationCompleted callback is never invoked on iOS since auto-validation is
@@ -292,9 +315,10 @@ public sealed class PhoneAuthProvider : global::System.IDisposable {
   /// @param[in] verificationFailed Phone number verification failed with an
   ///    error. For example, quota exceeded or unknown phone number format.
   ///    Provided with a description of the error.
+  [System.Obsolete("Please use `VerifyPhoneNumber(PhoneAuthOptions, VerificationCompleted, VerificationFailed, CodeSent, CodeAutoRetrievalTimeOut)` instead", false)]
   public void VerifyPhoneNumber(string phoneNumber, uint autoVerifyTimeOutMs,
                                 ForceResendingToken forceResendingToken,
-                                VerificationCompleted verificationCompleted,
+                                VerificationCompleted_DEPRECATED verificationCompleted,
                                 VerificationFailed verificationFailed,
                                 CodeAutoRetrievalTimeOut codeAutoRetrievalTimeOut) {
     VerifyPhoneNumber(phoneNumber, autoVerifyTimeOutMs, forceResendingToken,
@@ -302,6 +326,10 @@ public sealed class PhoneAuthProvider : global::System.IDisposable {
                       null, codeAutoRetrievalTimeOut);
   }
 
+  /// @deprecated This is a deprecated method. Please use @ref
+  /// VerifyPhoneNumber(PhoneAuthOptions, VerificationCompleted, VerificationFailed, CodeSent,
+  /// CodeAutoRetrievalTimeOut) instead.
+  ///
   /// Start the phone number authentication operation.
   ///
   /// @note  On iOS the verificationCompleted callback is never invoked and the
@@ -334,9 +362,10 @@ public sealed class PhoneAuthProvider : global::System.IDisposable {
   ///    the user requests another SMS message be sent.
   /// @param[in] codeAutoRetrievalTimeOut The timeout specified has expired.
   ///    Provided with the verification id for the transaction that timed out.
+  [System.Obsolete("Please use `VerifyPhoneNumber(PhoneAuthOptions, VerificationCompleted, VerificationFailed, CodeSent, CodeAutoRetrievalTimeOut)` instead", false)]
   public void VerifyPhoneNumber(string phoneNumber, uint autoVerifyTimeOutMs,
                                 ForceResendingToken forceResendingToken,
-                                VerificationCompleted verificationCompleted,
+                                VerificationCompleted_DEPRECATED verificationCompleted,
                                 VerificationFailed verificationFailed,
                                 CodeSent codeSent,
                                 CodeAutoRetrievalTimeOut codeAutoRetrievalTimeOut) {
@@ -390,6 +419,8 @@ public sealed class PhoneAuthProvider : global::System.IDisposable {
     }
   }
 
+  /// @deprecated This is a deprecated method. Please use @ref GetCredential instead.
+  ///
   /// Generate a credential for the given phone number.
   ///
   /// @param[in] verification_id The id returned when sending the verification
@@ -399,9 +430,10 @@ public sealed class PhoneAuthProvider : global::System.IDisposable {
   ///    received in the SMS sent by @ref VerifyPhoneNumber.
   ///
   /// @returns New Credential.
-  public Credential GetCredential(string verificationId,
+  [System.Obsolete("Please use `PhoneAuthCredential GetCredential(string, string)` instead", false)]
+  public Credential GetCredential_DEPRECATED(string verificationId,
                                   string verificationCode) {
-    return InternalProvider.GetCredential(verificationId, verificationCode);
+    return InternalProvider.GetCredential_DEPRECATED(verificationId, verificationCode);
   }
 }
 

--- a/auth/src/PhoneAuthProvider.cs
+++ b/auth/src/PhoneAuthProvider.cs
@@ -59,19 +59,6 @@ namespace Firebase.Auth {
 ///       send an SMS. Credential is automatically created and passed to
 ///       the app via @ref VerificationCompleted.
 public sealed class PhoneAuthProvider : global::System.IDisposable {
-  /// Maximum value of `autoVerifyTimeOutMs` in @ref VerifyPhoneNumber.
-  /// @ref VerifyPhoneNumber will automatically clamp values to this amount.
-  ///
-  /// @deprecated This value is no longer used to clamp
-  /// `autoVerifyTimeOutMs` in @ref VerifyPhoneNumber. The range is
-  /// determined by the underlying SDK, ex. <a href="/docs/reference/android/com/google/firebase/auth/PhoneAuthOptions.Builder"><code>PhoneAuthOptions.Build</code> in Android SDK</a>
-  [System.Obsolete("PhoneAuthProvider.MaxTimeoutMs is deprecated. This value no longer affects PhoneAuthProvider.VerifyPhoneNumber()")]
-  public static uint MaxTimeoutMs {
-    get {
-      return PhoneAuthProviderInternal.kMaxTimeoutMs;
-    }
-  }
-
   /// Callback used when phone number auto-verification succeeded.
   public delegate void VerificationCompleted(Credential credential);
   /// Callback used when phone number verification fails.

--- a/auth/src/swig/auth.i
+++ b/auth/src/swig/auth.i
@@ -477,16 +477,16 @@ static CppInstanceManager<Auth> g_auth_instances;
     }
   }
 
+  /// @deprecated This method is deprecated in favor of methods that return
+  /// `Task<AuthResult>`. Please use
+  /// @ref SignInWithProviderAsync(FederatedAuthProvider) instead.
+  ///
   /// Sign-in a user authenticated via a federated auth provider.
   ///
   /// @note: This operation is supported only on iOS, tvOS and Android
   /// platforms. On other platforms this method will return a Future with a
   /// preset error code: kAuthErrorUnimplemented.
-  ///
-  /// @deprecated This method is deprecated in favor of methods that return
-  /// `Task<AuthResult>`. Please use
-  /// `Task<AuthResult> SignInWithProviderAsync(FederatedAuthProvider)` instead.
-  [System.ObsoleteAttribute("Please use `Task<AuthResult> SignInWithProviderAsync(FederatedAuthProvider)` instead", false)]
+  [System.Obsolete("Please use `Task<AuthResult> SignInWithProviderAsync(FederatedAuthProvider)` instead", false)]
   public System.Threading.Tasks.Task<SignInResult> SignInWithProviderAsync_DEPRECATED(
       FederatedAuthProvider provider) {
     ThrowIfNull();
@@ -807,15 +807,15 @@ static CppInstanceManager<Auth> g_auth_instances;
     }
   }
 
+  /// @deprecated This method is deprecated in favor of methods that return
+  /// `Task<AuthResult>`. Please use
+  /// @ref SignInWithCustomTokenAsync(string) instead.
+  ///
   /// Asynchronously logs into Firebase with the given Auth token.
   ///
   /// An error is returned, if the token is invalid, expired or otherwise
   /// not accepted by the server.
-  ///
-  /// @deprecated This method is deprecated in favor of methods that return
-  /// `Task<AuthResult>`. Please use
-  /// `Task<AuthResult> SignInWithCustomTokenAsync(string)` instead.
-  [System.ObsoleteAttribute("Please use `Task<AuthResult> SignInWithCustomTokenAsync(string)` instead", false)]
+  [System.Obsolete("Please use `Task<AuthResult> SignInWithCustomTokenAsync(string)` instead", false)]
   public System.Threading.Tasks.Task<FirebaseUser> SignInWithCustomTokenAsync_DEPRECATED(
       string token) {
     ThrowIfNull();
@@ -827,15 +827,15 @@ static CppInstanceManager<Auth> g_auth_instances;
     return taskCompletionSource.Task;
   }
 
+  /// @deprecated This method is deprecated in favor of methods that return
+  /// `Task<AuthResult>`. Please use
+  /// @ref SignInWithCredentialAsync(Credential) instead.
+  ///
   /// @brief Asynchronously logs into Firebase with the given `Auth` token.
   ///
   /// An error is returned, if the token is invalid, expired or otherwise not
   /// accepted by the server.
-  ///
-  /// @deprecated This method is deprecated in favor of methods that return
-  /// `Task<AuthResult>`. Please use
-  /// `Task<AuthResult> SignInWithCredentialAsync(Credential)` instead.
-  [System.ObsoleteAttribute("Please use `Task<AuthResult> SignInWithCredentialAsync(Credential)` instead", false)]
+  [System.Obsolete("Please use `Task<AuthResult> SignInWithCredentialAsync(Credential)` instead", false)]
   public System.Threading.Tasks.Task<FirebaseUser> SignInWithCredentialAsync_DEPRECATED(
       Credential credential) {
     ThrowIfNull();
@@ -847,6 +847,11 @@ static CppInstanceManager<Auth> g_auth_instances;
     return taskCompletionSource.Task;
   }
 
+  /// @deprecated This method is deprecated in favor of methods that return
+  /// `Task<AuthResult>`. Please use
+  /// @ref SignInAndRetrieveDataWithCredentialAsync(Credential)
+  /// instead.
+  ///
   /// Asynchronously logs into Firebase with the given credentials.
   ///
   /// For example, the credential could wrap a Facebook login access token,
@@ -858,12 +863,7 @@ static CppInstanceManager<Auth> g_auth_instances;
   ///
   /// An error is returned if the token is invalid, expired, or otherwise not
   /// accepted by the server.
-  ///
-  /// @deprecated This method is deprecated in favor of methods that return
-  /// `Task<AuthResult>`. Please use
-  /// `Task<AuthResult> SignInAndRetrieveDataWithCredentialAsync(Credential)`
-  /// instead.
-  [System.ObsoleteAttribute("Please use `Task<AuthResult> SignInAndRetrieveDataWithCredentialAsync(Credential)` instead", false)]
+  [System.Obsolete("Please use `Task<AuthResult> SignInAndRetrieveDataWithCredentialAsync(Credential)` instead", false)]
   public System.Threading.Tasks.Task<SignInResult>
       SignInAndRetrieveDataWithCredentialAsync_DEPRECATED(Credential credential) {
     ThrowIfNull();
@@ -874,6 +874,10 @@ static CppInstanceManager<Auth> g_auth_instances;
     return taskCompletionSource.Task;
   }
 
+  /// @deprecated This method is deprecated in favor of methods that return
+  /// `Task<AuthResult>`. Please use
+  /// @ref SignInAnonymouslyAsync() instead.
+  ///
   /// Asynchronously creates and becomes an anonymous user.
   /// If there is already an anonymous user signed in, that user will be
   /// returned instead.
@@ -895,11 +899,7 @@ static CppInstanceManager<Auth> g_auth_instances;
   ///    });
   ///  }
   /// @endcode
-  ///
-  /// @deprecated This method is deprecated in favor of methods that return
-  /// `Task<AuthResult>`. Please use
-  /// `Task<AuthResult> SignInAnonymouslyAsync()` instead.
-  [System.ObsoleteAttribute("Please use `Task<AuthResult> SignInAnonymouslyAsync()` instead", false)]
+  [System.Obsolete("Please use `Task<AuthResult> SignInAnonymouslyAsync()` instead", false)]
   public System.Threading.Tasks.Task<FirebaseUser> SignInAnonymouslyAsync_DEPRECATED() {
     ThrowIfNull();
     var taskCompletionSource =
@@ -910,14 +910,14 @@ static CppInstanceManager<Auth> g_auth_instances;
     return taskCompletionSource.Task;
   }
 
-  /// Signs in using provided email address and password.
-  /// An error is returned if the password is wrong or otherwise not accepted
-  /// by the server.
-  ///
   /// @deprecated This method is deprecated in favor of methods that return
   /// `Task<AuthResult>`. Please use `Task<AuthResult> SignInAnonymouslyAsync()`
   /// instead.
-  [System.ObsoleteAttribute("Please use `Task<AuthResult> SignInWithEmailAndPasswordAsync(string, string)` instead", false)]
+  ///
+  /// Signs in using provided email address and password.
+  /// An error is returned if the password is wrong or otherwise not accepted
+  /// by the server.
+  [System.Obsolete("Please use `Task<AuthResult> SignInWithEmailAndPasswordAsync(string, string)` instead", false)]
   public System.Threading.Tasks.Task<FirebaseUser> SignInWithEmailAndPasswordAsync_DEPRECATED(
       string email, string password) {
     ThrowIfNull();
@@ -930,17 +930,17 @@ static CppInstanceManager<Auth> g_auth_instances;
     return taskCompletionSource.Task;
   }
 
+  /// @deprecated This method is deprecated in favor of methods that return
+  /// `Task<AuthResult>`. Please use
+  /// `Task<AuthResult> CreateUserWithEmailAndPasswordAsync(string, string)`
+  /// instead.
+  ///
   /// Creates, and on success, logs in a user with the given email address
   /// and password.
   ///
   /// An error is returned when account creation is unsuccessful
   /// (due to another existing account, invalid password, etc.).
-  ///
-  /// @deprecated This method is deprecated in favor of methods that return
-  /// `Task<AuthResult>`. Please use
-  /// `Task<AuthResult> CreateUserWithEmailAndPasswordAsync(string, string)`
-  /// instead.
-  [System.ObsoleteAttribute("Please use `Task<AuthResult> CreateUserWithEmailAndPasswordAsync(string, string)` instead", false)]
+  [System.Obsolete("Please use `Task<AuthResult> CreateUserWithEmailAndPasswordAsync(string, string)` instead", false)]
   public System.Threading.Tasks.Task<FirebaseUser>
       CreateUserWithEmailAndPasswordAsync_DEPRECATED(string email, string password) {
     ThrowIfNull();
@@ -954,7 +954,7 @@ static CppInstanceManager<Auth> g_auth_instances;
   }
 
   // Complete a task that returns a FirebaseUser.
-  private void CompleteFirebaseUserTask(
+  internal void CompleteFirebaseUserTask(
       System.Threading.Tasks.Task<FirebaseUser> task,
       System.Threading.Tasks.TaskCompletionSource<FirebaseUser>
         taskCompletionSource) {
@@ -1037,6 +1037,11 @@ static CppInstanceManager<Auth> g_auth_instances;
 %rename(ProviderId) firebase::auth::PhoneAuthProvider::kProviderId;
 %rename(ProviderId) firebase::auth::PlayGamesAuthProvider::kProviderId;
 %rename(ProviderId) firebase::auth::TwitterAuthProvider::kProviderId;
+%typemap(csclassmodifiers) firebase::auth::YahooAuthProvider "
+  /// @deprecated This class is no longer used and will be removed in a future release.
+  /// Please use the OAuthProvider to create credentials for Yahoo.
+  [System.Obsolete(\"Please use the OAuthProvider to create credentials for Yahoo.\")]
+  public class";
 %rename(ProviderId) firebase::auth::YahooAuthProvider::kProviderId;
 
 %STATIC_CLASS(EmailAuthProvider(), firebase::auth::EmailAuthProvider)
@@ -1129,17 +1134,16 @@ static CppInstanceManager<Auth> g_auth_instances;
     }
   }
 
+  /// @deprecated This method is deprecated in favor of methods that return
+  /// `Task<AuthResult>`. Please use
+  /// @ref ReauthenticateWithProviderAsync(FederatedAuthProvider) instead.
+  ///
   /// Reauthenticate a user via a federated auth provider.
   ///
   /// @note: This operation is supported only on iOS, tvOS and Android
   /// platforms. On other platforms this method will return a Future with a
   /// preset error code: kAuthErrorUnimplemented.
-  ///
-  /// @deprecated This method is deprecated in favor of methods that return
-  /// `Task<AuthResult>`. Please use
-  /// `Task<AuthResult> ReauthenticateWithProviderAsync(FederatedAuthProvider)`
-  /// instead.
-  [System.ObsoleteAttribute("Please use `Task<AuthResult> ReauthenticateWithProviderAsync(FederatedAuthProvider)` instead", false)]
+  [System.Obsolete("Please use `Task<AuthResult> ReauthenticateWithProviderAsync(FederatedAuthProvider)` instead", false)]
   public System.Threading.Tasks.Task<SignInResult>
       ReauthenticateWithProviderAsync_DEPRECATED(FederatedAuthProvider provider) {
     ThrowIfNull();
@@ -1158,17 +1162,16 @@ static CppInstanceManager<Auth> g_auth_instances;
     }
   }
 
+  /// @deprecated This method is deprecated in favor of methods that return
+  /// `Task<AuthResult>`. Please use
+  /// @ref LinkWithProviderAsync(FederatedAuthProvider) instead.
+  ///
   /// Link a user via a federated auth provider.
   ///
   /// @note: This operation is supported only on iOS, tvOS and Android
   /// platforms. On other platforms this method will return a Future with a
   /// preset error code: kAuthErrorUnimplemented.
-  ///
-  /// @deprecated This method is deprecated in favor of methods that return
-  /// `Task<AuthResult>`. Please use
-  /// `Task<AuthResult> LinkWithProviderAsync(FederatedAuthProvider)`
-  /// instead.
-  [System.ObsoleteAttribute("Please use `Task<AuthResult> LinkWithProviderAsync(FederatedAuthProvider)` instead", false)]
+  [System.Obsolete("Please use `Task<AuthResult> LinkWithProviderAsync(FederatedAuthProvider)` instead", false)]
   public System.Threading.Tasks.Task<SignInResult> LinkWithProviderAsync_DEPRECATED(
       FederatedAuthProvider provider) {
     ThrowIfNull();
@@ -1177,6 +1180,141 @@ static CppInstanceManager<Auth> g_auth_instances;
     LinkWithProviderInternalAsync_DEPRECATED(provider).ContinueWith(task => {
         CompleteSignInResultTask(task, taskCompletionSource);
       });
+    return taskCompletionSource.Task;
+  }
+
+  /// @deprecated This method is deprecated in favor of methods that return
+  /// `Task<AuthResult>`. Please use
+  /// @ref LinkWithCredentialAsync(Credential) instead.
+  ///
+  /// Links the user with the given 3rd party credentials.
+  ///
+  /// For example, a Facebook login access token, a Twitter token/token-secret
+  /// pair.
+  /// Status will be an error if the token is invalid, expired, or otherwise
+  /// not accepted by the server as well as if the given 3rd party
+  /// user id is already linked with another user account or if the current user
+  /// is already linked with another id from the same provider.
+  ///
+  /// Data from the Identity Provider used to sign-in is returned in the
+  /// @ref AdditionalUserInfo inside @ref SignInResult.
+  [System.Obsolete("Please use `Task<AuthResult> LinkWithProviderAsync(Credential)` instead", false)]
+  public System.Threading.Tasks.Task<SignInResult> LinkAndRetrieveDataWithCredentialAsync(
+      Credential credential) {
+    ThrowIfNull();
+    var taskCompletionSource =
+        new System.Threading.Tasks.TaskCompletionSource<SignInResult>();
+    LinkAndRetrieveDataWithCredentialInternalAsync(credential).ContinueWith(task => {
+        CompleteSignInResultTask(task, taskCompletionSource);
+      });
+    return taskCompletionSource.Task;
+  }
+
+  /// @deprecated This method is deprecated in favor of methods that return
+  /// `Task<AuthResult>`. Please use
+  /// @ref LinkWithCredentialAsync(Credential) instead.
+  ///
+  /// Associates a user account from a third-party identity provider.
+  [System.Obsolete("Please use `Task<AuthResult> LinkWithCredentialAsync(Credential)` instead", false)]
+  public System.Threading.Tasks.Task<FirebaseUser> LinkWithCredentialAsync_DEPRECATED(
+      Credential credential) {
+    ThrowIfNull();
+    var taskCompletionSource =
+        new System.Threading.Tasks.TaskCompletionSource<FirebaseUser>();
+    LinkWithCredentialInternalAsync_DEPRECATED(credential).ContinueWith(
+        task => {
+          if(authProxy != null) {
+              authProxy.CompleteFirebaseUserTask(task, taskCompletionSource);
+          } else {
+            // This should not happen. But if it does, throw exception and
+            // notify the team.
+            taskCompletionSource.TrySetException(new FirebaseException(0,
+                "Cannot complete 'LinkWithCredentialAsync_DEPRECATED()' " +
+                "because the authProxy is null."));
+          }
+        });
+    return taskCompletionSource.Task;
+  }
+
+  /// @deprecated This method is deprecated in favor of methods that return
+  /// `Task<AuthResult>`. Please use
+  /// @ref ReauthenticateAndRetrieveDataAsync(Credential) instead.
+  ///
+  /// Reauthenticate using a credential.
+  ///
+  /// Data from the Identity Provider used to sign-in is returned in the
+  /// AdditionalUserInfo inside the returned SignInResult.
+  ///
+  /// Returns an error if the existing credential is not for this user
+  /// or if sign-in with that credential failed.
+  ///
+  /// @note: The current user may be signed out if this operation fails on
+  /// Android and desktop platforms.
+  [System.Obsolete("Please use `Task<AuthResult> ReauthenticateAndRetrieveDataAsync(Credential)` instead", false)]
+  public System.Threading.Tasks.Task<SignInResult> ReauthenticateAndRetrieveDataAsync_DEPRECATED(
+      Credential credential) {
+    ThrowIfNull();
+    var taskCompletionSource =
+        new System.Threading.Tasks.TaskCompletionSource<SignInResult>();
+    ReauthenticateAndRetrieveDataInternalAsync_DEPRECATED(credential).ContinueWith(task => {
+        CompleteSignInResultTask(task, taskCompletionSource);
+      });
+    return taskCompletionSource.Task;
+  }
+
+  /// @deprecated This method is deprecated in favor of methods that return
+  /// `Task<AuthResult>`. Please use @ref UnlinkAsync(string) instead.
+  ///
+  /// Unlinks the current user from the provider specified.
+  /// Status will be an error if the user is not linked to the given provider.
+  [System.Obsolete("Please use `Task<AuthResult> UnlinkAsync(string)` instead", false)]
+  public System.Threading.Tasks.Task<FirebaseUser> UnlinkAsync_DEPRECATED(
+      string provider) {
+    ThrowIfNull();
+    var taskCompletionSource =
+        new System.Threading.Tasks.TaskCompletionSource<FirebaseUser>();
+    UnlinkInternalAsync_DEPRECATED(provider).ContinueWith(
+        task => {
+          if(authProxy != null) {
+            authProxy.CompleteFirebaseUserTask(task, taskCompletionSource);
+          } else {
+            // This should not happen. But if it does, throw exception and
+            // notify the team.
+            taskCompletionSource.TrySetException(new FirebaseException(0,
+                "Cannot complete 'UnlinkAsync_DEPRECATED()' " +
+                "because the authProxy is null."));
+          }
+        });
+    return taskCompletionSource.Task;
+  }
+
+  /// @deprecated This method is deprecated in favor of methods that return
+  /// `Task<AuthResult>`. Please use
+  /// @ref UpdatePhoneNumberCredentialAsync(PhoneAuthCredential) instead.
+  ///
+  /// Updates the currently linked phone number on the user.
+  /// This is useful when a user wants to change their phone number. It is a
+  /// shortcut to calling `UnlinkAsync_DEPRECATED(phoneCredential.Provider)`
+  /// and then `LinkWithCredentialAsync_DEPRECATED(phoneCredential)`.
+  /// `phoneCredential` must have been created with @ref PhoneAuthProvider.
+  [System.Obsolete("Please use `Task<AuthResult> UpdatePhoneNumberCredentialAsync(PhoneAuthCredential)` instead", false)]
+  public System.Threading.Tasks.Task<FirebaseUser> UpdatePhoneNumberCredentialAsync_DEPRECATED(
+      Credential credential) {
+    ThrowIfNull();
+    var taskCompletionSource =
+        new System.Threading.Tasks.TaskCompletionSource<FirebaseUser>();
+    UpdatePhoneNumberCredentialInternalAsync_DEPRECATED(credential).ContinueWith(
+        task => {
+          if(authProxy != null) {
+            authProxy.CompleteFirebaseUserTask(task, taskCompletionSource);
+          } else {
+            // This should not happen. But if it does, throw exception and
+            // notify the team.
+            taskCompletionSource.TrySetException(new FirebaseException(0,
+                "Cannot complete 'UpdatePhoneNumberCredentialAsync_DEPRECATED()' " +
+                "because the authProxy is null."));
+          }
+        });
     return taskCompletionSource.Task;
   }
 %}
@@ -1215,6 +1353,17 @@ static CppInstanceManager<Auth> g_auth_instances;
   firebase::auth::User::ReauthenticateWithProvider_DEPRECATED;
 %rename(LinkWithProviderInternalAsync_DEPRECATED)
   firebase::auth::User::LinkWithProvider_DEPRECATED;
+
+%rename(LinkAndRetrieveDataWithCredentialInternalAsync)
+  firebase::auth::User::LinkAndRetrieveDataWithCredential;
+%rename(LinkWithCredentialInternalAsync_DEPRECATED)
+  firebase::auth::User::LinkWithCredential_DEPRECATED;
+%rename(ReauthenticateAndRetrieveDataInternalAsync_DEPRECATED)
+  firebase::auth::User::ReauthenticateAndRetrieveData_DEPRECATED;
+%rename(UnlinkInternalAsync_DEPRECATED)
+  firebase::auth::User::Unlink_DEPRECATED;
+%rename(UpdatePhoneNumberCredentialInternalAsync_DEPRECATED)
+  firebase::auth::User::UpdatePhoneNumberCredential_DEPRECATED;
 
 // Rename token retrieval method.
 // NOTE: This is not a property as it is an asynchronous operation.
@@ -1293,7 +1442,9 @@ SWIG_MAP_CFUNC_TO_CSDELEGATE(::firebase::auth::AuthStateChangedDelegateFunc,
 // The classes should be sealed.
 %typemap(csclassmodifiers) firebase::auth::AdditionalUserInfo
   "public sealed class";
-%typemap(csclassmodifiers) firebase::auth::SignInResult "public sealed class";
+%typemap(csclassmodifiers) firebase::auth::SignInResult "
+  [System.Obsolete(\"Please use the Auth methods which return instances of `AuthResult` instead.\")]
+  public sealed class";
 // The classes are not meant to be publicly constructable.
 %ignore firebase::auth::AdditionalUserInfo::AdditionalUserInfo;
 %ignore firebase::auth::SignInResult::SignInResult;
@@ -1524,7 +1675,7 @@ TimeOutCallback PhoneAuthListenerImpl::g_time_out_callback = nullptr;
 }
 
 %typemap(cscode) firebase::auth::PhoneAuthProvider %{
-public delegate void VerificationCompletedDelegate(int callbackId, System.IntPtr credential);
+public delegate void VerificationCompletedDelegate_DEPRECATED(int callbackId, System.IntPtr credential);
 public delegate void VerificationFailedDelegate(int callbackId, string error);
 public delegate void CodeSentDelegate(int callbackId, string verificationId, System.IntPtr token);
 public delegate void TimeOutDelegate(int callbackId, string verificationId);
@@ -1533,7 +1684,7 @@ public delegate void TimeOutDelegate(int callbackId, string verificationId);
 // Map callback function types delegates.
 SWIG_MAP_CFUNC_TO_CSDELEGATE(
     ::firebase::auth::VerificationCompletedCallback,
-    Firebase.Auth.PhoneAuthProviderInternal.VerificationCompletedDelegate)
+    Firebase.Auth.PhoneAuthProviderInternal.VerificationCompletedDelegate_DEPRECATED)
 SWIG_MAP_CFUNC_TO_CSDELEGATE(
     ::firebase::auth::VerificationFailedCallback,
     Firebase.Auth.PhoneAuthProviderInternal.VerificationFailedDelegate)

--- a/auth/src/swig/auth.i
+++ b/auth/src/swig/auth.i
@@ -288,14 +288,14 @@ static CppInstanceManager<Auth> g_auth_instances;
     std::vector< std::string > * "StringList";
 
 // Don't expose UserInfoInterfaceList externally.
-%typemap(csclassmodifiers) std::vector<firebase::auth::UserInfoInterface*> "internal class"
-%template(UserInfoInterfaceList) std::vector<firebase::auth::UserInfoInterface*>;
+%typemap(csclassmodifiers) std::vector<firebase::auth::UserInfoInterface> "internal class"
+%template(UserInfoInterfaceList) std::vector<firebase::auth::UserInfoInterface>;
 // All outputs of UserInfoInterfaceList should be IEnumerable<IUserInfo>
 %typemap(cstype,
          out="global::System.Collections.Generic.IEnumerable<IUserInfo>")
-  std::vector<firebase::auth::UserInfoInterface*>&
+  std::vector<firebase::auth::UserInfoInterface>*
   "UserInfoInterfaceList";
-%typemap(csvarout) std::vector<firebase::auth::UserInfoInterface*>& %{
+%typemap(csvarout) std::vector<firebase::auth::UserInfoInterface>* %{
   get {
     // Convert the UserInfoInterfaceList into a List<IUserInfo>, as we don't
     // expose UserInfoInterface, which inherites from the public IUserInfo.
@@ -308,6 +308,13 @@ static CppInstanceManager<Auth> g_auth_instances;
     return newList;
   }
 %}
+
+%typemap(csclassmodifiers) firebase::auth::PhoneAuthOptions "public sealed class";
+%rename(ForceResendingToken) firebase::auth::PhoneAuthOptions::force_resending_token;
+%rename(PhoneNumber) firebase::auth::PhoneAuthOptions::phone_number;
+%rename(TimeoutInMilliseconds) firebase::auth::PhoneAuthOptions::timeout_milliseconds;
+// Ignore UIParent for now. Always use default Activity/UIView
+%ignore firebase::auth::PhoneAuthOptions::ui_parent;
 
 %SWIG_FUTURE(Future_User, FirebaseUser, internal, firebase::auth::User *,
              FirebaseException)
@@ -406,21 +413,20 @@ static CppInstanceManager<Auth> g_auth_instances;
 
 // The following methods need to be overridden to return a customized proxy to
 // each C++ object.
-%rename(SignInWithCustomTokenInternal)
-  firebase::auth::Auth::SignInWithCustomToken;
-%rename(SignInWithCredentialInternal)
-  firebase::auth::Auth::SignInWithCredential;
-%rename(SignInAndRetrieveDataWithCredentialInternal)
-  firebase::auth::Auth::SignInAndRetrieveDataWithCredential;
-%rename(SignInAnonymouslyInternal)
-  firebase::auth::Auth::SignInAnonymously;
-%rename(SignInWithEmailAndPasswordInternal)
-  firebase::auth::Auth::SignInWithEmailAndPassword;
-%rename(CreateUserWithEmailAndPasswordInternal)
-  firebase::auth::Auth::CreateUserWithEmailAndPassword;
-
-%rename(SignInWithProviderInternal)
-  firebase::auth::Auth::SignInWithProvider;
+%rename(SignInWithCustomTokenInternalAsync_DEPRECATED)
+  firebase::auth::Auth::SignInWithCustomToken_DEPRECATED;
+%rename(SignInWithCredentialInternalAsync_DEPRECATED)
+  firebase::auth::Auth::SignInWithCredential_DEPRECATED;
+%rename(SignInAndRetrieveDataWithCredentialInternalAsync_DEPRECATED)
+  firebase::auth::Auth::SignInAndRetrieveDataWithCredential_DEPRECATED;
+%rename(SignInAnonymouslyInternalAsync_DEPRECATED)
+  firebase::auth::Auth::SignInAnonymously_DEPRECATED;
+%rename(SignInWithEmailAndPasswordInternalAsync_DEPRECATED)
+  firebase::auth::Auth::SignInWithEmailAndPassword_DEPRECATED;
+%rename(CreateUserWithEmailAndPasswordInternalAsync_DEPRECATED)
+  firebase::auth::Auth::CreateUserWithEmailAndPassword_DEPRECATED;
+%rename(SignInWithProviderInternalAsync_DEPRECATED)
+  firebase::auth::Auth::SignInWithProvider_DEPRECATED;
 
 %extend firebase::auth::Auth {
   // Get a C++ instance and increment the reference count to it
@@ -476,12 +482,17 @@ static CppInstanceManager<Auth> g_auth_instances;
   /// @note: This operation is supported only on iOS, tvOS and Android
   /// platforms. On other platforms this method will return a Future with a
   /// preset error code: kAuthErrorUnimplemented.
-  public System.Threading.Tasks.Task<SignInResult> SignInWithProviderAsync(
+  ///
+  /// @deprecated This method is deprecated in favor of methods that return
+  /// `Task<AuthResult>`. Please use
+  /// `Task<AuthResult> SignInWithProviderAsync(FederatedAuthProvider)` instead.
+  [System.ObsoleteAttribute("Please use `Task<AuthResult> SignInWithProviderAsync(FederatedAuthProvider)` instead", false)]
+  public System.Threading.Tasks.Task<SignInResult> SignInWithProviderAsync_DEPRECATED(
       FederatedAuthProvider provider) {
     ThrowIfNull();
     var taskCompletionSource =
         new System.Threading.Tasks.TaskCompletionSource<SignInResult>();
-    SignInWithProviderInternalAsync(provider).ContinueWith(task => {
+    SignInWithProviderInternalAsync_DEPRECATED(provider).ContinueWith(task => {
         CompleteSignInResultTask(task, taskCompletionSource);
       });
     return taskCompletionSource.Task;
@@ -800,12 +811,17 @@ static CppInstanceManager<Auth> g_auth_instances;
   ///
   /// An error is returned, if the token is invalid, expired or otherwise
   /// not accepted by the server.
-  public System.Threading.Tasks.Task<FirebaseUser> SignInWithCustomTokenAsync(
+  ///
+  /// @deprecated This method is deprecated in favor of methods that return
+  /// `Task<AuthResult>`. Please use
+  /// `Task<AuthResult> SignInWithCustomTokenAsync(string)` instead.
+  [System.ObsoleteAttribute("Please use `Task<AuthResult> SignInWithCustomTokenAsync(string)` instead", false)]
+  public System.Threading.Tasks.Task<FirebaseUser> SignInWithCustomTokenAsync_DEPRECATED(
       string token) {
     ThrowIfNull();
     var taskCompletionSource =
         new System.Threading.Tasks.TaskCompletionSource<FirebaseUser>();
-    SignInWithCustomTokenInternalAsync(token).ContinueWith(task => {
+    SignInWithCustomTokenInternalAsync_DEPRECATED(token).ContinueWith(task => {
         CompleteFirebaseUserTask(task, taskCompletionSource);
       });
     return taskCompletionSource.Task;
@@ -815,12 +831,17 @@ static CppInstanceManager<Auth> g_auth_instances;
   ///
   /// An error is returned, if the token is invalid, expired or otherwise not
   /// accepted by the server.
-  public System.Threading.Tasks.Task<FirebaseUser> SignInWithCredentialAsync(
+  ///
+  /// @deprecated This method is deprecated in favor of methods that return
+  /// `Task<AuthResult>`. Please use
+  /// `Task<AuthResult> SignInWithCredentialAsync(Credential)` instead.
+  [System.ObsoleteAttribute("Please use `Task<AuthResult> SignInWithCredentialAsync(Credential)` instead", false)]
+  public System.Threading.Tasks.Task<FirebaseUser> SignInWithCredentialAsync_DEPRECATED(
       Credential credential) {
     ThrowIfNull();
     var taskCompletionSource =
         new System.Threading.Tasks.TaskCompletionSource<FirebaseUser>();
-    SignInWithCredentialInternalAsync(credential).ContinueWith(task => {
+    SignInWithCredentialInternalAsync_DEPRECATED(credential).ContinueWith(task => {
         CompleteFirebaseUserTask(task, taskCompletionSource);
       });
     return taskCompletionSource.Task;
@@ -837,12 +858,18 @@ static CppInstanceManager<Auth> g_auth_instances;
   ///
   /// An error is returned if the token is invalid, expired, or otherwise not
   /// accepted by the server.
+  ///
+  /// @deprecated This method is deprecated in favor of methods that return
+  /// `Task<AuthResult>`. Please use
+  /// `Task<AuthResult> SignInAndRetrieveDataWithCredentialAsync(Credential)`
+  /// instead.
+  [System.ObsoleteAttribute("Please use `Task<AuthResult> SignInAndRetrieveDataWithCredentialAsync(Credential)` instead", false)]
   public System.Threading.Tasks.Task<SignInResult>
-      SignInAndRetrieveDataWithCredentialAsync(Credential credential) {
+      SignInAndRetrieveDataWithCredentialAsync_DEPRECATED(Credential credential) {
     ThrowIfNull();
     var taskCompletionSource =
         new System.Threading.Tasks.TaskCompletionSource<SignInResult>();
-    SignInAndRetrieveDataWithCredentialInternalAsync(credential).ContinueWith(
+    SignInAndRetrieveDataWithCredentialInternalAsync_DEPRECATED(credential).ContinueWith(
         task => { CompleteSignInResultTask(task, taskCompletionSource); });
     return taskCompletionSource.Task;
   }
@@ -868,11 +895,16 @@ static CppInstanceManager<Auth> g_auth_instances;
   ///    });
   ///  }
   /// @endcode
-  public System.Threading.Tasks.Task<FirebaseUser> SignInAnonymouslyAsync() {
+  ///
+  /// @deprecated This method is deprecated in favor of methods that return
+  /// `Task<AuthResult>`. Please use
+  /// `Task<AuthResult> SignInAnonymouslyAsync()` instead.
+  [System.ObsoleteAttribute("Please use `Task<AuthResult> SignInAnonymouslyAsync()` instead", false)]
+  public System.Threading.Tasks.Task<FirebaseUser> SignInAnonymouslyAsync_DEPRECATED() {
     ThrowIfNull();
     var taskCompletionSource =
         new System.Threading.Tasks.TaskCompletionSource<FirebaseUser>();
-    SignInAnonymouslyInternalAsync().ContinueWith(task => {
+    SignInAnonymouslyInternalAsync_DEPRECATED().ContinueWith(task => {
         CompleteFirebaseUserTask(task, taskCompletionSource);
       });
     return taskCompletionSource.Task;
@@ -881,12 +913,17 @@ static CppInstanceManager<Auth> g_auth_instances;
   /// Signs in using provided email address and password.
   /// An error is returned if the password is wrong or otherwise not accepted
   /// by the server.
-  public System.Threading.Tasks.Task<FirebaseUser> SignInWithEmailAndPasswordAsync(
+  ///
+  /// @deprecated This method is deprecated in favor of methods that return
+  /// `Task<AuthResult>`. Please use `Task<AuthResult> SignInAnonymouslyAsync()`
+  /// instead.
+  [System.ObsoleteAttribute("Please use `Task<AuthResult> SignInWithEmailAndPasswordAsync(string, string)` instead", false)]
+  public System.Threading.Tasks.Task<FirebaseUser> SignInWithEmailAndPasswordAsync_DEPRECATED(
       string email, string password) {
     ThrowIfNull();
     var taskCompletionSource =
         new System.Threading.Tasks.TaskCompletionSource<FirebaseUser>();
-    SignInWithEmailAndPasswordInternalAsync(email, password).ContinueWith(
+    SignInWithEmailAndPasswordInternalAsync_DEPRECATED(email, password).ContinueWith(
         task => {
           CompleteFirebaseUserTask(task, taskCompletionSource);
         });
@@ -898,12 +935,18 @@ static CppInstanceManager<Auth> g_auth_instances;
   ///
   /// An error is returned when account creation is unsuccessful
   /// (due to another existing account, invalid password, etc.).
+  ///
+  /// @deprecated This method is deprecated in favor of methods that return
+  /// `Task<AuthResult>`. Please use
+  /// `Task<AuthResult> CreateUserWithEmailAndPasswordAsync(string, string)`
+  /// instead.
+  [System.ObsoleteAttribute("Please use `Task<AuthResult> CreateUserWithEmailAndPasswordAsync(string, string)` instead", false)]
   public System.Threading.Tasks.Task<FirebaseUser>
-      CreateUserWithEmailAndPasswordAsync(string email, string password) {
+      CreateUserWithEmailAndPasswordAsync_DEPRECATED(string email, string password) {
     ThrowIfNull();
     var taskCompletionSource =
         new System.Threading.Tasks.TaskCompletionSource<FirebaseUser>();
-    CreateUserWithEmailAndPasswordInternalAsync(email, password).ContinueWith(
+    CreateUserWithEmailAndPasswordInternalAsync_DEPRECATED(email, password).ContinueWith(
         task => {
           CompleteFirebaseUserTask(task, taskCompletionSource);
         });
@@ -975,7 +1018,8 @@ static CppInstanceManager<Auth> g_auth_instances;
 
 %typemap(csclassmodifiers) firebase::auth::User::UserProfile
   "public sealed class";
-%typemap(csclassmodifiers) firebase::auth::Credential "public sealed class";
+%typemap(csclassmodifiers) firebase::auth::Credential "public class";
+%typemap(csclassmodifiers) firebase::auth::PhoneAuthCredential "public sealed class";
 
 %typemap(csclassmodifiers) firebase::auth::FederatedAuthProvider "public class";
 
@@ -1090,12 +1134,18 @@ static CppInstanceManager<Auth> g_auth_instances;
   /// @note: This operation is supported only on iOS, tvOS and Android
   /// platforms. On other platforms this method will return a Future with a
   /// preset error code: kAuthErrorUnimplemented.
+  ///
+  /// @deprecated This method is deprecated in favor of methods that return
+  /// `Task<AuthResult>`. Please use
+  /// `Task<AuthResult> ReauthenticateWithProviderAsync(FederatedAuthProvider)`
+  /// instead.
+  [System.ObsoleteAttribute("Please use `Task<AuthResult> ReauthenticateWithProviderAsync(FederatedAuthProvider)` instead", false)]
   public System.Threading.Tasks.Task<SignInResult>
-      ReauthenticateWithProviderAsync(FederatedAuthProvider provider) {
+      ReauthenticateWithProviderAsync_DEPRECATED(FederatedAuthProvider provider) {
     ThrowIfNull();
     var taskCompletionSource =
         new System.Threading.Tasks.TaskCompletionSource<SignInResult>();
-    ReauthenticateWithProviderInternalAsync(provider).ContinueWith(task => {
+    ReauthenticateWithProviderInternalAsync_DEPRECATED(provider).ContinueWith(task => {
         CompleteSignInResultTask(task, taskCompletionSource);
       });
     return taskCompletionSource.Task;
@@ -1113,12 +1163,18 @@ static CppInstanceManager<Auth> g_auth_instances;
   /// @note: This operation is supported only on iOS, tvOS and Android
   /// platforms. On other platforms this method will return a Future with a
   /// preset error code: kAuthErrorUnimplemented.
-  public System.Threading.Tasks.Task<SignInResult> LinkWithProviderAsync(
+  ///
+  /// @deprecated This method is deprecated in favor of methods that return
+  /// `Task<AuthResult>`. Please use
+  /// `Task<AuthResult> LinkWithProviderAsync(FederatedAuthProvider)`
+  /// instead.
+  [System.ObsoleteAttribute("Please use `Task<AuthResult> LinkWithProviderAsync(FederatedAuthProvider)` instead", false)]
+  public System.Threading.Tasks.Task<SignInResult> LinkWithProviderAsync_DEPRECATED(
       FederatedAuthProvider provider) {
     ThrowIfNull();
     var taskCompletionSource =
         new System.Threading.Tasks.TaskCompletionSource<SignInResult>();
-    LinkWithProviderInternalAsync(provider).ContinueWith(task => {
+    LinkWithProviderInternalAsync_DEPRECATED(provider).ContinueWith(task => {
         CompleteSignInResultTask(task, taskCompletionSource);
       });
     return taskCompletionSource.Task;
@@ -1155,10 +1211,10 @@ static CppInstanceManager<Auth> g_auth_instances;
   %}
 
 // Rename User Federated Auth methods
-%rename(ReauthenticateWithProviderInternal)
-  firebase::auth::User::ReauthenticateWithProvider;
-%rename(LinkWithProviderInternal)
-  firebase::auth::User::LinkWithProvider;
+%rename(ReauthenticateWithProviderInternalAsync_DEPRECATED)
+  firebase::auth::User::ReauthenticateWithProvider_DEPRECATED;
+%rename(LinkWithProviderInternalAsync_DEPRECATED)
+  firebase::auth::User::LinkWithProvider_DEPRECATED;
 
 // Rename token retrieval method.
 // NOTE: This is not a property as it is an asynchronous operation.
@@ -1192,8 +1248,8 @@ static CppInstanceManager<Auth> g_auth_instances;
 // Deprecated method that conflicts with the CurrentUser property.
 %ignore firebase::auth::Auth::CurrentUser;
 // Make basic getters use C# Properties instead.
-%attribute(firebase::auth::Auth, firebase::auth::User *,
-           CurrentUserInternal, current_user);
+%attributeval(firebase::auth::Auth, firebase::auth::User,
+              CurrentUserInternal, current_user);
 
 %attributestring(firebase::auth::Credential, std::string, Provider, provider);
 
@@ -1205,8 +1261,8 @@ static CppInstanceManager<Auth> g_auth_instances;
 %attributeval(firebase::auth::User, firebase::auth::UserMetadata, Metadata, metadata);
 %attributestring(firebase::auth::User, std::string, PhoneNumber, phone_number);
 %attributestring(firebase::auth::User, std::string, PhotoUrlInternal, photo_url);
-%attribute(firebase::auth::User,
-  std::vector<firebase::auth::UserInfoInterface*>&, ProviderData, provider_data);
+%attributeval(firebase::auth::User,
+  std::vector<firebase::auth::UserInfoInterface>, ProviderData, provider_data);
 %attributestring(firebase::auth::User, std::string, ProviderId, provider_id);
 %attributestring(firebase::auth::User, std::string, UserId, uid);
 
@@ -1317,11 +1373,24 @@ class PhoneAuthListenerImpl
   virtual ~PhoneAuthListenerImpl() {}
 
   virtual void OnVerificationCompleted(Credential credential) {
+    // Both `OnVerificationCompleted(Credential) and
+    // OnVerificationCompleted(PhoneAuthCredential) will be triggered. We
+    // support both delegates but the user needs to choose to use only one of
+    // them.
     if (g_verification_completed_callback) {
       firebase::callback::AddCallback(
           new firebase::callback::CallbackValue2<int, Credential>(
               callback_id_, credential, VerificationCompleted));
     }
+  }
+
+  virtual void OnVerificationCompleted(PhoneAuthCredential credential) {
+    // Both `OnVerificationCompleted(Credential) and
+    // OnVerificationCompleted(PhoneAuthCredential) will be triggered. We
+    // support both delegates but the user needs to choose to use only one of
+    // them.
+
+    // TODO(IO2023): Add hooks to new PhoneAuthCredential. Need new delegates.
   }
 
   virtual void OnVerificationFailed(const std::string& error) {

--- a/auth/testapp/Assets/Firebase/Sample/Auth/UIHandler.cs
+++ b/auth/testapp/Assets/Firebase/Sample/Auth/UIHandler.cs
@@ -271,7 +271,7 @@ namespace Firebase.Sample.Auth {
     }
 
     // Create a user with the email and password.
-    public Task CreateUserWithEmailAsync() {
+    public Task CreateUserWithEmailAsync_DEPRECATED() {
       DebugLog(String.Format("Attempting to create user {0}...", email));
       DisableUI();
 
@@ -279,7 +279,7 @@ namespace Firebase.Sample.Auth {
       // so that it can be passed to UpdateUserProfile().  displayName will be
       // reset by AuthStateChanged() when the new user is created and signed in.
       string newDisplayName = displayName;
-      return auth.CreateUserWithEmailAndPasswordAsync(email, password)
+      return auth.CreateUserWithEmailAndPasswordAsync_DEPRECATED(email, password)
         .ContinueWithOnMainThread((task) => {
           EnableUI();
           if (LogTaskCompletion(task, "User Creation")) {
@@ -312,15 +312,15 @@ namespace Firebase.Sample.Auth {
     }
 
     // Sign-in with an email and password.
-    public Task SigninWithEmailAsync() {
+    public Task SigninWithEmailAsync_DEPRECATED() {
       DebugLog(String.Format("Attempting to sign in as {0}...", email));
       DisableUI();
       if (signInAndFetchProfile) {
-        return auth.SignInAndRetrieveDataWithCredentialAsync(
+        return auth.SignInAndRetrieveDataWithCredentialAsync_DEPRECATED(
           Firebase.Auth.EmailAuthProvider.GetCredential(email, password)).ContinueWithOnMainThread(
             HandleSignInWithSignInResult);
       } else {
-        return auth.SignInWithEmailAndPasswordAsync(email, password)
+        return auth.SignInWithEmailAndPasswordAsync_DEPRECATED(email, password)
           .ContinueWithOnMainThread(HandleSignInWithUser);
       }
     }
@@ -328,25 +328,25 @@ namespace Firebase.Sample.Auth {
     // This is functionally equivalent to the Signin() function.  However, it
     // illustrates the use of Credentials, which can be aquired from many
     // different sources of authentication.
-    public Task SigninWithEmailCredentialAsync() {
+    public Task SigninWithEmailCredentialAsync_DEPRECATED() {
       DebugLog(String.Format("Attempting to sign in as {0}...", email));
       DisableUI();
       if (signInAndFetchProfile) {
-        return auth.SignInAndRetrieveDataWithCredentialAsync(
+        return auth.SignInAndRetrieveDataWithCredentialAsync_DEPRECATED(
           Firebase.Auth.EmailAuthProvider.GetCredential(email, password)).ContinueWithOnMainThread(
             HandleSignInWithSignInResult);
       } else {
-        return auth.SignInWithCredentialAsync(
+        return auth.SignInWithCredentialAsync_DEPRECATED(
           Firebase.Auth.EmailAuthProvider.GetCredential(email, password)).ContinueWithOnMainThread(
             HandleSignInWithUser);
       }
     }
 
     // Attempt to sign in anonymously.
-    public Task SigninAnonymouslyAsync() {
+    public Task SigninAnonymouslyAsync_DEPRECATED() {
       DebugLog("Attempting to sign anonymously...");
       DisableUI();
-      return auth.SignInAnonymouslyAsync().ContinueWithOnMainThread(HandleSignInWithUser);
+      return auth.SignInAnonymouslyAsync_DEPRECATED().ContinueWithOnMainThread(HandleSignInWithUser);
     }
 
     public void AuthenticateToGameCenter() {
@@ -359,7 +359,7 @@ namespace Firebase.Sample.Auth {
       #endif
     }
 
-    public Task SignInWithGameCenterAsync() {
+    public Task SignInWithGameCenterAsync_DEPRECATED() {
       var credentialTask = Firebase.Auth.GameCenterAuthProvider.GetCredentialAsync();
       var continueTask = credentialTask.ContinueWithOnMainThread(task => {
         if(!task.IsCompleted)
@@ -370,7 +370,7 @@ namespace Firebase.Sample.Auth {
 
         var credential = task.Result;
 
-        var loginTask = auth.SignInWithCredentialAsync(credential);
+        var loginTask = auth.SignInWithCredentialAsync_DEPRECATED(credential);
         return loginTask.ContinueWithOnMainThread(HandleSignInWithUser);
       });
 
@@ -394,7 +394,7 @@ namespace Firebase.Sample.Auth {
     }
 
     // Link the current user with an email / password credential.
-    protected Task LinkWithEmailCredentialAsync() {
+    protected Task LinkWithEmailCredentialAsync_DEPRECATED() {
       if (auth.CurrentUser == null) {
         DebugLog("Not signed in, unable to link credential to user.");
         var tcs = new TaskCompletionSource<bool>();
@@ -414,7 +414,7 @@ namespace Firebase.Sample.Auth {
             }
           );
       } else {
-        return auth.CurrentUser.LinkWithCredentialAsync(cred).ContinueWithOnMainThread(task => {
+        return auth.CurrentUser.LinkWithCredentialAsync_DEPRECATED(cred).ContinueWithOnMainThread(task => {
           if (LogTaskCompletion(task, "Link Credential")) {
               DisplayDetailedUserInfo(task.Result, 1);
           }
@@ -423,7 +423,7 @@ namespace Firebase.Sample.Auth {
     }
 
     // Reauthenticate the user with the current email / password.
-    protected Task ReauthenticateAsync() {
+    protected Task ReauthenticateAsync_DEPRECATED() {
       var user = auth.CurrentUser;
       if (user == null) {
         DebugLog("Not signed in, unable to reauthenticate user.");
@@ -435,7 +435,7 @@ namespace Firebase.Sample.Auth {
       DisableUI();
       Firebase.Auth.Credential cred = Firebase.Auth.EmailAuthProvider.GetCredential(email, password);
       if (signInAndFetchProfile) {
-        return user.ReauthenticateAndRetrieveDataAsync(cred).ContinueWithOnMainThread(task => {
+        return user.ReauthenticateAndRetrieveDataAsync_DEPRECATED(cred).ContinueWithOnMainThread(task => {
           EnableUI();
           if (LogTaskCompletion(task, "Reauthentication")) {
             DisplaySignInResult(task.Result, 1);
@@ -492,7 +492,7 @@ namespace Firebase.Sample.Auth {
     }
 
     // Unlink the email credential from the currently logged in user.
-    protected Task UnlinkEmailAsync() {
+    protected Task UnlinkEmailAsync_DEPRECATED() {
       if (auth.CurrentUser == null) {
         DebugLog("Not signed in, unable to unlink");
         var tcs = new TaskCompletionSource<bool>();
@@ -501,7 +501,7 @@ namespace Firebase.Sample.Auth {
       }
       DebugLog("Unlinking email credential");
       DisableUI();
-      return auth.CurrentUser.UnlinkAsync(
+      return auth.CurrentUser.UnlinkAsync_DEPRECATED(
         Firebase.Auth.EmailAuthProvider.GetCredential(email, password).Provider)
           .ContinueWithOnMainThread(task => {
             EnableUI();
@@ -574,9 +574,9 @@ namespace Firebase.Sample.Auth {
 
       return  new Firebase.Auth.FederatedOAuthProvider(data);
     }
-    protected void SignInWithProvider(string providerId) {
+    protected void SignInWithProvider_DEPRECATED(string providerId) {
       Firebase.Auth.FederatedOAuthProvider provider = BuildFederatedOAuthProvider(providerId);
-      auth.SignInWithProviderAsync(provider).ContinueWithOnMainThread(signin_task => {
+      auth.SignInWithProviderAsync_DEPRECATED(provider).ContinueWithOnMainThread(signin_task => {
           if (LogTaskCompletion(signin_task, "SignInWithProvider")) {
             DebugLog("SignInWithProviderTask Completed:" + signin_task.IsCompleted);
           }
@@ -589,7 +589,7 @@ namespace Firebase.Sample.Auth {
       });
     }
 
-    protected void ReauthenticateWithProvider(string providerId) {
+    protected void ReauthenticateWithProvider_DEPRECATED(string providerId) {
       if(auth.CurrentUser == null) {
         DebugLog("Login with user before re-authenticating");
         return;
@@ -597,7 +597,7 @@ namespace Firebase.Sample.Auth {
 
       Firebase.Auth.FederatedOAuthProvider provider = BuildFederatedOAuthProvider(providerId);
 
-      auth.CurrentUser.ReauthenticateWithProviderAsync(provider).ContinueWithOnMainThread(task => {
+      auth.CurrentUser.ReauthenticateWithProviderAsync_DEPRECATED(provider).ContinueWithOnMainThread(task => {
         if (LogTaskCompletion(task, "ReauthenticateWithProvider")) {
           DebugLog("ReauthenticateWithProvider Completed:" + task.IsCompleted);
         }
@@ -609,14 +609,14 @@ namespace Firebase.Sample.Auth {
       });
     }
 
-    protected void LinkWithProvider(string providerId) {
+    protected void LinkWithProvider_DEPRECATED(string providerId) {
       if(auth.CurrentUser == null) {
         DebugLog("Login with user before linking.");
         return;
       }
 
       Firebase.Auth.FederatedOAuthProvider provider = BuildFederatedOAuthProvider(providerId);
-      auth.CurrentUser.LinkWithProviderAsync(provider).ContinueWithOnMainThread(task => {
+      auth.CurrentUser.LinkWithProviderAsync_DEPRECATED(provider).ContinueWithOnMainThread(task => {
         if (LogTaskCompletion(task, "LinkWithProvider")) {
           DebugLog("LinkWithProvider Completed:" + task.IsCompleted);
         }
@@ -628,7 +628,7 @@ namespace Firebase.Sample.Auth {
       });
     }
 
-    protected void UnlinkUser(string providerId) {
+    protected void UnlinkUser_DEPRECATED(string providerId) {
       if(auth.CurrentUser == null) {
         DebugLog("Login with user before un-linking.");
         return;
@@ -637,7 +637,7 @@ namespace Firebase.Sample.Auth {
       if (auth.CurrentUser != null) {
         DebugLog("Attempting to ulink user from provider: " + providerId);
         DisableUI();
-        auth.CurrentUser.UnlinkAsync(providerId).ContinueWithOnMainThread( task => {
+        auth.CurrentUser.UnlinkAsync_DEPRECATED(providerId).ContinueWithOnMainThread( task => {
           EnableUI();
           DebugLog("Unlink Complete");
         });
@@ -647,16 +647,16 @@ namespace Firebase.Sample.Auth {
     }
 
     // Begin authentication with the phone number.
-    protected void VerifyPhoneNumber() {
+    protected void VerifyPhoneNumber_DEPRECATED() {
       var phoneAuthProvider = Firebase.Auth.PhoneAuthProvider.GetInstance(auth);
       phoneAuthProvider.VerifyPhoneNumber(phoneNumber, phoneAuthTimeoutMs, null,
         verificationCompleted: (cred) => {
           DebugLog("Phone Auth, auto-verification completed");
           if (signInAndFetchProfile) {
-            auth.SignInAndRetrieveDataWithCredentialAsync(cred).ContinueWithOnMainThread(
+            auth.SignInAndRetrieveDataWithCredentialAsync_DEPRECATED(cred).ContinueWithOnMainThread(
               HandleSignInWithSignInResult);
           } else {
-            auth.SignInWithCredentialAsync(cred).ContinueWithOnMainThread(HandleSignInWithUser);
+            auth.SignInWithCredentialAsync_DEPRECATED(cred).ContinueWithOnMainThread(HandleSignInWithUser);
           }
         },
         verificationFailed: (error) => {
@@ -672,15 +672,15 @@ namespace Firebase.Sample.Auth {
     }
 
     // Sign in using phone number authentication using code input by the user.
-    protected void VerifyReceivedPhoneCode() {
+    protected void VerifyReceivedPhoneCode_DEPRECATED() {
       var phoneAuthProvider = Firebase.Auth.PhoneAuthProvider.GetInstance(auth);
       // receivedCode should have been input by the user.
-      var cred = phoneAuthProvider.GetCredential(phoneAuthVerificationId, receivedCode);
+      var cred = phoneAuthProvider.GetCredential_DEPRECATED(phoneAuthVerificationId, receivedCode);
       if (signInAndFetchProfile) {
-        auth.SignInAndRetrieveDataWithCredentialAsync(cred).ContinueWithOnMainThread(
+        auth.SignInAndRetrieveDataWithCredentialAsync_DEPRECATED(cred).ContinueWithOnMainThread(
           HandleSignInWithSignInResult);
       } else {
-        auth.SignInWithCredentialAsync(cred).ContinueWithOnMainThread(HandleSignInWithUser);
+        auth.SignInWithCredentialAsync_DEPRECATED(cred).ContinueWithOnMainThread(HandleSignInWithUser);
       }
     }
 
@@ -718,7 +718,7 @@ namespace Firebase.Sample.Auth {
             tooltip = "No Game Center player authenticated.";
           }
           if (GUILayout.Button(new GUIContent("Sign In With Game Center", tooltip))) {
-            SignInWithGameCenterAsync();
+            SignInWithGameCenterAsync_DEPRECATED();
           }
         }
       }
@@ -774,22 +774,22 @@ namespace Firebase.Sample.Auth {
         GUILayout.Space(20);
 
         if (GUILayout.Button("Create User")) {
-          CreateUserWithEmailAsync();
+          CreateUserWithEmailAsync_DEPRECATED();
         }
         if (GUILayout.Button("Sign In Anonymously")) {
-          SigninAnonymouslyAsync();
+          SigninAnonymouslyAsync_DEPRECATED();
         }
         if (GUILayout.Button("Sign In With Email")) {
-          SigninWithEmailAsync();
+          SigninWithEmailAsync_DEPRECATED();
         }
         if (GUILayout.Button("Sign In With Email Credential")) {
-          SigninWithEmailCredentialAsync();
+          SigninWithEmailCredentialAsync_DEPRECATED();
         }
         if (GUILayout.Button("Link With Email Credential")) {
-          LinkWithEmailCredentialAsync();
+          LinkWithEmailCredentialAsync_DEPRECATED();
         }
         if (GUILayout.Button("Reauthenticate with Email")) {
-          ReauthenticateAsync();
+          ReauthenticateAsync_DEPRECATED();
         }
         GUIDisplayGameCenterControls();
         if (GUILayout.Button("Reload User")) {
@@ -802,7 +802,7 @@ namespace Firebase.Sample.Auth {
           GetUserInfo();
         }
         if (GUILayout.Button("Unlink Email Credential")) {
-          UnlinkEmailAsync();
+          UnlinkEmailAsync_DEPRECATED();
         }
         if (GUILayout.Button("Sign Out")) {
           SignOut();
@@ -817,10 +817,10 @@ namespace Firebase.Sample.Auth {
           SendPasswordResetEmail();
         }
         if (GUILayout.Button("Authenticate Phone Number")) {
-          VerifyPhoneNumber();
+          VerifyPhoneNumber_DEPRECATED();
         }
         if (GUILayout.Button("Verify Received Phone Code")) {
-          VerifyReceivedPhoneCode();
+          VerifyReceivedPhoneCode_DEPRECATED();
         }
         if (GUILayout.Button(String.Format("Fetch Profile on Sign-in {0}",
                                             signInAndFetchProfile ?
@@ -878,28 +878,28 @@ namespace Firebase.Sample.Auth {
 
         GUILayout.Space(20);
         if (GUILayout.Button("SignInWith | Microsoft")) {
-          SignInWithProvider(Firebase.Auth.MicrosoftAuthProvider.ProviderId);
+          SignInWithProvider_DEPRECATED(Firebase.Auth.MicrosoftAuthProvider.ProviderId);
         }
         if (GUILayout.Button("SignInWith | Yahoo")) {
-          SignInWithProvider(Firebase.Auth.YahooAuthProvider.ProviderId);
+          SignInWithProvider_DEPRECATED(Firebase.Auth.YahooAuthProvider.ProviderId);
         }
         if (GUILayout.Button("ReauthWith | Microsoft")) {
-          ReauthenticateWithProvider(Firebase.Auth.MicrosoftAuthProvider.ProviderId);
+          ReauthenticateWithProvider_DEPRECATED(Firebase.Auth.MicrosoftAuthProvider.ProviderId);
         }
         if (GUILayout.Button("ReauthWith | Yahoo")) {
-          ReauthenticateWithProvider(Firebase.Auth.YahooAuthProvider.ProviderId);
+          ReauthenticateWithProvider_DEPRECATED(Firebase.Auth.YahooAuthProvider.ProviderId);
         }
         if (GUILayout.Button("LinkWith | Microsoft")) {
-          LinkWithProvider(Firebase.Auth.MicrosoftAuthProvider.ProviderId);
+          LinkWithProvider_DEPRECATED(Firebase.Auth.MicrosoftAuthProvider.ProviderId);
         }
         if (GUILayout.Button("LinkWith | Yahoo")) {
-          LinkWithProvider(Firebase.Auth.YahooAuthProvider.ProviderId);
+          LinkWithProvider_DEPRECATED(Firebase.Auth.YahooAuthProvider.ProviderId);
         }
         if (GUILayout.Button("Unlink User | Microsoft")) {
-          UnlinkUser(Firebase.Auth.MicrosoftAuthProvider.ProviderId);
+          UnlinkUser_DEPRECATED(Firebase.Auth.MicrosoftAuthProvider.ProviderId);
         }
         if (GUILayout.Button("Unlink User | Yahoo")) {
-          UnlinkUser(Firebase.Auth.YahooAuthProvider.ProviderId);
+          UnlinkUser_DEPRECATED(Firebase.Auth.YahooAuthProvider.ProviderId);
         }
 
         GUIDisplayCustomControls();

--- a/auth/testapp/Assets/Firebase/Sample/Auth/UIHandlerAutomated.cs
+++ b/auth/testapp/Assets/Firebase/Sample/Auth/UIHandlerAutomated.cs
@@ -35,10 +35,10 @@ namespace Firebase.Sample.Auth {
       // non-static.
       Func<Task>[] tests = {
         TestCreateDestroy,
-        TestSignInAnonymouslyAsync,
-        TestSignInEmailAsync,
-        TestSignInCredentialAsync,
-        TestUpdateUserProfileAsync,
+        TestSignInAnonymouslyAsync_DEPRECATED,
+        TestSignInEmailAsync_DEPRECATED,
+        TestSignInCredentialAsync_DEPRECATED,
+        TestUpdateUserProfileAsync_DEPRECATED,
         // TODO(b/132083720) This test is currently broken, so disable it until it is fixed.
         // TestSignInAnonymouslyWithExceptionsInEventHandlersAsync,
       };
@@ -210,7 +210,7 @@ namespace Firebase.Sample.Auth {
 
     // Perform the standard sign in flow with an Anonymous account.
     // Tests: SignInAnonymouslyAsync, DeleteUserAsync.
-    Task TestSignInAnonymouslyAsync() {
+    Task TestSignInAnonymouslyAsync_DEPRECATED() {
       TaskCompletionSource<int> tcs = new TaskCompletionSource<int>();
 
       // We don't want to be signed in at the start of this test.
@@ -219,7 +219,7 @@ namespace Firebase.Sample.Auth {
       }
 
       // First, sign in anonymously.
-      SigninAnonymouslyAsync().ContinueWithOnMainThread(t1 => {
+      SigninAnonymouslyAsync_DEPRECATED().ContinueWithOnMainThread(t1 => {
         if (ForwardTaskException(tcs, t1)) return;
         // Confirm that the current user is correct.
         if (!ConfirmAnonymousCurrentUser(tcs)) return;
@@ -240,7 +240,7 @@ namespace Firebase.Sample.Auth {
     // Goes over the standard create/signout/signin flow, using the provided function to sign in.
     // Tests: CreateUserWithEmailAndPasswordAsync, SignOut, the given signin function,
     // and DeleteUserAsync.
-    Task TestSignInFlowAsync(Func<Task> signInFunc) {
+    Task TestSignInFlowAsync_DEPRECATED(Func<Task> signInFunc) {
       TaskCompletionSource<int> tcs = new TaskCompletionSource<int>();
 
       // We don't want to be signed in at the start of this test.
@@ -251,7 +251,7 @@ namespace Firebase.Sample.Auth {
       // Set up the test email/password/etc fields.
       SetDefaultUIFields();
 
-      CreateUserWithEmailAsync().ContinueWithOnMainThread(createTask => {
+      CreateUserWithEmailAsync_DEPRECATED().ContinueWithOnMainThread(createTask => {
         // Confirm that the current user is correct
         if (!ConfirmDefaultCurrentUser(tcs)) return;
         // Sign out of the user
@@ -277,20 +277,20 @@ namespace Firebase.Sample.Auth {
 
     // Perform the standard sign in flow, using Email/Password.
     // Tests: SignInWithEmailAndPasswordAsync.
-    Task TestSignInEmailAsync() {
-      return TestSignInFlowAsync(SigninWithEmailAsync);
+    Task TestSignInEmailAsync_DEPRECATED() {
+      return TestSignInFlowAsync_DEPRECATED(SigninWithEmailAsync_DEPRECATED);
     }
 
     // Perform the standard sign in flow, using a credential generated from the Email/Password.
     // Tests: SignInWithCredentialAsync (Email credential).
-    Task TestSignInCredentialAsync() {
-      return TestSignInFlowAsync(SigninWithEmailCredentialAsync);
+    Task TestSignInCredentialAsync_DEPRECATED() {
+      return TestSignInFlowAsync_DEPRECATED(SigninWithEmailCredentialAsync_DEPRECATED);
     }
 
     // Update the user profile.
-    Task TestUpdateUserProfileAsync() {
+    Task TestUpdateUserProfileAsync_DEPRECATED() {
       TaskCompletionSource<bool> tcs = new TaskCompletionSource<bool>();
-      SigninAnonymouslyAsync().ContinueWithOnMainThread(t1 => {
+      SigninAnonymouslyAsync_DEPRECATED().ContinueWithOnMainThread(t1 => {
         if (ForwardTaskException(tcs, t1)) return;
         const string ExpectedDisplayName = "Test Name";
         const string ExpectedPhotoUrl = "http://test.com/image.jpg";
@@ -318,7 +318,7 @@ namespace Firebase.Sample.Auth {
 
     // Anonymous sign-in with exceptions being thrown by auth state and token event handlers.
     // The sign-in process should continue uninterrupted.
-    Task TestSignInAnonymouslyWithExceptionsInEventHandlersAsync() {
+    Task TestSignInAnonymouslyWithExceptionsInEventHandlersAsync_DEPRECATED() {
       SignOut();
 
       var exceptions = new List<Exception>();
@@ -336,7 +336,7 @@ namespace Firebase.Sample.Auth {
       auth.StateChanged += stateChangedThrowException;
       auth.IdTokenChanged += idTokenChangedThrowException;
 
-      SigninAnonymouslyAsync().ContinueWithOnMainThread(t => {
+      SigninAnonymouslyAsync_DEPRECATED().ContinueWithOnMainThread(t => {
           auth.StateChanged -= stateChangedThrowException;
           auth.IdTokenChanged -= idTokenChangedThrowException;
           var exceptionMessages = new HashSet<string>();

--- a/firestore/testapp/Assets/Firebase/Sample/Firestore/UIHandlerAutomated.cs
+++ b/firestore/testapp/Assets/Firebase/Sample/Firestore/UIHandlerAutomated.cs
@@ -1800,7 +1800,7 @@ namespace Firebase.Sample.Firestore {
         // TODO(mikelehen): Check for permission_denied once we plumb errors through somehow.
         AssertException(typeof(Exception), () => Await(doc.SetAsync(data)));
 
-        Await(firebaseAuth.SignInAnonymouslyAsync());
+        Await(firebaseAuth.SignInAnonymouslyAsync_DEPRECATED());
 
         // Write should now succeed.
         Await(doc.SetAsync(data));
@@ -3577,7 +3577,7 @@ namespace Firebase.Sample.Firestore {
         AssertNe(query6.GetHashCode(), query7.GetHashCode());
       });
     }
-    
+
     Task TestAggregateQueryEqualsAndGetHashCode() {
       return Async(() => {
         var collection = TestCollection();
@@ -4035,7 +4035,7 @@ namespace Firebase.Sample.Firestore {
       for (int i = 0; i < snapshot.Count; i++) {
         AssertEq(desc + ": Document ID " + i, docIds[i], snapshot[i].Id);
       }
-      
+
       var aggregateSnapshot = Await(query.Count.GetSnapshotAsync(AggregateSource.Server));
       AssertEq(desc + ": Aggregate query count", aggregateSnapshot.Count, docIds.Count);
     }

--- a/firestore/testapp/Assets/Tests/FirestoreInstanceTests.cs
+++ b/firestore/testapp/Assets/Tests/FirestoreInstanceTests.cs
@@ -37,7 +37,7 @@ namespace Tests {
       AssertTaskFaulted(setTask, FirestoreError.PermissionDenied);
 
       try {
-        yield return AwaitSuccess(firebaseAuth.SignInAnonymouslyAsync());
+        yield return AwaitSuccess(firebaseAuth.SignInAnonymouslyAsync_DEPRECATED());
 
         // Write should now succeed.
         yield return AwaitSuccess(doc.SetAsync(data));

--- a/functions/testapp/Assets/Firebase/Sample/Functions/UIHandlerAutomated.cs
+++ b/functions/testapp/Assets/Firebase/Sample/Functions/UIHandlerAutomated.cs
@@ -82,7 +82,7 @@ namespace Firebase.Sample.Functions {
     protected override void InitializeFirebase() {
       // One of the automated tests requires Auth, so we want to sign in before running it.
       firebaseAuth = Firebase.Auth.FirebaseAuth.DefaultInstance;
-      firebaseAuth.SignInAnonymouslyAsync().ContinueWithOnMainThread(
+      firebaseAuth.SignInAnonymouslyAsync_DEPRECATED().ContinueWithOnMainThread(
         t => base.InitializeFirebase());
     }
 

--- a/swig_post_process.py
+++ b/swig_post_process.py
@@ -320,9 +320,16 @@ class RenameAsyncMethods(SWIGPostProcessingInterface):
           # If the function name already ends with Async or is GetTask
           # (since it's from a Future result class) don't replace it.
           function_name = m.groups()[1]
-          if function_name.endswith('Async') or function_name == 'GetTask':
+          if (function_name.endswith('Async') or
+              function_name.endswith('Async_DEPRECATED') or
+              function_name == 'GetTask'):
             break
+          is_deprecated = function_name.endswith('_DEPRECATED')
           line = regexp.sub(r'\g<1>\g<2>Async\g<3>', line)
+          if function_name.endswith('_DEPRECATED'):
+            # Swap the location of 'Async' and '_DEPRECATED'
+            line = line.replace('_DEPRECATEDAsync', 'Async_DEPRECATED')
+
           break
       output.append(line)
     return '\n'.join(output)
@@ -512,7 +519,7 @@ class StaticFunctionKInitRemoval(SWIGPostProcessingInterface):
                         line[match.end(2):]])
       output.append(line)
     return '\n'.join(output)
-    
+
 class DynamicToReinterpretCast(SWIGPostProcessingInterface):
   """Changes the use of dynamic_cast in SWIG generated code to reinterpret_cast.
 


### PR DESCRIPTION
### Description
> Provide details of the change, and generalize the change in the PR title above.

This change includes:
  - Remove `PhoneAuthProvider.MaxTimeoutMs`
  - Wire the following function to new C++ impl
    - `Firebase.Auth.FirebaseAuth.CurrentUser`
    - `Firebase.Auth.FirebaseUser.ProviderData`
  - Deprecated the following function
    - `FirebaseUser.LinkAndRetrieveDataWithCredentialAsync_DEPRECATED()`
    - `FirebaseUser.LinkWithCredentialAsync_DEPRECATED()`
    - `FirebaseUser.ReauthenticateAndRetrieveDataAsync_DEPRECATED()`
    - `FirebaseUser.UnlinkAsync_DEPRECATED()`
    - `FirebaseUser.UpdatePhoneNumberCredentialAsync_DEPRECATED()`
    - `PhoneAuthProvider.VerificationCompleted_DEPRECATED`
    - `PhoneAuthProvider.VerifyPhoneNumber()`
    - `PhoneAuthProvider.GetCredential_DEPRECATED()`
    - `Firebase.Auth.FirebaseAuth.SignInWithCustomTokenAsync_DEPRECATED`
    - `Firebase.Auth.FirebaseAuth.SignInWithCredentialAsync_DEPRECATED`
    - `Firebase.Auth.FirebaseAuth.SignInAndRetrieveDataWithCredentialAsync_DEPRECATED`
    - `Firebase.Auth.FirebaseAuth.SignInAnonymouslyAsync_DEPRECATED`
    - `Firebase.Auth.FirebaseAuth.SignInWithEmailAndPasswordAsync_DEPRECATED`
    - `Firebase.Auth.FirebaseAuth.CreateUserWithEmailAndPasswordAsync_DEPRECATED`
    - `Firebase.Auth.FirebaseAuth.SignInWithProviderAsync_DEPRECATED`
    - `Firebase.Auth.FirebaseUser.ReauthenticateWithProviderAsync_DEPRECATED`
    - `Firebase.Auth.FirebaseUser.LinkWithProviderAsync_DEPRECATED`
  - Added C# impl for new `PhoneAuthOptions` class
  - Placeholder impl for `PhoneAuthListenerImpl.OnVerificationCompleted(PhoneAuthCredential)`
***
### Testing
> Describe how you've tested these changes.


Build: https://github.com/firebase/firebase-unity-sdk/actions/runs/4879946559
Test: https://github.com/firebase/firebase-unity-sdk/actions/runs/4880313451
***

### Type of Change
Place an `x` the applicable box:
- [ ] Bug fix. Add the issue # below if applicable.
- [ ] New feature. A non-breaking change which adds functionality.
- [x] Other, such as a build process or documentation change.
***

