### PR TITLE
Update RemoteConfig testapp to use the new Realtime methods

### DIFF
--- a/remote_config/testapp/Assets/Firebase/Sample/RemoteConfig/UIHandler.cs
+++ b/remote_config/testapp/Assets/Firebase/Sample/RemoteConfig/UIHandler.cs
@@ -113,6 +113,34 @@ namespace Firebase.Sample.RemoteConfig {
       }
     }
 
+    public void EnableAutoFetch() {
+      DebugLog("Enabling auto-fetch:");
+      Firebase.RemoteConfig.FirebaseRemoteConfig.DefaultInstance.OnConfigUpdateListener
+          += ConfigUpdateListenerEventHandler;
+    }
+
+    public void DisableAutoFetch() {
+      DebugLog("Disabling auto-fetch:");
+      Firebase.RemoteConfig.FirebaseRemoteConfig.DefaultInstance.OnConfigUpdateListener
+          -= ConfigUpdateListenerEventHandler;
+    }
+
+    private void ConfigUpdateListenerEventHandler(
+        object sender, Firebase.RemoteConfig.ConfigUpdateEventArgs args) {
+      if (args.Error != Firebase.RemoteConfig.RemoteConfigError.None) {
+        DebugLog(String.Format("Error occurred while listening: {0}", args.Error));
+        return;
+      }
+      DebugLog(String.Format("Auto-fetch has received a new config. Updated keys: {0}",
+          string.Join(", ", args.UpdatedKeys)));
+      var info = Firebase.RemoteConfig.FirebaseRemoteConfig.DefaultInstance.Info;
+      Firebase.RemoteConfig.FirebaseRemoteConfig.DefaultInstance.ActivateAsync()
+        .ContinueWithOnMainThread(task => {
+          DebugLog(String.Format("Remote data loaded and ready (last fetch time {0}).",
+                                info.FetchTime));
+        });
+    }
+
     // [START fetch_async]
     // Start a fetch request.
     // FetchAsync only fetches new data if the current data is older than the provided
@@ -208,6 +236,12 @@ namespace Firebase.Sample.RemoteConfig {
         }
         if (GUILayout.Button("Fetch Remote Data")) {
           FetchDataAsync();
+        }
+        if (GUILayout.Button("Enable Auto-Fetch")) {
+          EnableAutoFetch();
+        }
+        if (GUILayout.Button("Disable Auto-Fetch")) {
+          DisableAutoFetch();
         }
         GUILayout.EndVertical();
         GUILayout.EndScrollView();

--- a/remote_config/testapp/Assets/Firebase/Sample/RemoteConfig/UIHandlerAutomated.cs
+++ b/remote_config/testapp/Assets/Firebase/Sample/RemoteConfig/UIHandlerAutomated.cs
@@ -18,8 +18,8 @@ namespace Firebase.Sample.RemoteConfig {
 // Skip the Realtime RC test on desktop as it is not yet supported.
 #if (UNITY_IOS || UNITY_TVOS || UNITY_ANDROID) && !UNITY_EDITOR
         TestAddOnConfigUpdateListener,
-#endif  // !(UNITY_IOS || UNITY_TVOS || UNITY_ANDROID) || UNITY_EDITOR
         TestAddAndRemoveConfigUpdateListener,
+#endif  // !(UNITY_IOS || UNITY_TVOS || UNITY_ANDROID) || UNITY_EDITOR
         TestFetchData,
       };
       testRunner = AutomatedTestRunner.CreateTestRunner(

--- a/remote_config/testapp/Assets/Firebase/Sample/RemoteConfig/UIHandlerAutomated.cs
+++ b/remote_config/testapp/Assets/Firebase/Sample/RemoteConfig/UIHandlerAutomated.cs
@@ -1,6 +1,7 @@
 namespace Firebase.Sample.RemoteConfig {
   using Firebase.Extensions;
   using System;
+  using System.Linq;
   using System.Threading.Tasks;
 
   // An automated version of the UIHandler that runs tests on Firebase Remote Config.
@@ -13,6 +14,11 @@ namespace Firebase.Sample.RemoteConfig {
       Func<Task>[] tests = {
         TestDisplayData,
         TestDisplayAllKeys,
+// Skip the Realtime RC test on desktop as it is not yet supported.
+#if (UNITY_IOS || UNITY_TVOS || UNITY_ANDROID) && !UNITY_EDITOR
+        TestAddOnConfigUpdateListener,
+#endif  // !(UNITY_IOS || UNITY_TVOS || UNITY_ANDROID) || UNITY_EDITOR
+        TestAddAndRemoveConfigUpdateListener,
         TestFetchData,
       };
       testRunner = AutomatedTestRunner.CreateTestRunner(
@@ -32,6 +38,15 @@ namespace Firebase.Sample.RemoteConfig {
       }
     }
 
+    // Throw when value1 != value2.
+    private void AssertEq<T>(string message, T value1, T value2) {
+      if (!(object.Equals(value1, value2))) {
+        throw new Exception(String.Format("Assertion failed ({0}): {1} != {2} ({3})",
+                                          testRunner.CurrentTestDescription, value1, value2,
+                                          message));
+      }
+    }
+
     Task TestDisplayData() {
       DisplayData();
       return Task.FromResult(true);
@@ -42,18 +57,81 @@ namespace Firebase.Sample.RemoteConfig {
       return Task.FromResult(true);
     }
 
+    private void ConfigUpdateListenerEventHandler(
+        object sender, Firebase.RemoteConfig.ConfigUpdateEventArgs args) {
+      if (args.Error != Firebase.RemoteConfig.RemoteConfigError.None) {
+        DebugLog(String.Format("Error occurred while listening: {0}", args.Error));
+        return;
+      }
+      DebugLog(String.Format("Auto-fetch has received a new config. Updated keys: {0}",
+          string.Join(", ", args.UpdatedKeys)));
+      var info = Firebase.RemoteConfig.FirebaseRemoteConfig.DefaultInstance.Info;
+      Firebase.RemoteConfig.FirebaseRemoteConfig.DefaultInstance.ActivateAsync()
+        .ContinueWithOnMainThread(task => {
+          DebugLog(String.Format("Remote data loaded and ready (last fetch time {0}).",
+                                info.FetchTime));
+        });
+    }
+
+    Task TestAddOnConfigUpdateListener() {
+      bool hasDefaultValue =
+          Firebase.RemoteConfig.FirebaseRemoteConfig.DefaultInstance.GetValue("config_test_string").Source
+          == Firebase.RemoteConfig.ValueSource.DefaultValue;
+      if (!hasDefaultValue) {
+        // Some previous run of the integration test already has cached local data. This can happen if the test is run twice in a row on the same device.
+        DebugLog("WARNING: The device already has fetched data from a previous run of the test. To test config update listener, clear app data and re-run the test.");
+        return Task.FromResult(true);
+      }
+
+      TaskCompletionSource<bool> test_success = new TaskCompletionSource<bool>();
+      EventHandler<Firebase.RemoteConfig.ConfigUpdateEventArgs> myHandler =
+          (object sender, Firebase.RemoteConfig.ConfigUpdateEventArgs args) => {
+            DebugLog(String.Format("Auto-fetch has received a config"));
+            // Verify that the config update contains all expected keys.
+            String[] expectedKeys = new String[] {
+              "config_test_string", "config_test_int", "config_test_int", "config_test_float"
+            };
+            foreach (String expectedKey in expectedKeys) {
+              if (!args.UpdatedKeys.Contains(expectedKey)) {
+                test_success.SetException(new Exception(String.Format(
+                  "ConfigUpdate does not contain an update for key '{0}'",
+                  expectedKey)));
+              }
+            }
+            test_success.SetResult(true);
+          };
+      DebugLog("Enabling auto-fetch:");
+      Firebase.RemoteConfig.FirebaseRemoteConfig.DefaultInstance.OnConfigUpdateListener
+          += myHandler;
+      return test_success.Task;
+    }
+
+    Task TestAddAndRemoveConfigUpdateListener() {
+      // This test just verifies that listeners can be added and removed.
+      EventHandler<Firebase.RemoteConfig.ConfigUpdateEventArgs> myHandler =
+          (object sender, Firebase.RemoteConfig.ConfigUpdateEventArgs args) => {};
+      DebugLog("Adding a config update listener");
+      Firebase.RemoteConfig.FirebaseRemoteConfig.DefaultInstance.OnConfigUpdateListener
+          += myHandler;
+      DebugLog("Removing a config update listener");
+      Firebase.RemoteConfig.FirebaseRemoteConfig.DefaultInstance.OnConfigUpdateListener
+          -= myHandler;
+      return Task.FromResult(true);
+    }
+
     Task TestFetchData() {
+      // Note: FetchDataAsync calls both Fetch and Activate.
       return FetchDataAsync().ContinueWithOnMainThread((_) => {
-        DebugLog("TestFetchData data=" + String.Join(",", new string[] {
-          "config_test_string: " +
-               Firebase.RemoteConfig.FirebaseRemoteConfig.DefaultInstance.GetValue("config_test_string").StringValue,
-          "config_test_int: " +
-               Firebase.RemoteConfig.FirebaseRemoteConfig.DefaultInstance.GetValue("config_test_int").LongValue,
-          "config_test_float: " +
-               Firebase.RemoteConfig.FirebaseRemoteConfig.DefaultInstance.GetValue("config_test_float").DoubleValue,
-          "config_test_bool: " +
-               Firebase.RemoteConfig.FirebaseRemoteConfig.DefaultInstance.GetValue("config_test_bool").BooleanValue
-      }));
+        // Verify that last fetch time has increased.
+        // Verify that RemoteConfig now has the expected values.
+        AssertEq("Unexpected value for config_test_string", "Hello from the new cloud x3",
+          Firebase.RemoteConfig.FirebaseRemoteConfig.DefaultInstance.GetValue("config_test_string").StringValue);
+        AssertEq("Unexpected value for config_test_int", 42,
+          Firebase.RemoteConfig.FirebaseRemoteConfig.DefaultInstance.GetValue("config_test_int").LongValue);
+        AssertEq("Unexpected value for config_test_float", 3.14,
+          Firebase.RemoteConfig.FirebaseRemoteConfig.DefaultInstance.GetValue("config_test_float").DoubleValue);
+        AssertEq("Unexpected value for config_test_bool", true,
+          Firebase.RemoteConfig.FirebaseRemoteConfig.DefaultInstance.GetValue("config_test_bool").BooleanValue);
       });
     }
   }


### PR DESCRIPTION
### Description
Add GUI buttons to enable and disable auto-fetch by adding and removing config a update listener.
Add an automated test to verify that the config update listener is called with the correct keys.
Update an existing test to assert the fetched values.
***
### Testing
Ran testapp on a local android device and local ios simulator.
***

### Type of Change
Place an `x` the applicable box:
- [ ] Bug fix. Add the issue # below if applicable.
- [ ] New feature. A non-breaking change which adds functionality.
- [x] Other, such as a build process or documentation change.
***

