### PR TITLE
Change the Messaging topic test to avoid accidental messages

### DIFF
--- a/messaging/testapp/Assets/Firebase/Sample/Messaging/UIHandler.cs
+++ b/messaging/testapp/Assets/Firebase/Sample/Messaging/UIHandler.cs
@@ -33,6 +33,13 @@ namespace Firebase.Sample.Messaging {
     private string topic = "TestTopic";
     private bool UIEnabled = true;
 
+    // Should this Subscribe to the topic on startup.
+    protected virtual bool SubscribeToTopicOnStart {
+      get {
+        return true;
+      }
+    }
+
     // Log the result of the specified task, returning true if the task
     // completed successfully, false otherwise.
     protected bool LogTaskCompletion(Task task, string operation) {
@@ -87,9 +94,11 @@ namespace Firebase.Sample.Messaging {
         task => {
           LogTaskCompletion(task, "RequestPermissionAsync");
 
-          Firebase.Messaging.FirebaseMessaging.SubscribeAsync(topic).ContinueWithOnMainThread(task => {
-            LogTaskCompletion(task, "SubscribeAsync");
-          });
+          if (SubscribeToTopicOnStart) {
+            Firebase.Messaging.FirebaseMessaging.SubscribeAsync(topic).ContinueWithOnMainThread(task => {
+              LogTaskCompletion(task, "SubscribeAsync");
+            });
+          }
         }
       );
       isFirebaseInitialized = true;

--- a/messaging/testapp/Assets/Firebase/Sample/Messaging/UIHandlerAutomated.cs
+++ b/messaging/testapp/Assets/Firebase/Sample/Messaging/UIHandlerAutomated.cs
@@ -194,7 +194,7 @@ namespace Firebase.Sample.Messaging {
       while (lastReceivedMessage == null) {
         yield return new WaitForSeconds(0.5f);
       }
-      // Subsubscribe from the test topic, to make sure that other messages aren't received.
+      // Unsubscribe from the test topic, to make sure that other messages aren't received.
       Firebase.Messaging.FirebaseMessaging.UnsubscribeAsync(TestTopic).ContinueWithOnMainThread(t => {
         ValidateJsonMessageB(tcs, lastReceivedMessage);
         lastReceivedMessage = null;

--- a/messaging/testapp/Assets/Firebase/Sample/Messaging/UIHandlerAutomated.cs
+++ b/messaging/testapp/Assets/Firebase/Sample/Messaging/UIHandlerAutomated.cs
@@ -177,7 +177,11 @@ namespace Firebase.Sample.Messaging {
     // waits until the app receives the message and verifies the contents are the same as were sent.
     IEnumerator TestSendJsonMessageToSubscribedTopic(TaskCompletionSource<string> tcs) {
       yield return StartCoroutine(WaitForToken());
-      SendJsonMessageToTopicAsync(JsonMessageB, TestTopic);
+      // Combine the TestTopic and registrationToken to generate a unique topic
+      string testTopic = TestTopic + registrationToken;
+      Firebase.Messaging.FirebaseMessaging.SubscribeAsync(testTopic).ContinueWithOnMainThread(t => {
+        SendJsonMessageToTopicAsync(JsonMessageB, testTopic);
+      });
       // TODO(b/65218400): check message id.
       while (lastReceivedMessage == null) {
         yield return new WaitForSeconds(0.5f);

--- a/messaging/testapp/Assets/Firebase/Sample/Messaging/UIHandlerAutomated.cs
+++ b/messaging/testapp/Assets/Firebase/Sample/Messaging/UIHandlerAutomated.cs
@@ -34,6 +34,13 @@ namespace Firebase.Sample.Messaging {
     private string registrationToken;
     private FirebaseMessage lastReceivedMessage;
 
+    // Don't subscribe to a topic, since it might confuse the tests.
+    protected override bool SubscribeToTopicOnStart {
+      get {
+        return false;
+      }
+    }
+
     protected override void Start() {
 #if FIREBASE_RUNNING_FROM_CI && (UNITY_IOS || UNITY_TVOS)
       // Messaging on iOS requires user interaction to give permissions
@@ -177,16 +184,20 @@ namespace Firebase.Sample.Messaging {
     // waits until the app receives the message and verifies the contents are the same as were sent.
     IEnumerator TestSendJsonMessageToSubscribedTopic(TaskCompletionSource<string> tcs) {
       yield return StartCoroutine(WaitForToken());
-      // Combine the TestTopic and registrationToken to generate a unique topic
-      string testTopic = TestTopic + registrationToken;
-      Firebase.Messaging.FirebaseMessaging.SubscribeAsync(testTopic).ContinueWithOnMainThread(t => {
-        SendJsonMessageToTopicAsync(JsonMessageB, testTopic);
+      // Note: Ideally this would use a more unique topic, but topic creation and subscription
+      // takes additional time, so instead this only subscribes during this one test, and doesn't
+      // fully test unsubscribing.
+      Firebase.Messaging.FirebaseMessaging.SubscribeAsync(TestTopic).ContinueWithOnMainThread(t => {
+        SendJsonMessageToTopicAsync(JsonMessageB, TestTopic);
       });
       // TODO(b/65218400): check message id.
       while (lastReceivedMessage == null) {
         yield return new WaitForSeconds(0.5f);
       }
-      ValidateJsonMessageB(tcs, lastReceivedMessage);
+      // Subsubscribe from the test topic, to make sure that other messages aren't received.
+      Firebase.Messaging.FirebaseMessaging.UnsubscribeAsync(TestTopic).ContinueWithOnMainThread(t => {
+        ValidateJsonMessageB(tcs, lastReceivedMessage);
+      });
       lastReceivedMessage = null;
     }
 

--- a/messaging/testapp/Assets/Firebase/Sample/Messaging/UIHandlerAutomated.cs
+++ b/messaging/testapp/Assets/Firebase/Sample/Messaging/UIHandlerAutomated.cs
@@ -197,8 +197,8 @@ namespace Firebase.Sample.Messaging {
       // Subsubscribe from the test topic, to make sure that other messages aren't received.
       Firebase.Messaging.FirebaseMessaging.UnsubscribeAsync(TestTopic).ContinueWithOnMainThread(t => {
         ValidateJsonMessageB(tcs, lastReceivedMessage);
+        lastReceivedMessage = null;
       });
-      lastReceivedMessage = null;
     }
 
     // Fake test (always passes immediately). Can be used on platforms with no other tests.


### PR DESCRIPTION
### Description
> Provide details of the change, and generalize the change in the PR title above.

Change the Messaging topic test to subscribe, send, and unsubscribe in the same test.  This is to prevent accidentally receiving a topic test while running a different test.  Ideally it would use a more unique test topic, but creating a test topic takes some time after creation before it can be used to send messages.
***
### Testing
> Describe how you've tested these changes.

https://github.com/firebase/firebase-unity-sdk/actions/runs/5604605972
***

### Type of Change
Place an `x` the applicable box:
- [ ] Bug fix. Add the issue # below if applicable.
- [ ] New feature. A non-breaking change which adds functionality.
- [x] Other, such as a build process or documentation change.
***

