### PR TITLE
Uninstall all versions of android platform 33 or newer

### DIFF
--- a/scripts/gha/build_testapps.py
+++ b/scripts/gha/build_testapps.py
@@ -89,6 +89,7 @@ import stat
 import shutil
 import subprocess
 import time
+import re
 import requests
 import zipfile
 import json
@@ -552,18 +553,17 @@ def patch_android_env(unity_version):
   try:
     # The platform android-33 includes libraries that were built with Java 11, and require a newer version of gradle
     # than Unity comes with. Note this only happens when using minification.
-    # If this continues to be a problem, this logic might need to be smarter, to remove all versions newer than 32,
-    # but currently the GitHub runners have 33 as their max.
-    logging.info("Uninstall Android platform android-33")
-    _run([sdkmanager_path, "--uninstall",
-          "platforms;android-33", "platforms;android-33-ext4", "platforms;android-33-ext5"], check=False)
+    list_installed_result = _run([sdkmanager_path, "--list"], capture_output=True, text=True, check=False)
+    matches = re.findall(r'(platforms;android-(\d+)-?\w*)', list_installed_result.stdout)
+    installed_versions = [android_platform for android_platform, version in matches if int(version) >= 33]
+    if installed_versions:
+      _run([sdkmanager_path, "--uninstall"] + installed_versions, check=False)
   except Exception as e:
-    logging.exception("Failed to uninstall Android platform android-33")
-
+    logging.exception("Failed to uninstall Android platforms;android-33")
   try:
     # List the installed packages to make it easier to notice if any incompatible packages are present.
     logging.info("Listing installed sdks")
-    _run([sdkmanager_path, "--list_installed"], check=False)
+    _run([sdkmanager_path, "--list"], check=False)
   except Exception as e:
     logging.info(str(e))
 

--- a/scripts/gha/build_testapps.py
+++ b/scripts/gha/build_testapps.py
@@ -557,8 +557,8 @@ def patch_android_env(unity_version):
     list_installed_result = _run(
         [sdkmanager_path, "--list"], capture_output=True, text=True, check=False)
     # This should match both platforms;android-33 and platforms;android-33-ext4.
-    matches = re.findall(
-        r'(platforms;android-(\d+)-?\w*)', list_installed_result.stdout)
+    matches = set(re.findall(
+        r'(platforms;android-(\d+)-?\w*)', list_installed_result.stdout))
     installed_versions = [
         platform for platform, version in matches if int(version) >= 33]
     if installed_versions:

--- a/scripts/gha/build_testapps.py
+++ b/scripts/gha/build_testapps.py
@@ -551,17 +551,23 @@ def patch_android_env(unity_version):
       logging.info(str(e))
 
   try:
-    # The platform android-33 includes libraries that were built with Java 11, and require a newer version of gradle
-    # than Unity comes with. Note this only happens when using minification.
-    list_installed_result = _run([sdkmanager_path, "--list"], capture_output=True, text=True, check=False)
-    matches = re.findall(r'(platforms;android-(\d+)-?\w*)', list_installed_result.stdout)
-    installed_versions = [android_platform for android_platform, version in matches if int(version) >= 33]
+    # The platform android-33 includes libraries that were built with Java 11,
+    # and require a newer version of gradle than Unity comes with. Note this
+    # only happens when using minification.
+    list_installed_result = _run(
+        [sdkmanager_path, "--list"], capture_output=True, text=True, check=False)
+    # This should match both platforms;android-33 and platforms;android-33-ext4.
+    matches = re.findall(
+        r'(platforms;android-(\d+)-?\w*)', list_installed_result.stdout)
+    installed_versions = [
+        platform for platform, version in matches if int(version) >= 33]
     if installed_versions:
       _run([sdkmanager_path, "--uninstall"] + installed_versions, check=False)
   except Exception as e:
     logging.exception("Failed to uninstall Android platforms;android-33")
   try:
-    # List the installed packages to make it easier to notice if any incompatible packages are present.
+    # List the installed packages to make it easier to debug if any incompatible
+    # packages are present.
     logging.info("Listing installed sdks")
     _run([sdkmanager_path, "--list"], check=False)
   except Exception as e:


### PR DESCRIPTION
### Description
> Provide details of the change, and generalize the change in the PR title above.

This generalizes some previous changes (#604) that uninstalled android platform 33 to also uninstall newer versions.
Recent GitHub runners have had android platform 34 installed.

This also changes from list_installed to list as when I tested locally, list_installed was not a recognized command. List outputs installed and available.
***
### Testing
Build with this change
https://github.com/firebase/firebase-unity-sdk/actions/runs/5360532633
***

### Type of Change
Place an `x` the applicable box:
- [ ] Bug fix. Add the issue # below if applicable.
- [ ] New feature. A non-breaking change which adds functionality.
- [ ] Other, such as a build process or documentation change.
***

