### PR TITLE
Uninstall android-34 on the GHA machines

### DIFF
--- a/scripts/gha/build_testapps.py
+++ b/scripts/gha/build_testapps.py
@@ -556,7 +556,8 @@ def patch_android_env(unity_version):
     # but currently the GitHub runners have 33 as their max.
     logging.info("Uninstall Android platform android-33")
     _run([sdkmanager_path, "--uninstall",
-          "platforms;android-33", "platforms;android-33-ext4", "platforms;android-33-ext5"], check=False)
+          "platforms;android-33", "platforms;android-33-ext4", "platforms;android-33-ext5",
+          "platforms;android-34"], check=False)
   except Exception as e:
     logging.exception("Failed to uninstall Android platform android-33")
 


### PR DESCRIPTION
### Description
> Provide details of the change, and generalize the change in the PR title above.

The GHA machines added android-34, which has problems with the Unity Android build when using proguard.
***
### Testing
> Describe how you've tested these changes.


***

### Type of Change
Place an `x` the applicable box:
- [x] Bug fix. Add the issue # below if applicable.
- [ ] New feature. A non-breaking change which adds functionality.
- [ ] Other, such as a build process or documentation change.
***

