### PR TITLE
Log previous run ID in workflow.

### DIFF
--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -121,6 +121,10 @@ jobs:
       run: pip install -r scripts/gha/requirements.txt
     - id: matrix_config
       run: |
+        # Log that we ran against a given packaged SDK.
+        if [[ -n "${{ github.event.inputs.packaged_sdk_run_id }}" ]]; then
+          echo "::warning ::Downloading package from previous run: https://github.com/${{github.repository}}/actions/runs/${{ github.event.inputs.packaged_sdk_run_id }}"
+        fi
         if [[ "${{ steps.set_outputs.outputs.requested_tests }}" == "expanded" ]]; then 
           TEST_MATRIX_PARAM=-m=expanded
           echo "::warning ::Running on the expanded matrix"


### PR DESCRIPTION
### Description
> Provide details of the change, and generalize the change in the PR title above.

When using a previously packaged SDK, the integration test should log what GitHub run_id it was created with.

This will be used by the build report script to match integration test runs with scheduled package builds, as we do in C++.

***
### Testing
> Describe how you've tested these changes.

[Manually run workflow](https://github.com/firebase/firebase-unity-sdk/actions/runs/5480308755)

***

### Type of Change
Place an `x` the applicable box:
- [ ] Bug fix. Add the issue # below if applicable.
- [ ] New feature. A non-breaking change which adds functionality.
- [X] Other, such as a build process or documentation change.
***

