### PR TITLE
Add support for multi tenant authentication

### DIFF
--- a/auth/src/swig/auth.i
+++ b/auth/src/swig/auth.i
@@ -65,6 +65,7 @@
 %include "app/src/swig/null_check_this.i"
 %include "app/src/swig/serial_dispose.i"
 %include "stdint.i"
+%include "std_string.i"
 
 %{
 namespace firebase {
@@ -476,6 +477,12 @@ static CppInstanceManager<Auth> g_auth_instances;
 %csmethodmodifiers set_language_code(const char *lagnuage_code) "internal";
 %rename(SetLanguageCodeInternal) set_language_code;
 
+%csmethodmodifiers testrminal_id() "internal";
+%rename(TenantIdInternal) tenant_id;
+
+%csmethodmodifiers set_tenant_id(const char *tenant_id) "internal";
+%rename(SetTenantIdInternal) set_tenant_id;
+
 %include "app/src/swig/init_result.i"
 
 // Implemented inline below.
@@ -561,6 +568,16 @@ static CppInstanceManager<Auth> g_auth_instances;
     }
     set {
       SetLanguageCodeInternal(value);
+    }
+  }
+
+  /// The user-facing terminal id for multi-tenant authentication
+  public System.String TenantId {
+    get {
+      return TenantIdInternal();
+    }
+    set {
+      SetTenantIdInternal(value);
     }
   }
 


### PR DESCRIPTION
### Description
> Add tenant id to firebase::auth::Auth to send it as a parameter on every request

This change requires support tenantId variable on firebase-cpp-sdk, here is a PR for that as well 

https://github.com/firebase/firebase-cpp-sdk/pull/1331
***
### Testing
> Create a new Google Cloud identity platform with multi tenant
- Create a custom token manually
- Sign in with custom token and tenantId parameter set

There are a lot of more things to test....
***

### Type of Change
Place an `x` the applicable box:
- [ ] Bug fix. Add the issue # below if applicable.
- [X] New feature. A non-breaking change which adds functionality.
- [ ] Other, such as a build process or documentation change.
***

