### PR TITLE
Increase timeout for building Firestore testapp

### DIFF
--- a/scripts/gha/build_testapps.py
+++ b/scripts/gha/build_testapps.py
@@ -1100,7 +1100,7 @@ def _fix_path(path):
 
 def _run(args, timeout=_DEFAULT_TIMEOUT_SECONDS, capture_output=False, text=None, check=True):
   """Executes a command in a subprocess."""
-  logging.info("Running in subprocess: %s, timeout:%d", " ".join(args), timeout)
+  logging.info("Running in subprocess: %s", " ".join(args))
   return subprocess.run(
       args=args,
       timeout=timeout,


### PR DESCRIPTION
### Description
> Provide details of the change, and generalize the change in the PR title above.

Increase the timeout to 30 minutes when building the iOS and tvOS Firestore testapp, since it has routinely been hitting that.
***
### Testing
> Describe how you've tested these changes.

https://github.com/firebase/firebase-unity-sdk/actions/runs/5216934710
***

### Type of Change
Place an `x` the applicable box:
- [ ] Bug fix. Add the issue # below if applicable.
- [ ] New feature. A non-breaking change which adds functionality.
- [x] Other, such as a build process or documentation change.
***

