### PR TITLE
Firestore: Add a test and readme about the android global refs crash

### DIFF
--- a/docs/readme.md
+++ b/docs/readme.md
@@ -71,6 +71,13 @@ Support
 
 Release Notes
 -------------
+### Upcoming Release
+- Changes
+    - Firestore (Android) Fix the intermittent global references exhaustion
+      crash when working with documents with a large number of keys and/or large
+      map and/or array fields.
+      ([#1364](https://github.com/firebase/firebase-cpp-sdk/pull/1364)).
+
 ### 11.2.0
 - Changes
     - General: Update to Firebase C++ SDK version 11.2.0.

--- a/firestore/testapp/Assets/Firebase/Sample/Firestore/UIHandlerAutomated.cs
+++ b/firestore/testapp/Assets/Firebase/Sample/Firestore/UIHandlerAutomated.cs
@@ -4326,7 +4326,7 @@ namespace Firebase.Sample.Firestore {
         for (int i = 0; i < 60000; i++) {
           numbers.Add(i);
         }
-        Await(doc.SetAsync(new Dictionary<string, object>{{"foo", numbers}});
+        Await(doc.SetAsync(new Dictionary<string, object>{{"foo", numbers}}));
       });
     }
 

--- a/firestore/testapp/Assets/Firebase/Sample/Firestore/UIHandlerAutomated.cs
+++ b/firestore/testapp/Assets/Firebase/Sample/Firestore/UIHandlerAutomated.cs
@@ -4317,6 +4317,19 @@ namespace Firebase.Sample.Firestore {
       });
     }
 
+    // Regression test for https://github.com/firebase/firebase-unity-sdk/issues/569
+    // As long as this test doesn't crash, then it passes.
+    Task TestAndroidGlobalRefsExhaustionBugFix() {
+      return Async(() => {
+        DocumentReference doc = db.Collection("col").Document();
+        var numbers = new List<object>();
+        for (int i = 0; i < 60000; i++) {
+          numbers.Add(i);
+        }
+        Await(doc.SetAsync(new Dictionary<string, object>{{"foo", numbers}});
+      });
+    }
+
     private void RoundtripValue(DocumentReference doc, object input, out object nativeOutput, out object convertedOutput) {
       SerializeToDoc(doc, input);
 


### PR DESCRIPTION
Add a test and release notes entry for a fix to an intermittent crash in Firestore on Android when large documents and/or a large number of documents with large arrays or maps were used. See https://github.com/firebase/firebase-unity-sdk/issues/569 and https://github.com/firebase/firebase-cpp-sdk/pull/1364 for details.