### PR TITLE
Improve the iOS simulator install logic

### DIFF
--- a/scripts/gha/test_simulator.py
+++ b/scripts/gha/test_simulator.py
@@ -408,11 +408,10 @@ def _create_and_boot_simulator(apple_platform, device_name, device_os):
     if (device_os not in available_versions):
       logging.warning("Unable to find version %s, will fall back to %s", device_os, available_versions[-1])
       device_os = available_versions[-1]
-    logging.info("Will try to use %s", device_os)
 
     args = ["xcodes", "runtimes", "install", "%s %s" % (apple_platform, device_os)]
     logging.info("Download simulator: %s", " ".join(args))
-    subprocess.run(args=args, check=True)
+    subprocess.run(args=args, check=False)
     
     args = ["xcrun", "simctl", "create", "test_simulator", device_name, "%s%s" % (apple_platform, device_os)]
     logging.info("Create test simulator: %s", " ".join(args))


### PR DESCRIPTION
### Description
> Provide details of the change, and generalize the change in the PR title above.

Add logic to check which versions of iOS/tvOS are available, and fallback to the latest if the requested one isn't available. Also change to using xcodes to install iOS simulators, since xcode-install has been deprecated in favor of it.
***
### Testing
> Describe how you've tested these changes.

Running locally, and https://github.com/firebase/firebase-unity-sdk/actions/runs/5395850671
***

### Type of Change
Place an `x` the applicable box:
- [ ] Bug fix. Add the issue # below if applicable.
- [ ] New feature. A non-breaking change which adds functionality.
- [x] Other, such as a build process or documentation change.
***

