### PR TITLE
Suppress annoying error messages when building iOS on Windows

### DIFF
--- a/editor/app/src/XcodeProjectPatcher.cs
+++ b/editor/app/src/XcodeProjectPatcher.cs
@@ -173,7 +173,7 @@ internal class XcodeProjectPatcher : AssetPostprocessor {
         BuildTarget buildTarget = EditorUserBuildSettings.activeBuildTarget;
         if ((buildTarget == BuildTarget.iOS || buildTarget == BuildTarget.tvOS) &&
             Application.platform == RuntimePlatform.WindowsEditor) {
-            Debug.LogError(DocRef.IOSNotSupportedOnWindows);
+            Debug.LogWarning(DocRef.IOSNotSupportedOnWindows);
         }
     }
 


### PR DESCRIPTION
In previous versions, an error message was displayed when doing an iOS build on Windows OS. However, since Unity allows iOS xcodeproj to be built on Windows OS, messages like this should at least be displayed as a warning, not an error.

### Description
> Provide details of the change, and generalize the change in the PR title above.

When building iOS on Windos, the error message below is shown everytime. 
`Firebase iOS builds are not supported on Windows. Please build on a OSX machine instead.`
![image](https://github.com/firebase/firebase-unity-sdk/assets/30720776/822624c0-0cd5-4cd3-8081-437e138dd88b)

That is very annoying when developing. This problem is also mentioned on the issue below.
[https://github.com/firebase/quickstart-unity/issues/976](url)

Since Unity allows iOS xcodeproj to be built on Windows OS, messages like that should at least be displayed as a warning, not an error. 
If some features of Firebase SDK don't work fine in some situations, the error message should be shown only such cases, not all cases when building iOS on Windows. At least in my project, building iOS xcodeproject on Windows works fine. However Firebase SDK gives me the unneccessary error message. This is an odd behaviour.

[replace this line]: # (Describe your changes in detail.)
***
### Testing
> Describe how you've tested these changes.

This is the kind of change that does not require testing.

[replace this line]: # (Describe your testing in detail.)
***

### Type of Change
Place an `x` the applicable box:
- [ ] Bug fix. Add the issue # below if applicable.
- [ ] New feature. A non-breaking change which adds functionality.
- [x] Other, such as a build process or documentation change.
***

