### PR TITLE
Ignore GetApps since it is meant to be internal

### DIFF
--- a/app/src/swig/app.i
+++ b/app/src/swig/app.i
@@ -374,6 +374,8 @@ static firebase::AppOptions* AppOptionsLoadFromJsonConfig(const char* config) {
 // Remove GetInstance() as it's replaced by the DefaultInstance property below.
 %ignore firebase::App::GetInstance();
 %ignore firebase::App::GetInstance(const char*);
+// Remove GetApps() until it is ready to be released.
+%ignore firebase::App::GetApps();
 
 %typemap(cscode) firebase::App %{
   // Static constructor to initialize C# logging


### PR DESCRIPTION
### Description
> Provide details of the change, and generalize the change in the PR title above.

GetApps was recently added to C++, but isn't intended to be part of the Unity API for now, so ignore it.
***
### Testing
> Describe how you've tested these changes.

Building locally.
***

### Type of Change
Place an `x` the applicable box:
- [ ] Bug fix. Add the issue # below if applicable.
- [ ] New feature. A non-breaking change which adds functionality.
- [x] Other, such as a build process or documentation change.
***

