### PR TITLE
Don't enable development on iOS device CI builds

### DIFF
--- a/scripts/gha/build_testapps.py
+++ b/scripts/gha/build_testapps.py
@@ -472,6 +472,8 @@ def build_testapp(dir_helper, api_config, ios_config, target):
       "-AppBuilderHelper.outputDir", dir_helper.output_dir,
       "-buildTarget", target
   ]
+  if FLAGS.ci:
+    build_flags.append("-AppBuilderHelper.buildForCI")
   if target == _IOS or target == _TVOS:
     for device_type in ios_config.ios_sdk:
       build_flags += ["-AppBuilderHelper.targetIosSdk", _IOS_SDK[device_type]]

--- a/scripts/gha/integration_testing/AppBuilderHelper.cs
+++ b/scripts/gha/integration_testing/AppBuilderHelper.cs
@@ -37,6 +37,9 @@
  * Set to 'proguard' to cause unity to use proguarding for the android
  * minification stage. The default is to not minify.
  *
+ * -AppBuilderHelper.buildForCI (optional)
+ * Flag to determine if the apps are being built for use with a CI.
+ *
  * In addition to flags, this script depends on optional environment variables:
  *
  * UNITY_ANDROID_SDK
@@ -73,6 +76,7 @@ public sealed class AppBuilderHelper {
   static readonly bool symlinkLibraries = true;
   static readonly bool forceXcodeProject;
   static readonly string minify;
+  static readonly bool buildForCI = false;
 
   // General extensionless name for a testapp executable, apk, ipa, etc.
   // Having a unified name makes it easier to grab artifacts with a script.
@@ -115,6 +119,10 @@ public sealed class AppBuilderHelper {
       }
       if (args[i] == "-buildTarget") {
         buildTarget = args[++i];
+        continue;
+      }
+      if (args[i] == "-AppBuilderHelper.buildForCI") {
+        buildForCI = true;
         continue;
       }
     }
@@ -407,7 +415,11 @@ public sealed class AppBuilderHelper {
     playerOptions.scenes = GetScenes();
     playerOptions.locationPathName = buildPath;
     playerOptions.target = target;
-    playerOptions.options |= BuildOptions.Development;
+    // Development builds on iOS can trigger a user permission prompt for Local Network access,
+    // so when running on CI we do not want to include it.
+    if (!(buildForCI && target == BuildTarget.iOS && targetIosSdk == "device")) {
+      playerOptions.options |= BuildOptions.Development;
+    }
     playerOptions.options |= BuildOptions.StrictMode;
     if (symlinkLibraries) {
       playerOptions.options |= BuildOptions.SymlinkLibraries;


### PR DESCRIPTION
### Description
> Provide details of the change, and generalize the change in the PR title above.

Occasionally the iOS testapps fail on device because they are asking for local network permissions. This seems to be triggered by Unity development mode, which would allow machine access to the device, for debugging purposes.  Disable that setting when building iOS device tests for CI, to see if that improves things.
***
### Testing
> Describe how you've tested these changes.

https://github.com/firebase/firebase-unity-sdk/actions/runs/5591444715
***

### Type of Change
Place an `x` the applicable box:
- [ ] Bug fix. Add the issue # below if applicable.
- [ ] New feature. A non-breaking change which adds functionality.
- [x] Other, such as a build process or documentation change.
***

