### PR TITLE
Remove accidentally swig generated field FirebaseUser.provider_data_DEPRECATED

### DIFF
--- a/auth/src/swig/auth.i
+++ b/auth/src/swig/auth.i
@@ -85,6 +85,7 @@ namespace auth {
 %ignore User::GetTokenThreadSafe;
 %ignore User::GetTokenLastResult;
 %ignore User::provider_data;
+%ignore User::provider_data_DEPRECATED;
 %ignore User::is_email_verified;
 %ignore User::is_anonymous;
 %ignore User::metadata;
@@ -300,6 +301,30 @@ static CppInstanceManager<Auth> g_auth_instances;
     // Convert the UserInfoInterfaceList into a List<IUserInfo>, as we don't
     // expose UserInfoInterface, which inherites from the public IUserInfo.
     UserInfoInterfaceList oldList = new UserInfoInterfaceList($imcall, false);
+    System.Collections.Generic.List<IUserInfo> newList =
+      new System.Collections.Generic.List<IUserInfo>();
+    foreach (IUserInfo info in oldList) {
+      newList.Add(info);
+    }
+    return newList;
+  }
+%}
+
+// The following block related to UserInfoInterfaceList_DEPRECATED can be 
+// deleted when ProviderData_DEPRECATED is deleted.
+// Don't expose UserInfoInterfaceList_DEPRECATED externally.
+%typemap(csclassmodifiers) std::vector<firebase::auth::UserInfoInterface*> "internal class"
+%template(UserInfoInterfaceList_DEPRECATED) std::vector<firebase::auth::UserInfoInterface*>;
+// All outputs of UserInfoInterfaceList_DEPRECATED should be IEnumerable<IUserInfo>
+%typemap(cstype,
+         out="global::System.Collections.Generic.IEnumerable<IUserInfo>")
+  std::vector<firebase::auth::UserInfoInterface*>&
+  "UserInfoInterfaceList_DEPRECATED";
+%typemap(csvarout) std::vector<firebase::auth::UserInfoInterface*>& %{
+  get {
+    // Convert the UserInfoInterfaceList_DEPRECATED into a List<IUserInfo>, as we don't
+    // expose UserInfoInterface, which inherites from the public IUserInfo.
+    UserInfoInterfaceList_DEPRECATED oldList = new UserInfoInterfaceList_DEPRECATED($imcall, false);
     System.Collections.Generic.List<IUserInfo> newList =
       new System.Collections.Generic.List<IUserInfo>();
     foreach (IUserInfo info in oldList) {
@@ -1881,6 +1906,8 @@ static CppInstanceManager<Auth> g_auth_instances;
 %attributestring(firebase::auth::User, std::string, PhotoUrlInternal, photo_url);
 %attributeval(firebase::auth::User,
   std::vector<firebase::auth::UserInfoInterface>, ProviderData, provider_data);
+%attribute(firebase::auth::User,
+  std::vector<firebase::auth::UserInfoInterface*>&, ProviderData_DEPRECATED, provider_data_DEPRECATED);
 %attributestring(firebase::auth::User, std::string, ProviderId, provider_id);
 %attributestring(firebase::auth::User, std::string, UserId, uid);
 %rename(IsValid) firebase::auth::User::is_valid;

--- a/auth/src/swig/auth.i
+++ b/auth/src/swig/auth.i
@@ -310,30 +310,6 @@ static CppInstanceManager<Auth> g_auth_instances;
   }
 %}
 
-// The following block related to UserInfoInterfaceList_DEPRECATED can be 
-// deleted when ProviderData_DEPRECATED is deleted.
-// Don't expose UserInfoInterfaceList_DEPRECATED externally.
-%typemap(csclassmodifiers) std::vector<firebase::auth::UserInfoInterface*> "internal class"
-%template(UserInfoInterfaceList_DEPRECATED) std::vector<firebase::auth::UserInfoInterface*>;
-// All outputs of UserInfoInterfaceList_DEPRECATED should be IEnumerable<IUserInfo>
-%typemap(cstype,
-         out="global::System.Collections.Generic.IEnumerable<IUserInfo>")
-  std::vector<firebase::auth::UserInfoInterface*>&
-  "UserInfoInterfaceList_DEPRECATED";
-%typemap(csvarout) std::vector<firebase::auth::UserInfoInterface*>& %{
-  get {
-    // Convert the UserInfoInterfaceList_DEPRECATED into a List<IUserInfo>, as we don't
-    // expose UserInfoInterface, which inherites from the public IUserInfo.
-    UserInfoInterfaceList_DEPRECATED oldList = new UserInfoInterfaceList_DEPRECATED($imcall, false);
-    System.Collections.Generic.List<IUserInfo> newList =
-      new System.Collections.Generic.List<IUserInfo>();
-    foreach (IUserInfo info in oldList) {
-      newList.Add(info);
-    }
-    return newList;
-  }
-%}
-
 %typemap(csclassmodifiers) firebase::auth::PhoneAuthOptions "public sealed class";
 %rename(ForceResendingToken) firebase::auth::PhoneAuthOptions::force_resending_token;
 %rename(PhoneNumber) firebase::auth::PhoneAuthOptions::phone_number;
@@ -1906,8 +1882,6 @@ static CppInstanceManager<Auth> g_auth_instances;
 %attributestring(firebase::auth::User, std::string, PhotoUrlInternal, photo_url);
 %attributeval(firebase::auth::User,
   std::vector<firebase::auth::UserInfoInterface>, ProviderData, provider_data);
-%attribute(firebase::auth::User,
-  std::vector<firebase::auth::UserInfoInterface*>&, ProviderData_DEPRECATED, provider_data_DEPRECATED);
 %attributestring(firebase::auth::User, std::string, ProviderId, provider_id);
 %attributestring(firebase::auth::User, std::string, UserId, uid);
 %rename(IsValid) firebase::auth::User::is_valid;

--- a/auth/src/swig/auth.i
+++ b/auth/src/swig/auth.i
@@ -85,7 +85,6 @@ namespace auth {
 %ignore User::GetTokenThreadSafe;
 %ignore User::GetTokenLastResult;
 %ignore User::provider_data;
-%ignore User::provider_data_DEPRECATED;
 %ignore User::is_email_verified;
 %ignore User::is_anonymous;
 %ignore User::metadata;
@@ -1847,6 +1846,7 @@ static CppInstanceManager<Auth> g_auth_instances;
 %ignore firebase::auth::User::EmailVerified;
 %ignore firebase::auth::User::Anonymous;
 %ignore firebase::auth::User::RefreshToken;
+%ignore firebase::auth::User::provider_data_DEPRECATED;
 // NOTE: It's not necesaary to ignore the following methods
 // as they're replaced by the attributes below:
 // * firebase::auth::User::Email


### PR DESCRIPTION
### Description
Currently

C++ Auth User has
provider_data()     std::vector< UserInfoInterface >
[provider_data_DEPRECATED](https://firebase.google.com/docs/reference/cpp/class/firebase/auth/user#provider_data_deprecated)()      std::vector< UserInfoInterface * > &

Unity Auth FirebaseUser has
ProviderData    IEnumerable< IUserInfo >
[provider_data_DEPRECATED](https://firebase.google.com/docs/reference/unity/class/firebase/auth/firebase-user#provider_data_deprecated)()     SWIGTYPE_p_std__vectorT_firebase__auth__UserInfoInterface_p_t

Since the type for Unity ProviderData has not changed as part of the 11.0.0 release, the Unity provider_data_DEPRECATED field can just be deleted.
***
### Testing
Built Auth locally and inspected the generated C# code. Verified that the provider_data_DEPRECATED method is no longer generated.
***

### Type of Change
Place an `x` the applicable box:
- [ ] Bug fix. Add the issue # below if applicable.
- [ ] New feature. A non-breaking change which adds functionality.
- [x] Other, such as a build process or documentation change.
***

