### PR TITLE
Remove the Auth currentUser cache

### DIFF
--- a/docs/readme.md
+++ b/docs/readme.md
@@ -73,6 +73,8 @@ Release Notes
 -------------
 # Upcoming release
 - Changes
+    - Auth: Fix a [crash](https://github.com/firebase/firebase-unity-sdk/issues/733)
+      that could occur when referencing CurrentUser. 
     - Auth: Remove internal methods.
     - General: Fix an [issue](https://github.com/firebase/firebase-unity-sdk/issues/726)
       where AppCheck bundles were unintentionally included in App in the tgz.


### PR DESCRIPTION
### Description
> Provide details of the change, and generalize the change in the PR title above.

Caching the currentUser seems to be causing problems when checking the cached version's validity.  Removing the cache, since it isn't being used for anything beyond Disposing, which the garbage collection should handle.

Should address: https://github.com/firebase/firebase-unity-sdk/issues/733

***
### Testing
> Describe how you've tested these changes.

https://github.com/firebase/firebase-unity-sdk/actions/runs/5094756381
***

### Type of Change
Place an `x` the applicable box:
- [x] Bug fix. Add the issue # below if applicable.
- [ ] New feature. A non-breaking change which adds functionality.
- [ ] Other, such as a build process or documentation change.
***

