### PR TITLE
Only print passing warning log if test passes

### DIFF
--- a/scripts/gha/integration_testing/automated_testapp/AutomatedTestRunner.cs
+++ b/scripts/gha/integration_testing/automated_testapp/AutomatedTestRunner.cs
@@ -385,8 +385,8 @@ namespace Firebase.Sample {
     }
 
     public void CollectWarnings(List<string> warnings) {
-      // Add a warning if multiple attempts were made.
-      if (TookMultipleAttempts) {
+      // Add a warning if multiple attempts were made and it passed.
+      if (TookMultipleAttempts && Status == AutomatedTestStatus.Succeeded) {
         warnings.Add(String.Format("Test {0} took {1} of {2} attempts to pass (Possible Flake).",
                                    Description, currentAttempt, maxAttempts));
       }


### PR DESCRIPTION
### Description
> Provide details of the change, and generalize the change in the PR title above.

A test should only print a warning log about how a test took multiple attempts to pass if it actually passed in the end.
***
### Testing
> Describe how you've tested these changes.


***

### Type of Change
Place an `x` the applicable box:
- [ ] Bug fix. Add the issue # below if applicable.
- [ ] New feature. A non-breaking change which adds functionality.
- [x] Other, such as a build process or documentation change.
***

