### PR TITLE
Wraps UNITY_2023_1_OR_NEWER directive around BaseGameActivityClass

### DIFF
--- a/messaging/activity/FirebaseMessagingActivityGenerator.cs
+++ b/messaging/activity/FirebaseMessagingActivityGenerator.cs
@@ -118,7 +118,9 @@ public class FirebaseMessagingActivityGenerator : IPreprocessBuildWithReport {
 "}}"
   };
   private readonly string BaseActivityClass = "UnityPlayerActivity";
+#if UNITY_2023_1_OR_NEWER
   private readonly string BaseGameActivityClass = "UnityPlayerGameActivity";
+#endif
 
   private readonly string GeneratedFileTag = "FirebaseMessagingActivityGenerated";
   // If this tag is present on the generated file, it will not be replaced.


### PR DESCRIPTION
### Description
Currently, the class fails to compile in versions of Unity below 2023. Wrapping the `UNITY_2023_1_OR_NEWER` directive around BaseGameActivityClass solves the problem.

### Testing
It compiles.

### Type of Change
Place an `x` the applicable box:
- [ x] Bug fix. Add the issue # below if applicable.
- [ ] New feature. A non-breaking change which adds functionality.
- [ ] Other, such as a build process or documentation change.
***

