### PR TITLE
Update Unity export so that App does not include AppCheck files

### DIFF
--- a/docs/readme.md
+++ b/docs/readme.md
@@ -71,9 +71,11 @@ Support
 
 Release Notes
 -------------
-# 11.0.1
+# Upcoming release
 - Changes
     - Auth: Remove internal methods.
+    - General: Fix an [issue](https://github.com/firebase/firebase-unity-sdk/issues/726))
+      where AppCheck bundles were unintentionally included in App.
 
 ### 11.0.0
 - Changes

--- a/docs/readme.md
+++ b/docs/readme.md
@@ -75,7 +75,7 @@ Release Notes
 - Changes
     - Auth: Remove internal methods.
     - General: Fix an [issue](https://github.com/firebase/firebase-unity-sdk/issues/726)
-      where AppCheck bundles were unintentionally included in App.
+      where AppCheck bundles were unintentionally included in App in the tgz.
 
 ### 11.0.0
 - Changes

--- a/docs/readme.md
+++ b/docs/readme.md
@@ -74,7 +74,7 @@ Release Notes
 # Upcoming release
 - Changes
     - Auth: Remove internal methods.
-    - General: Fix an [issue](https://github.com/firebase/firebase-unity-sdk/issues/726))
+    - General: Fix an [issue](https://github.com/firebase/firebase-unity-sdk/issues/726)
       where AppCheck bundles were unintentionally included in App.
 
 ### 11.0.0

--- a/scripts/create_debug_export.py
+++ b/scripts/create_debug_export.py
@@ -18,7 +18,7 @@
 export config for each product.
 
 Example usage:
-  python scripts/build_scripts/create_debug_export.py
+  python scripts/create_debug_export.py
 """
 
 import os
@@ -78,7 +78,6 @@ def main(argv):
         elif package_dict["name"] == package_name:
           output_package_list.append(packages[idx])
       output_dict["packages"] = output_package_list
-      output_dict["builds"] = builds
 
       with open(output_path, 'w', encoding='utf-8') as fout:
         fout.write(json.dumps(output_dict, indent=2))

--- a/unity_packer/debug_single_export_json/analytics.json
+++ b/unity_packer/debug_single_export_json/analytics.json
@@ -40,9 +40,28 @@
           ],
           "cpu": "AnyCPU",
           "paths": [
-            "Plugins/iOS/Firebase/libFirebaseCppApp.a",
             "Firebase/Plugins/iOS/Firebase.App.dll",
             "Firebase/Plugins/iOS/Firebase.App.pdb"
+          ]
+        },
+        {
+          "importer": "PluginImporter",
+          "platforms": [
+            "iOS"
+          ],
+          "cpu": "AnyCPU",
+          "paths": [
+            "Plugins/iOS/Firebase/libFirebaseCppApp.a"
+          ]
+        },
+        {
+          "importer": "PluginImporter",
+          "platforms": [
+            "tvOS"
+          ],
+          "cpu": "AnyCPU",
+          "paths": [
+            "Plugins/tvOS/Firebase/libFirebaseCppApp.a"
           ]
         },
         {
@@ -128,7 +147,7 @@
           ],
           "cpu": "x86_64",
           "paths": [
-            "Firebase/Plugins/x86_64/FirebaseCppApp*"
+            "Firebase/Plugins/x86_64/FirebaseCppApp[-.]*"
           ]
         },
         {
@@ -166,9 +185,9 @@
       "export_upm": 1,
       "upm_package_config": {
         "manifest": {
-          "unity": "2018.1",
+          "unity": "2019.1",
           "dependencies": {
-            "com.google.external-dependency-manager": "1.2.172"
+            "com.google.external-dependency-manager": "1.2.176"
           }
         }
       }
@@ -318,7 +337,7 @@
       "export_upm": 1,
       "upm_package_config": {
         "manifest": {
-          "unity": "2018.1"
+          "unity": "2019.1"
         }
       }
     }

--- a/unity_packer/debug_single_export_json/analytics.json
+++ b/unity_packer/debug_single_export_json/analytics.json
@@ -147,7 +147,8 @@
           ],
           "cpu": "x86_64",
           "paths": [
-            "Firebase/Plugins/x86_64/FirebaseCppApp[-.]*"
+            "Firebase/Plugins/x86_64/FirebaseCppApp-*",
+            "Firebase/Plugins/x86_64/FirebaseCppApp.*"
           ]
         },
         {

--- a/unity_packer/debug_single_export_json/app_check.json
+++ b/unity_packer/debug_single_export_json/app_check.json
@@ -147,7 +147,7 @@
           ],
           "cpu": "x86_64",
           "paths": [
-            "Firebase/Plugins/x86_64/FirebaseCppApp*"
+            "Firebase/Plugins/x86_64/FirebaseCppApp[-.]*"
           ]
         },
         {
@@ -185,9 +185,9 @@
       "export_upm": 1,
       "upm_package_config": {
         "manifest": {
-          "unity": "2018.1",
+          "unity": "2019.1",
           "dependencies": {
-            "com.google.external-dependency-manager": "1.2.172"
+            "com.google.external-dependency-manager": "1.2.176"
           }
         }
       }
@@ -215,7 +215,11 @@
       "imports": [
         {
           "importer": "PluginImporter",
-          "platforms": ["Editor", "Standalone", "Android"],
+          "platforms": [
+            "Editor",
+            "Standalone",
+            "Android"
+          ],
           "cpu": "AnyCPU",
           "paths": [
             "Firebase/Plugins/Firebase.AppCheck.dll",
@@ -224,7 +228,10 @@
         },
         {
           "importer": "PluginImporter",
-          "platforms": ["iOS", "tvOS"],
+          "platforms": [
+            "iOS",
+            "tvOS"
+          ],
           "cpu": "AnyCPU",
           "paths": [
             "Firebase/Plugins/iOS/Firebase.AppCheck.dll",
@@ -233,7 +240,9 @@
         },
         {
           "importer": "PluginImporter",
-          "platforms": ["iOS"],
+          "platforms": [
+            "iOS"
+          ],
           "cpu": "AnyCPU",
           "paths": [
             "Plugins/iOS/Firebase/libFirebaseCppAppCheck.a"
@@ -241,7 +250,9 @@
         },
         {
           "importer": "PluginImporter",
-          "platforms": ["tvOS"],
+          "platforms": [
+            "tvOS"
+          ],
           "cpu": "AnyCPU",
           "paths": [
             "Plugins/tvOS/Firebase/libFirebaseCppAppCheck.a"
@@ -256,7 +267,10 @@
         },
         {
           "importer": "PluginImporter",
-          "platforms": ["Editor", "Standalone"],
+          "platforms": [
+            "Editor",
+            "Standalone"
+          ],
           "cpu": "x86_64",
           "paths": [
             "Firebase/Plugins/x86_64/FirebaseCppAppCheck*"
@@ -264,14 +278,19 @@
         },
         {
           "importer": "DefaultImporter",
-          "sections": ["samples"],
+          "sections": [
+            "samples"
+          ],
           "paths": [
             "Firebase/Sample/AppCheck/"
           ]
         },
         {
           "importer": "DefaultImporter",
-          "sections": ["samples", "documentation"],
+          "sections": [
+            "samples",
+            "documentation"
+          ],
           "paths": [
             "Firebase/Editor/AppCheckReadme.md"
           ]
@@ -283,10 +302,10 @@
       ],
       "manifest_path": "Firebase/Editor",
       "readme": "Firebase/Editor/AppCheckReadme.md",
-      "changelog" : "Firebase/Editor/readme.md",
-      "license" : "Firebase/Editor/LICENSE",
-      "documentation" : "Firebase/Editor/AppCheckReadme.md",
-      "common_manifest" : {
+      "changelog": "Firebase/Editor/readme.md",
+      "license": "Firebase/Editor/LICENSE",
+      "documentation": "Firebase/Editor/AppCheckReadme.md",
+      "common_manifest": {
         "name": "com.google.firebase.app-check",
         "display_name": "Firebase App Check",
         "description": [
@@ -295,16 +314,20 @@
           "resources. It works with both Firebase services, Google Cloud ",
           "services, and your own APIs to keep your resources safe."
         ],
-        "keywords": ["Google", "Firebase", "App Check"],
+        "keywords": [
+          "Google",
+          "Firebase",
+          "App Check"
+        ],
         "author": {
-          "name" : "Google LLC",
+          "name": "Google LLC",
           "url": "https://firebase.google.com/docs/app-check"
         }
       },
       "export_upm": 1,
-      "upm_package_config" : {
-        "manifest" : {
-          "unity": "2018.1"
+      "upm_package_config": {
+        "manifest": {
+          "unity": "2019.1"
         }
       }
     }

--- a/unity_packer/debug_single_export_json/app_check.json
+++ b/unity_packer/debug_single_export_json/app_check.json
@@ -147,7 +147,8 @@
           ],
           "cpu": "x86_64",
           "paths": [
-            "Firebase/Plugins/x86_64/FirebaseCppApp[-.]*"
+            "Firebase/Plugins/x86_64/FirebaseCppApp-*",
+            "Firebase/Plugins/x86_64/FirebaseCppApp.*"
           ]
         },
         {

--- a/unity_packer/debug_single_export_json/auth.json
+++ b/unity_packer/debug_single_export_json/auth.json
@@ -147,7 +147,8 @@
           ],
           "cpu": "x86_64",
           "paths": [
-            "Firebase/Plugins/x86_64/FirebaseCppApp[-.]*"
+            "Firebase/Plugins/x86_64/FirebaseCppApp-*",
+            "Firebase/Plugins/x86_64/FirebaseCppApp.*"
           ]
         },
         {

--- a/unity_packer/debug_single_export_json/auth.json
+++ b/unity_packer/debug_single_export_json/auth.json
@@ -147,7 +147,7 @@
           ],
           "cpu": "x86_64",
           "paths": [
-            "Firebase/Plugins/x86_64/FirebaseCppApp*"
+            "Firebase/Plugins/x86_64/FirebaseCppApp[-.]*"
           ]
         },
         {
@@ -185,9 +185,9 @@
       "export_upm": 1,
       "upm_package_config": {
         "manifest": {
-          "unity": "2018.1",
+          "unity": "2019.1",
           "dependencies": {
-            "com.google.external-dependency-manager": "1.2.172"
+            "com.google.external-dependency-manager": "1.2.176"
           }
         }
       }
@@ -336,7 +336,7 @@
       "export_upm": 1,
       "upm_package_config": {
         "manifest": {
-          "unity": "2018.1"
+          "unity": "2019.1"
         }
       }
     }

--- a/unity_packer/debug_single_export_json/crashlytics.json
+++ b/unity_packer/debug_single_export_json/crashlytics.json
@@ -147,7 +147,7 @@
           ],
           "cpu": "x86_64",
           "paths": [
-            "Firebase/Plugins/x86_64/FirebaseCppApp*"
+            "Firebase/Plugins/x86_64/FirebaseCppApp[-.]*"
           ]
         },
         {
@@ -185,9 +185,9 @@
       "export_upm": 1,
       "upm_package_config": {
         "manifest": {
-          "unity": "2018.1",
+          "unity": "2019.1",
           "dependencies": {
-            "com.google.external-dependency-manager": "1.2.172"
+            "com.google.external-dependency-manager": "1.2.176"
           }
         }
       }
@@ -255,7 +255,7 @@
           ],
           "cpu": "AnyCPU",
           "paths": [
-            "Plugins/tvOS/Firebase/libFirebaseCppCrashlytics.a",
+            "Plugins/tvOS/Firebase/libFirebaseCppCrashlytics.a"
           ]
         },
         {
@@ -333,7 +333,7 @@
       "export_upm": 1,
       "upm_package_config": {
         "manifest": {
-          "unity": "2018.1"
+          "unity": "2019.1"
         }
       }
     }

--- a/unity_packer/debug_single_export_json/crashlytics.json
+++ b/unity_packer/debug_single_export_json/crashlytics.json
@@ -147,7 +147,8 @@
           ],
           "cpu": "x86_64",
           "paths": [
-            "Firebase/Plugins/x86_64/FirebaseCppApp[-.]*"
+            "Firebase/Plugins/x86_64/FirebaseCppApp-*",
+            "Firebase/Plugins/x86_64/FirebaseCppApp.*"
           ]
         },
         {

--- a/unity_packer/debug_single_export_json/database.json
+++ b/unity_packer/debug_single_export_json/database.json
@@ -147,7 +147,7 @@
           ],
           "cpu": "x86_64",
           "paths": [
-            "Firebase/Plugins/x86_64/FirebaseCppApp*"
+            "Firebase/Plugins/x86_64/FirebaseCppApp[-.]*"
           ]
         },
         {
@@ -185,9 +185,9 @@
       "export_upm": 1,
       "upm_package_config": {
         "manifest": {
-          "unity": "2018.1",
+          "unity": "2019.1",
           "dependencies": {
-            "com.google.external-dependency-manager": "1.2.172"
+            "com.google.external-dependency-manager": "1.2.176"
           }
         }
       }
@@ -350,7 +350,7 @@
       "export_upm": 1,
       "upm_package_config": {
         "manifest": {
-          "unity": "2018.1"
+          "unity": "2019.1"
         }
       }
     }

--- a/unity_packer/debug_single_export_json/database.json
+++ b/unity_packer/debug_single_export_json/database.json
@@ -147,7 +147,8 @@
           ],
           "cpu": "x86_64",
           "paths": [
-            "Firebase/Plugins/x86_64/FirebaseCppApp[-.]*"
+            "Firebase/Plugins/x86_64/FirebaseCppApp-*",
+            "Firebase/Plugins/x86_64/FirebaseCppApp.*"
           ]
         },
         {

--- a/unity_packer/debug_single_export_json/dynamic_links.json
+++ b/unity_packer/debug_single_export_json/dynamic_links.json
@@ -9,7 +9,8 @@
             "Editor",
             "Standalone",
             "Android",
-            "iOS"
+            "iOS",
+            "tvOS"
           ],
           "cpu": "AnyCPU",
           "paths": [
@@ -34,13 +35,33 @@
         {
           "importer": "PluginImporter",
           "platforms": [
+            "iOS",
+            "tvOS"
+          ],
+          "cpu": "AnyCPU",
+          "paths": [
+            "Firebase/Plugins/iOS/Firebase.App.dll",
+            "Firebase/Plugins/iOS/Firebase.App.pdb"
+          ]
+        },
+        {
+          "importer": "PluginImporter",
+          "platforms": [
             "iOS"
           ],
           "cpu": "AnyCPU",
           "paths": [
-            "Plugins/iOS/Firebase/libFirebaseCppApp.a",
-            "Firebase/Plugins/iOS/Firebase.App.dll",
-            "Firebase/Plugins/iOS/Firebase.App.pdb"
+            "Plugins/iOS/Firebase/libFirebaseCppApp.a"
+          ]
+        },
+        {
+          "importer": "PluginImporter",
+          "platforms": [
+            "tvOS"
+          ],
+          "cpu": "AnyCPU",
+          "paths": [
+            "Plugins/tvOS/Firebase/libFirebaseCppApp.a"
           ]
         },
         {
@@ -69,7 +90,8 @@
             "Editor",
             "Standalone",
             "Android",
-            "iOS"
+            "iOS",
+            "tvOS"
           ],
           "cpu": "AnyCPU",
           "paths": [
@@ -125,7 +147,7 @@
           ],
           "cpu": "x86_64",
           "paths": [
-            "Firebase/Plugins/x86_64/FirebaseCppApp*"
+            "Firebase/Plugins/x86_64/FirebaseCppApp[-.]*"
           ]
         },
         {
@@ -163,9 +185,9 @@
       "export_upm": 1,
       "upm_package_config": {
         "manifest": {
-          "unity": "2018.1",
+          "unity": "2019.1",
           "dependencies": {
-            "com.google.external-dependency-manager": "1.2.172"
+            "com.google.external-dependency-manager": "1.2.176"
           }
         }
       }
@@ -287,7 +309,7 @@
       "export_upm": 1,
       "upm_package_config": {
         "manifest": {
-          "unity": "2018.1"
+          "unity": "2019.1"
         }
       }
     }

--- a/unity_packer/debug_single_export_json/dynamic_links.json
+++ b/unity_packer/debug_single_export_json/dynamic_links.json
@@ -147,7 +147,8 @@
           ],
           "cpu": "x86_64",
           "paths": [
-            "Firebase/Plugins/x86_64/FirebaseCppApp[-.]*"
+            "Firebase/Plugins/x86_64/FirebaseCppApp-*",
+            "Firebase/Plugins/x86_64/FirebaseCppApp.*"
           ]
         },
         {

--- a/unity_packer/debug_single_export_json/firestore.json
+++ b/unity_packer/debug_single_export_json/firestore.json
@@ -147,7 +147,7 @@
           ],
           "cpu": "x86_64",
           "paths": [
-            "Firebase/Plugins/x86_64/FirebaseCppApp*"
+            "Firebase/Plugins/x86_64/FirebaseCppApp[-.]*"
           ]
         },
         {
@@ -185,9 +185,9 @@
       "export_upm": 1,
       "upm_package_config": {
         "manifest": {
-          "unity": "2018.1",
+          "unity": "2019.1",
           "dependencies": {
-            "com.google.external-dependency-manager": "1.2.172"
+            "com.google.external-dependency-manager": "1.2.176"
           }
         }
       }
@@ -332,7 +332,7 @@
       "export_upm": 1,
       "upm_package_config": {
         "manifest": {
-          "unity": "2018.1"
+          "unity": "2019.1"
         }
       }
     }

--- a/unity_packer/debug_single_export_json/firestore.json
+++ b/unity_packer/debug_single_export_json/firestore.json
@@ -147,7 +147,8 @@
           ],
           "cpu": "x86_64",
           "paths": [
-            "Firebase/Plugins/x86_64/FirebaseCppApp[-.]*"
+            "Firebase/Plugins/x86_64/FirebaseCppApp-*",
+            "Firebase/Plugins/x86_64/FirebaseCppApp.*"
           ]
         },
         {

--- a/unity_packer/debug_single_export_json/functions.json
+++ b/unity_packer/debug_single_export_json/functions.json
@@ -147,7 +147,8 @@
           ],
           "cpu": "x86_64",
           "paths": [
-            "Firebase/Plugins/x86_64/FirebaseCppApp[-.]*"
+            "Firebase/Plugins/x86_64/FirebaseCppApp-*",
+            "Firebase/Plugins/x86_64/FirebaseCppApp.*"
           ]
         },
         {

--- a/unity_packer/debug_single_export_json/functions.json
+++ b/unity_packer/debug_single_export_json/functions.json
@@ -147,7 +147,7 @@
           ],
           "cpu": "x86_64",
           "paths": [
-            "Firebase/Plugins/x86_64/FirebaseCppApp*"
+            "Firebase/Plugins/x86_64/FirebaseCppApp[-.]*"
           ]
         },
         {
@@ -185,9 +185,9 @@
       "export_upm": 1,
       "upm_package_config": {
         "manifest": {
-          "unity": "2018.1",
+          "unity": "2019.1",
           "dependencies": {
-            "com.google.external-dependency-manager": "1.2.172"
+            "com.google.external-dependency-manager": "1.2.176"
           }
         }
       }
@@ -331,7 +331,7 @@
       "export_upm": 1,
       "upm_package_config": {
         "manifest": {
-          "unity": "2018.1"
+          "unity": "2019.1"
         }
       }
     }

--- a/unity_packer/debug_single_export_json/installations.json
+++ b/unity_packer/debug_single_export_json/installations.json
@@ -147,7 +147,8 @@
           ],
           "cpu": "x86_64",
           "paths": [
-            "Firebase/Plugins/x86_64/FirebaseCppApp[-.]*"
+            "Firebase/Plugins/x86_64/FirebaseCppApp-*",
+            "Firebase/Plugins/x86_64/FirebaseCppApp.*"
           ]
         },
         {

--- a/unity_packer/debug_single_export_json/installations.json
+++ b/unity_packer/debug_single_export_json/installations.json
@@ -147,7 +147,7 @@
           ],
           "cpu": "x86_64",
           "paths": [
-            "Firebase/Plugins/x86_64/FirebaseCppApp*"
+            "Firebase/Plugins/x86_64/FirebaseCppApp[-.]*"
           ]
         },
         {
@@ -185,9 +185,9 @@
       "export_upm": 1,
       "upm_package_config": {
         "manifest": {
-          "unity": "2018.1",
+          "unity": "2019.1",
           "dependencies": {
-            "com.google.external-dependency-manager": "1.2.172"
+            "com.google.external-dependency-manager": "1.2.176"
           }
         }
       }
@@ -331,7 +331,7 @@
       "export_upm": 1,
       "upm_package_config": {
         "manifest": {
-          "unity": "2018.1"
+          "unity": "2019.1"
         }
       }
     }

--- a/unity_packer/debug_single_export_json/messaging.json
+++ b/unity_packer/debug_single_export_json/messaging.json
@@ -147,7 +147,7 @@
           ],
           "cpu": "x86_64",
           "paths": [
-            "Firebase/Plugins/x86_64/FirebaseCppApp*"
+            "Firebase/Plugins/x86_64/FirebaseCppApp[-.]*"
           ]
         },
         {
@@ -185,9 +185,9 @@
       "export_upm": 1,
       "upm_package_config": {
         "manifest": {
-          "unity": "2018.1",
+          "unity": "2019.1",
           "dependencies": {
-            "com.google.external-dependency-manager": "1.2.172"
+            "com.google.external-dependency-manager": "1.2.176"
           }
         }
       }
@@ -300,7 +300,9 @@
         },
         {
           "importer": "PluginImporter",
-          "platforms": ["Android"],
+          "platforms": [
+            "Android"
+          ],
           "cpu": "AnyCPU",
           "paths": [
             "Firebase/Plugins/Android/firebase-messaging-cpp.aar"
@@ -367,7 +369,7 @@
       "export_upm": 1,
       "upm_package_config": {
         "manifest": {
-          "unity": "2018.1"
+          "unity": "2019.1"
         }
       }
     }

--- a/unity_packer/debug_single_export_json/messaging.json
+++ b/unity_packer/debug_single_export_json/messaging.json
@@ -147,7 +147,8 @@
           ],
           "cpu": "x86_64",
           "paths": [
-            "Firebase/Plugins/x86_64/FirebaseCppApp[-.]*"
+            "Firebase/Plugins/x86_64/FirebaseCppApp-*",
+            "Firebase/Plugins/x86_64/FirebaseCppApp.*"
           ]
         },
         {

--- a/unity_packer/debug_single_export_json/remote_config.json
+++ b/unity_packer/debug_single_export_json/remote_config.json
@@ -147,7 +147,8 @@
           ],
           "cpu": "x86_64",
           "paths": [
-            "Firebase/Plugins/x86_64/FirebaseCppApp[-.]*"
+            "Firebase/Plugins/x86_64/FirebaseCppApp-*",
+            "Firebase/Plugins/x86_64/FirebaseCppApp.*"
           ]
         },
         {

--- a/unity_packer/debug_single_export_json/remote_config.json
+++ b/unity_packer/debug_single_export_json/remote_config.json
@@ -147,7 +147,7 @@
           ],
           "cpu": "x86_64",
           "paths": [
-            "Firebase/Plugins/x86_64/FirebaseCppApp*"
+            "Firebase/Plugins/x86_64/FirebaseCppApp[-.]*"
           ]
         },
         {
@@ -185,9 +185,9 @@
       "export_upm": 1,
       "upm_package_config": {
         "manifest": {
-          "unity": "2018.1",
+          "unity": "2019.1",
           "dependencies": {
-            "com.google.external-dependency-manager": "1.2.172"
+            "com.google.external-dependency-manager": "1.2.176"
           }
         }
       }
@@ -336,7 +336,7 @@
       "export_upm": 1,
       "upm_package_config": {
         "manifest": {
-          "unity": "2018.1"
+          "unity": "2019.1"
         }
       }
     }

--- a/unity_packer/debug_single_export_json/storage.json
+++ b/unity_packer/debug_single_export_json/storage.json
@@ -147,7 +147,8 @@
           ],
           "cpu": "x86_64",
           "paths": [
-            "Firebase/Plugins/x86_64/FirebaseCppApp[-.]*"
+            "Firebase/Plugins/x86_64/FirebaseCppApp-*",
+            "Firebase/Plugins/x86_64/FirebaseCppApp.*"
           ]
         },
         {

--- a/unity_packer/debug_single_export_json/storage.json
+++ b/unity_packer/debug_single_export_json/storage.json
@@ -147,7 +147,7 @@
           ],
           "cpu": "x86_64",
           "paths": [
-            "Firebase/Plugins/x86_64/FirebaseCppApp*"
+            "Firebase/Plugins/x86_64/FirebaseCppApp[-.]*"
           ]
         },
         {
@@ -185,9 +185,9 @@
       "export_upm": 1,
       "upm_package_config": {
         "manifest": {
-          "unity": "2018.1",
+          "unity": "2019.1",
           "dependencies": {
-            "com.google.external-dependency-manager": "1.2.172"
+            "com.google.external-dependency-manager": "1.2.176"
           }
         }
       }
@@ -264,7 +264,8 @@
             "Editor",
             "Standalone",
             "Android",
-            "iOS"
+            "iOS",
+            "tvOS"
           ],
           "cpu": "AnyCPU",
           "paths": [
@@ -353,7 +354,7 @@
       "export_upm": 1,
       "upm_package_config": {
         "manifest": {
-          "unity": "2018.1"
+          "unity": "2019.1"
         }
       }
     }

--- a/unity_packer/exports.json
+++ b/unity_packer/exports.json
@@ -113,7 +113,7 @@
           "platforms": ["Editor", "Standalone"],
           "cpu": "x86_64",
           "paths": [
-            "Firebase/Plugins/x86_64/FirebaseCppApp*"
+            "Firebase/Plugins/x86_64/FirebaseCppApp[-.]*"
           ]
         },
         {

--- a/unity_packer/exports.json
+++ b/unity_packer/exports.json
@@ -113,7 +113,8 @@
           "platforms": ["Editor", "Standalone"],
           "cpu": "x86_64",
           "paths": [
-            "Firebase/Plugins/x86_64/FirebaseCppApp[-.]*"
+            "Firebase/Plugins/x86_64/FirebaseCppApp-*",
+            "Firebase/Plugins/x86_64/FirebaseCppApp.*"
           ]
         },
         {


### PR DESCRIPTION
### Description
Update exports.json to match App-* and App.* instead of App*
Fix create_debug_export.py and run it.

This is relevant because previously App* was matching FirebaseCppAppCheck.bundle, when the pattern was meant to match files like FirebaseCppApp-11_0_0.bundle. As a result the App tgz was unintentionally including AppCheck files.
***
### Testing
Build workflow based on this PR
https://github.com/firebase/firebase-unity-sdk/actions/runs/4996447348

Verified that the app.tgz produced by that build does not have redundant appcheck bundles.
***

### Type of Change
Place an `x` the applicable box:
- [x] Bug fix. Expected to resolve #726
- [ ] New feature. A non-breaking change which adds functionality.
- [ ] Other, such as a build process or documentation change.
***

