### PR TITLE
Remove iOS 32-bit support

### DIFF
--- a/cmake/unity_ios.cmake
+++ b/cmake/unity_ios.cmake
@@ -23,7 +23,7 @@ set(CMAKE_SYSTEM_NAME "iOS")
 # the long term fix will likely be to not handle both device and simulator with
 # the same toolchain, and instead merge the libraries after the fact.
 set(CMAKE_OSX_SYSROOT "")
-set(CMAKE_OSX_ARCHITECTURES "arm64;armv7;x86_64;i386" CACHE STRING "")
+set(CMAKE_OSX_ARCHITECTURES "arm64;x86_64" CACHE STRING "")
 set(CMAKE_XCODE_EFFECTIVE_PLATFORMS "-iphoneos;-iphonesimulator")
 set(IOS_PLATFORM_LOCATION "iPhoneOS.platform;iPhoneSimulator.platform")
 

--- a/docs/readme.md
+++ b/docs/readme.md
@@ -71,6 +71,10 @@ Support
 
 Release Notes
 -------------
+### Upcoming changes
+- Changes
+    - General (iOS): 32-bit iOS builds (i386 and armv7) are no longer supported.
+
 ### 11.3.0
 - Changes
     - General: Update to Firebase C++ SDK version 11.3.0.

--- a/scripts/build_scripts/build_zips.py
+++ b/scripts/build_scripts/build_zips.py
@@ -42,18 +42,18 @@ TVOS_SUPPORT_TARGETS = [
 ]
 SUPPORT_DEVICE = ["device", "simulator"]
 
-IOS_SUPPORT_ARCHITECTURE = ["arm64", "armv7", "x86_64", "i386"]
-IOS_DEVICE_ARCHITECTURE = ["arm64", "armv7"]
-IOS_SIMULATOR_ARCHITECTURE = ["arm64", "x86_64", "i386"]
+IOS_SUPPORT_ARCHITECTURE = ["arm64", "x86_64"]
+IOS_DEVICE_ARCHITECTURE = ["arm64"]
+IOS_SIMULATOR_ARCHITECTURE = ["arm64", "x86_64"]
 
 IOS_CONFIG_DICT = {
     "device": {
-        "architecture": ["arm64", "armv7"],
+        "architecture": ["arm64"],
         "ios_platform_location": "iPhoneOS.platform",
         "osx_sysroot": "iphoneos",
     },
     "simulator": {
-        "architecture": ["arm64", "x86_64", "i386"],
+        "architecture": ["arm64", "x86_64"],
         "ios_platform_location": "iPhoneSimulator.platform",
         "osx_sysroot": "iphonesimulator",
     }

--- a/scripts/gha/integration_testing/gameloop_apple/gameloop/Info.plist
+++ b/scripts/gha/integration_testing/gameloop_apple/gameloop/Info.plist
@@ -28,7 +28,7 @@
     <string>Main</string>
     <key>UIRequiredDeviceCapabilities</key>
     <array>
-      <string>armv7</string>
+      <string>arm64</string>
     </array>
     <key>UISupportedInterfaceOrientations</key>
     <array>


### PR DESCRIPTION
### Description
> Provide details of the change, and generalize the change in the PR title above.

The iOS and C++ SDKs no longer support iOS 32-bit devices and simulators, so remove the support.
***
### Testing
> Describe how you've tested these changes.


***

### Type of Change
Place an `x` the applicable box:
- [ ] Bug fix. Add the issue # below if applicable.
- [ ] New feature. A non-breaking change which adds functionality.
- [x] Other, such as a build process or documentation change.
***

