### PR TITLE
Fix dynamic link tests on mobile

### DIFF
--- a/dynamic_links/testapp/Assets/Firebase/Sample/DynamicLinks/UIHandler.cs
+++ b/dynamic_links/testapp/Assets/Firebase/Sample/DynamicLinks/UIHandler.cs
@@ -122,7 +122,7 @@ namespace Firebase.Sample.DynamicLinks {
 #endif
 
       return new DynamicLinkComponents(
-        // The base Link.
+        // The base Link. This should be in your allowlist in the Firebase console.
         new System.Uri("https://google.com/abc"),
         // The dynamic link domain.
         kDomainUriPrefix) {
@@ -134,11 +134,11 @@ namespace Firebase.Sample.DynamicLinks {
           Content = "mycontent"
         },
         IOSParameters = new Firebase.DynamicLinks.IOSParameters(appIdentifier) {
-          FallbackUrl = new System.Uri("https://mysite/fallback"),
+          FallbackUrl = new System.Uri("https://google.com/fallback"),
           CustomScheme = "mycustomscheme",
           MinimumVersion = "1.2.3",
           IPadBundleId = appIdentifier,
-          IPadFallbackUrl = new System.Uri("https://mysite/fallbackipad")
+          IPadFallbackUrl = new System.Uri("https://google.com/fallbackipad")
         },
         ITunesConnectAnalyticsParameters =
           new Firebase.DynamicLinks.ITunesConnectAnalyticsParameters() {
@@ -147,13 +147,13 @@ namespace Firebase.Sample.DynamicLinks {
             ProviderToken = "pq-rstuv"
           },
         AndroidParameters = new Firebase.DynamicLinks.AndroidParameters(appIdentifier) {
-          FallbackUrl = new System.Uri("https://mysite/fallback"),
+          FallbackUrl = new System.Uri("https://google.com/fallback"),
           MinimumVersion = 12
         },
         SocialMetaTagParameters = new Firebase.DynamicLinks.SocialMetaTagParameters() {
           Title = "My App!",
           Description = "My app is awesome!",
-          ImageUrl = new System.Uri("https://mysite.com/someimage.jpg")
+          ImageUrl = new System.Uri("https://google.com/someimage.jpg")
         },
       };
     }

--- a/dynamic_links/testapp/Assets/Firebase/Sample/DynamicLinks/UIHandlerAutomated.cs
+++ b/dynamic_links/testapp/Assets/Firebase/Sample/DynamicLinks/UIHandlerAutomated.cs
@@ -33,7 +33,7 @@ namespace Firebase.Sample.DynamicLinks {
       Func<Task>[] tests = {
         TestCreateLongLinkAsync,
 // TODO(b/264533368) Enable theses tests when the issue has been fixed.
-#if (false)  // (UNITY_ANDROID || UNITY_IOS)
+#if (UNITY_ANDROID || UNITY_IOS)
         // Link shortening does not work on desktop builds, so only test that for mobile.
         TestCreateShortLinkAsync,
         TestCreateUnguessableShortLinkAsync,
@@ -71,12 +71,12 @@ namespace Firebase.Sample.DynamicLinks {
 
       // This is taken from the values given in UIHandler.
       var expected =
-        urlHost + "/?afl=https://mysite/fallback&" +
+        urlHost + "/?afl=https://google.com/fallback&" +
         "amv=12&apn=" + identifier + "&at=abcdefg&ct=hijklmno&" +
-        "ibi=" + identifier + "&ifl=https://mysite/fallback&imv=1.2.3&" +
+        "ibi=" + identifier + "&ifl=https://google.com/fallback&imv=1.2.3&" +
         "ipbi=" + identifier + "&" +
-        "ipfl=https://mysite/fallbackipad&ius=mycustomscheme&link=https://google.com/abc&" +
-        "pt=pq-rstuv&sd=My app is awesome!&si=https://mysite.com/someimage.jpg&st=My App!&" +
+        "ipfl=https://google.com/fallbackipad&ius=mycustomscheme&link=https://google.com/abc&" +
+        "pt=pq-rstuv&sd=My app is awesome!&si=https://google.com/someimage.jpg&st=My App!&" +
         "utm_campaign=mycampaign&utm_content=mycontent&utm_medium=mymedium&utm_source=mysource&" +
         "utm_term=myterm";
       // The order of URL parameters is different between desktop and mobile implementations, and


### PR DESCRIPTION
### Description
> Provide details of the change, and generalize the change in the PR title above.

Dynamic Links set up requires the URLs being used to be part of the allowlist for the project, as set in the Firebase Console. 
Change the urls in the dynamic links testapp to use links that are in the allowlist for the project, and re-enable the disabled tests on mobile, since that was causing the problem.
***
### Testing
> Describe how you've tested these changes.

https://github.com/firebase/firebase-unity-sdk/actions/runs/5536178528
***

### Type of Change
Place an `x` the applicable box:
- [ ] Bug fix. Add the issue # below if applicable.
- [ ] New feature. A non-breaking change which adds functionality.
- [x] Other, such as a build process or documentation change.
***

