### PR TITLE
Fix Installations and Analytics testapp problems

### DIFF
--- a/analytics/testapp/Assets/Firebase/Sample/Analytics/UIHandlerAutomated.cs
+++ b/analytics/testapp/Assets/Firebase/Sample/Analytics/UIHandlerAutomated.cs
@@ -201,13 +201,6 @@ namespace Firebase.Sample.Analytics {
     }
 
     Task TestGetSessionId() {
-      // This test regularly fails on iOS simulator, and there isn't a great way
-      // to determine if this is on a device or simulator, so just disable on iOS
-      // for now
-      #if (UNITY_IOS || UNITY_TVOS)
-      ret
-      #endif  // (UNITY_IOS || UNITY_TVOS)
-
       // Depending on platform, GetSessionId needs a few seconds for Analytics
       // to initialize. Pause for 5 seconds before running this test.
       var tcs = new TaskCompletionSource<bool>();

--- a/analytics/testapp/Assets/Firebase/Sample/Analytics/UIHandlerAutomated.cs
+++ b/analytics/testapp/Assets/Firebase/Sample/Analytics/UIHandlerAutomated.cs
@@ -30,7 +30,12 @@ namespace Firebase.Sample.Analytics {
         TestAnalyticsScoreDoesNotThrow,
         TestAnalyticsGroupJoinDoesNotThrow,
         TestAnalyticsLevelUpDoesNotThrow,
+        // This test regularly fails on iOS simulator, and there isn't a great way
+        // to determine if this is on a device or simulator, so just disable on
+        // GHA iOS and tvOS for now.
+#if FIREBASE_RUNNING_FROM_CI && (UNITY_IOS || UNITY_TVOS)
         TestGetSessionId,
+#endif  // (UNITY_IOS || UNITY_TVOS)
         TestAnalyticsSetConsentDoesNotThrow,
         TestInstanceIdChangeAfterReset,
         TestResetAnalyticsData,
@@ -196,11 +201,12 @@ namespace Firebase.Sample.Analytics {
     }
 
     Task TestGetSessionId() {
-      // This test regularly fails on iOS simulator, so ignore on that.
-      if (SystemInfo.graphicsDeviceName.Contains("simulator")) {
-        DebugLog("Skipping test because of problems with simulators");
-        return Task.CompletedTask;
-      }
+      // This test regularly fails on iOS simulator, and there isn't a great way
+      // to determine if this is on a device or simulator, so just disable on iOS
+      // for now
+      #if (UNITY_IOS || UNITY_TVOS)
+      ret
+      #endif  // (UNITY_IOS || UNITY_TVOS)
 
       // Depending on platform, GetSessionId needs a few seconds for Analytics
       // to initialize. Pause for 5 seconds before running this test.

--- a/analytics/testapp/Assets/Firebase/Sample/Analytics/UIHandlerAutomated.cs
+++ b/analytics/testapp/Assets/Firebase/Sample/Analytics/UIHandlerAutomated.cs
@@ -196,9 +196,14 @@ namespace Firebase.Sample.Analytics {
     }
 
     Task TestGetSessionId() {
+      // This test regularly fails on iOS simulator, so ignore on that.
+      if (SystemInfo.graphicsDeviceName.Contains("simulator")) {
+        DebugLog("Skipping test because of problems with simulators");
+        return Task.CompletedTask;
+      }
+
       // Depending on platform, GetSessionId needs a few seconds for Analytics
-      // to initialize (especially on iOS simulator). Pause for 5 seconds before
-      // running this test.
+      // to initialize. Pause for 5 seconds before running this test.
       var tcs = new TaskCompletionSource<bool>();
       Task.Delay(TimeSpan.FromSeconds(5)).ContinueWithOnMainThread(task_ => {
         base.DisplaySessionId().ContinueWithOnMainThread(task => {

--- a/analytics/testapp/Assets/Firebase/Sample/Analytics/UIHandlerAutomated.cs
+++ b/analytics/testapp/Assets/Firebase/Sample/Analytics/UIHandlerAutomated.cs
@@ -35,7 +35,7 @@ namespace Firebase.Sample.Analytics {
         // GHA iOS and tvOS for now.
 #if FIREBASE_RUNNING_FROM_CI && (UNITY_IOS || UNITY_TVOS)
         TestGetSessionId,
-#endif  // (UNITY_IOS || UNITY_TVOS)
+#endif  // FIREBASE_RUNNING_FROM_CI && (UNITY_IOS || UNITY_TVOS)
         TestAnalyticsSetConsentDoesNotThrow,
         TestInstanceIdChangeAfterReset,
         TestResetAnalyticsData,

--- a/scripts/gha/integration_testing/build_testapps.json
+++ b/scripts/gha/integration_testing/build_testapps.json
@@ -148,7 +148,7 @@
       "name": "installations",
       "full_name": "FirebaseInstallations",
       "captial_name": "Installations",
-      "bundle_id": "com.google.firebase.unity.fis.testapp",
+      "bundle_id": "com.google.firebase.unity.installations.testapp",
       "testapp_path": "installations/testapp",
       "platforms": ["Android", "Playmode", "iOS", "tvOS", "Windows", "macOS", "Linux"],
       "plugins": [


### PR DESCRIPTION
### Description
> Provide details of the change, and generalize the change in the PR title above.

Installations was failing on simulators because of confusion around fis and installations.  Analytics was failing to get the session id on simulators, which is a known problem, and the test is disabled on the C++ side, so do the same here.
***
### Testing
> Describe how you've tested these changes.

https://github.com/firebase/firebase-unity-sdk/actions/runs/5581346312
***

### Type of Change
Place an `x` the applicable box:
- [ ] Bug fix. Add the issue # below if applicable.
- [ ] New feature. A non-breaking change which adds functionality.
- [x] Other, such as a build process or documentation change.
***

