### PR TITLE
Truncate the logs on Linux tests

### DIFF
--- a/scripts/gha/desktop_tester.py
+++ b/scripts/gha/desktop_tester.py
@@ -131,7 +131,11 @@ class Test(object):
           self.logs = f.read()
         test_running = "All tests finished" not in self.logs
     open_process.kill()
-    logging.info("Test result: %s", self.logs)
+    if platform.system() == 'Linux':
+      # Linux seems to have a problem printing out too much information, so truncate it
+      logging.info("Test result: %s (Log might be truncated)", self.logs[:64000])
+    else:
+      logging.info("Test result: %s", self.logs)
     logging.info("Finished running %s", self.testapp_path)
 
 


### PR DESCRIPTION
### Description
> Provide details of the change, and generalize the change in the PR title above.

The linux logs seem to fail when printing out too much information, so limit the size of the logs.
***
### Testing
> Describe how you've tested these changes.

https://github.com/firebase/firebase-unity-sdk/actions/runs/5593161169
***

### Type of Change
Place an `x` the applicable box:
- [ ] Bug fix. Add the issue # below if applicable.
- [ ] New feature. A non-breaking change which adds functionality.
- [x] Other, such as a build process or documentation change.
***

