### PR TITLE
Run tvOS configuration in sequence

### DIFF
--- a/.github/workflows/build_tvos.yml
+++ b/.github/workflows/build_tvos.yml
@@ -104,14 +104,6 @@ jobs:
         run: |
           pip install -r scripts/gha/requirements.txt
 
-      - name: Pod repo add
-        shell: bash
-        # The pod install fails during the cmake build, so preinstall it.
-        run: |
-          rm -rf ~/Library/Caches/CocoaPods/* || true
-          pod repo add cocoapods https://github.com/CocoaPods/Specs.git
-          pod repo update
-
       - id: unity_setup
         uses: ./gha/unity
         timeout-minutes: 30

--- a/scripts/build_scripts/build_zips.py
+++ b/scripts/build_scripts/build_zips.py
@@ -551,13 +551,17 @@ def make_macos_multi_arch_build(cmake_args):
                ",".join(g_target_architectures), final_zip_path)
 
 
-def make_tvos_target(device, arch, cmake_args):
-  """Make the tvos build for the given device and architecture.
+def configure_tvos_target(device, arch, cmake_args):
+  """Configure the tvos build for the given device and architecture.
      Assumed to be called from the build directory.
 
     Args:
+      device: Building for device or simulator.
       arch: The architecture to build for.
       cmake_args: Additional cmake arguments to use.
+
+    Returns:
+      The directory that the project is configured in.
   """
   build_args = cmake_args.copy()
   build_args.append("-DCMAKE_OSX_ARCHITECTURES=" + arch)
@@ -574,6 +578,14 @@ def make_tvos_target(device, arch, cmake_args):
     os.makedirs(arch)
   build_dir = os.path.join(os.getcwd(), arch)
   subprocess.call(build_args, cwd=build_dir)
+  return build_dir
+
+def make_tvos_target(build_dir):
+  """Builds the previously configured cmake project in the given directory.
+
+    Args:
+      The full path to the directory to perform the build in.
+  """
   subprocess.call('make', cwd=build_dir)
   subprocess.call(['cpack', '.'], cwd=build_dir)
 
@@ -594,10 +606,14 @@ def make_tvos_multi_arch_build(cmake_args):
   for device in g_target_devices:
     for arch in TVOS_CONFIG_DICT[device]["architecture"]:
       target_architectures.append(arch)
-      t = threading.Thread(target=make_tvos_target, args=(device, arch, cmake_args))
+      # Run the configure step sequentially, since they can clobber the shared Cocoapod cache
+      build_dir = configure_tvos_target(device, arch, cmake_args)
+      # Run the builds in parallel, since they can be
+      t = threading.Thread(target=make_tvos_target, args=(build_dir))
       t.start()
       threads.append(t)
 
+  # Wait for the builds to be finished
   for t in threads:
     t.join()
 

--- a/scripts/build_scripts/build_zips.py
+++ b/scripts/build_scripts/build_zips.py
@@ -609,7 +609,7 @@ def make_tvos_multi_arch_build(cmake_args):
       # Run the configure step sequentially, since they can clobber the shared Cocoapod cache
       build_dir = configure_tvos_target(device, arch, cmake_args)
       # Run the builds in parallel, since they can be
-      t = threading.Thread(target=make_tvos_target, args=(build_dir))
+      t = threading.Thread(target=make_tvos_target, args=(build_dir,))
       t.start()
       threads.append(t)
 


### PR DESCRIPTION
### Description
> Provide details of the change, and generalize the change in the PR title above.

The tvOS configuration updates the Cocoapods, which writes to a shared cache location. Run the configuration in sequence, so that the device and simulator builds don't accidentally clobber each other while doing this, but the build and package step can still be done in parallel.
***
### Testing
> Describe how you've tested these changes.

Just tvOS: https://github.com/firebase/firebase-unity-sdk/actions/runs/5534351005
Full package: https://github.com/firebase/firebase-unity-sdk/actions/runs/5526425595
***

### Type of Change
Place an `x` the applicable box:
- [ ] Bug fix. Add the issue # below if applicable.
- [ ] New feature. A non-breaking change which adds functionality.
- [x] Other, such as a build process or documentation change.
***

