### PR TITLE
Make methods end with `InternalAsync` internal

### DIFF
--- a/auth/src/swig/auth.i
+++ b/auth/src/swig/auth.i
@@ -1252,38 +1252,6 @@ static CppInstanceManager<Auth> g_auth_instances;
   public string SmsCode { get { return SmsCodeInternal; } }
 %}
 
-%attributestring(firebase::auth::PhoneAuthCredential, std::string, SmsCodeInternal, sms_code);
-%typemap(cscode) firebase::auth::PhoneAuthCredential %{
-  /// Gets the auto-retrieved SMS verification code if applicable.
-  ///
-  /// This method is supported on Android devices only. It will return empty strings on
-  /// other platforms.
-  ///
-  /// When SMS verification is used, you will be called back first via
-  /// @ref PhoneAuthProvider.CodeSent, and later
-  /// PhoneAuthProvider.VerificationCompleted with a PhoneAuthCredential containing
-  /// a non-null SMS code if auto-retrieval succeeded. If Firebase used another approach
-  /// to verify the phone number and triggers a callback via
-  /// @ref PhoneAuthProvider.VerificationCompleted, then the SMS code can be null.
-  public string SmsCode { get { return SmsCodeInternal; } }
-%}
-
-%attributestring(firebase::auth::PhoneAuthCredential, std::string, SmsCodeInternal, sms_code);
-%typemap(cscode) firebase::auth::PhoneAuthCredential %{
-  /// Gets the auto-retrieved SMS verification code if applicable.
-  ///
-  /// This method is supported on Android devices only. It will return empty strings on
-  /// other platforms.
-  ///
-  /// When SMS verification is used, you will be called back first via
-  /// @ref PhoneAuthProvider.CodeSent, and later
-  /// PhoneAuthProvider.VerificationCompleted with a PhoneAuthCredential containing
-  /// a non-null SMS code if auto-retrieval succeeded. If Firebase used another approach
-  /// to verify the phone number and triggers a callback via
-  /// @ref PhoneAuthProvider.VerificationCompleted, then the SMS code can be null.
-  public string SmsCode { get { return SmsCodeInternal; } }
-%}
-
 %typemap(csclassmodifiers) firebase::auth::FederatedAuthProvider "public class";
 
 %typemap(csclassmodifiers) firebase::auth::FederatedOAuthProvider

--- a/docs/readme.md
+++ b/docs/readme.md
@@ -71,6 +71,10 @@ Support
 
 Release Notes
 -------------
+# TBA
+- Changes
+    - Auth: Hide accidentally exposed methods.
+
 ### 11.0.0
 - Changes
     - App Check: Adds support for Firebase App Check on Android, iOS, tvOS,

--- a/swig_post_process.py
+++ b/swig_post_process.py
@@ -462,7 +462,7 @@ class InternalMethodsToInternalVisibility(SWIGPostProcessingInterface):
   def __init__(self):
     """Initialize the instance."""
     self.function_property_regexp = re.compile(
-        r'(public.*? )([^ )]+Internal)($| +|[({])')
+        r'(public.*? )([^ )]+Internal(Async)?(_DEPRECATED)?)($| +|[({])')
 
   def __call__(self, file_str, filename, iteration):
     """Change "Internal" methods and properties to internal visibility.


### PR DESCRIPTION
### Description
> Provide details of the change, and generalize the change in the PR title above.

Hide accidentally exposed methods by making both methods ended with `InternalAsync` and `InternalAsync_DEPRECATED` internal automatically through SWIG post process.

Also, duplicated SWIG code for `PhoneAuthCredential.SmsCode`

***
### Testing
> Describe how you've tested these changes.


GHA
Build: https://github.com/firebase/firebase-unity-sdk/actions/runs/4955353780
Test: TBD
***

### Type of Change
Place an `x` the applicable box:
- [x] Bug fix. Add the issue # below if applicable.
- [ ] New feature. A non-breaking change which adds functionality.
- [ ] Other, such as a build process or documentation change.
***

