### PR TITLE
Fix app_check testapp name.

### DIFF
--- a/scripts/gha/integration_testing/test_validation.py
+++ b/scripts/gha/integration_testing/test_validation.py
@@ -323,6 +323,8 @@ def get_name(testapp_path):
   for testapp in testapps:
     if testapp.replace("_", "") in testapp_path.lower():
       return testapp
+    elif testapp in testapp_path.lower():
+      return testapp
   return testapp_path
 
 


### PR DESCRIPTION
### Description
> Provide details of the change, and generalize the change in the PR title above.

Test logs were not correctly parsing testapp paths like "/home/runner/work/firebase-unity-sdk/firebase-unity-sdk/testapps/iOS/app_check/FirebaseAppCheckUnityTestapp.ipa" into "app_check" because it was assuming that testapp paths would remove the underscore, like remoteconfig. But app_check does not do this, so add an additional check including the underscore.

***
### Testing
> Describe how you've tested these changes.


When app_check iOS has a failure, we'll confirm that this worked.
***

### Type of Change
Place an `x` the applicable box:
- [ ] Bug fix. Add the issue # below if applicable.
- [ ] New feature. A non-breaking change which adds functionality.
- [ ] Other, such as a build process or documentation change.
***

