### PR TITLE
Remove more accidentally exposed methods

### DIFF
--- a/app/src/swig/app.i
+++ b/app/src/swig/app.i
@@ -319,6 +319,7 @@ static firebase::AppOptions* AppOptionsLoadFromJsonConfig(const char* config) {
 %warnfilter(844);
 // Ignore all methods ending in LastResult.
 %rename("$ignore", regextarget=1) "LastResult$";
+%rename("$ignore", regextarget=1) "LastResult_DEPRECATED$";
 
 %rename(FirebaseApp) firebase::App;
 %typemap(csclassmodifiers) firebase::App "public sealed class";

--- a/auth/src/swig/auth.i
+++ b/auth/src/swig/auth.i
@@ -85,6 +85,7 @@ namespace auth {
 %ignore User::GetTokenThreadSafe;
 %ignore User::GetTokenLastResult;
 %ignore User::provider_data;
+%ignore User::provider_data_DEPRECATED;
 %ignore User::is_email_verified;
 %ignore User::is_anonymous;
 %ignore User::metadata;
@@ -1814,7 +1815,6 @@ static CppInstanceManager<Auth> g_auth_instances;
 %ignore firebase::auth::User::EmailVerified;
 %ignore firebase::auth::User::Anonymous;
 %ignore firebase::auth::User::RefreshToken;
-%ignore firebase::auth::User::provider_data_DEPRECATED;
 // NOTE: It's not necesaary to ignore the following methods
 // as they're replaced by the attributes below:
 // * firebase::auth::User::Email
@@ -1833,7 +1833,8 @@ static CppInstanceManager<Auth> g_auth_instances;
 // * firebase::auth::UserInfoInterface::ProviderId
 
 // Deprecated method that conflicts with the CurrentUser property.
-%ignore firebase::auth::Auth::CurrentUser;
+%ignore firebase::auth::Auth::current_user;
+%ignore firebase::auth::Auth::current_user_DEPRECATED;
 // Make basic getters use C# Properties instead.
 %attributeval(firebase::auth::Auth, firebase::auth::User,
               CurrentUserInternal, current_user);


### PR DESCRIPTION
### Description
> Provide details of the change, and generalize the change in the PR title above.

- Remove `FirebaseAuth.current_user_DEPRECATED`
- Add a universal rule to ignore any method ended with `LastResult_DEPRECATED`
- Move `%ignore provider_data_DEPRECATE`

***
### Testing
> Describe how you've tested these changes.


GHA
***

### Type of Change
Place an `x` the applicable box:
- [x] Bug fix. Add the issue # below if applicable.
- [ ] New feature. A non-breaking change which adds functionality.
- [ ] Other, such as a build process or documentation change.
***

