### PR TITLE
Update EDM4U deps to 1.2.177

### DIFF
--- a/cmake/firebase_unity_version.cmake
+++ b/cmake/firebase_unity_version.cmake
@@ -21,7 +21,7 @@ set(FIREBASE_IOS_POD_VERSION "10.12.0"
     CACHE STRING "The version of the top-level Firebase Cocoapod to use.")
 
 # https://github.com/googlesamples/unity-jar-resolver
-set(FIREBASE_UNITY_JAR_RESOLVER_VERSION "1.2.176"
+set(FIREBASE_UNITY_JAR_RESOLVER_VERSION "1.2.177"
    CACHE STRING
   "Version tag of Play Services Resolver to download and use (no trailing .0)"
 )

--- a/unity_packer/debug_single_export_json/analytics.json
+++ b/unity_packer/debug_single_export_json/analytics.json
@@ -188,7 +188,7 @@
         "manifest": {
           "unity": "2019.1",
           "dependencies": {
-            "com.google.external-dependency-manager": "1.2.176"
+            "com.google.external-dependency-manager": "1.2.177"
           }
         }
       }

--- a/unity_packer/debug_single_export_json/app_check.json
+++ b/unity_packer/debug_single_export_json/app_check.json
@@ -188,7 +188,7 @@
         "manifest": {
           "unity": "2019.1",
           "dependencies": {
-            "com.google.external-dependency-manager": "1.2.176"
+            "com.google.external-dependency-manager": "1.2.177"
           }
         }
       }

--- a/unity_packer/debug_single_export_json/auth.json
+++ b/unity_packer/debug_single_export_json/auth.json
@@ -188,7 +188,7 @@
         "manifest": {
           "unity": "2019.1",
           "dependencies": {
-            "com.google.external-dependency-manager": "1.2.176"
+            "com.google.external-dependency-manager": "1.2.177"
           }
         }
       }

--- a/unity_packer/debug_single_export_json/crashlytics.json
+++ b/unity_packer/debug_single_export_json/crashlytics.json
@@ -188,7 +188,7 @@
         "manifest": {
           "unity": "2019.1",
           "dependencies": {
-            "com.google.external-dependency-manager": "1.2.176"
+            "com.google.external-dependency-manager": "1.2.177"
           }
         }
       }

--- a/unity_packer/debug_single_export_json/database.json
+++ b/unity_packer/debug_single_export_json/database.json
@@ -188,7 +188,7 @@
         "manifest": {
           "unity": "2019.1",
           "dependencies": {
-            "com.google.external-dependency-manager": "1.2.176"
+            "com.google.external-dependency-manager": "1.2.177"
           }
         }
       }

--- a/unity_packer/debug_single_export_json/dynamic_links.json
+++ b/unity_packer/debug_single_export_json/dynamic_links.json
@@ -188,7 +188,7 @@
         "manifest": {
           "unity": "2019.1",
           "dependencies": {
-            "com.google.external-dependency-manager": "1.2.176"
+            "com.google.external-dependency-manager": "1.2.177"
           }
         }
       }

--- a/unity_packer/debug_single_export_json/firestore.json
+++ b/unity_packer/debug_single_export_json/firestore.json
@@ -188,7 +188,7 @@
         "manifest": {
           "unity": "2019.1",
           "dependencies": {
-            "com.google.external-dependency-manager": "1.2.176"
+            "com.google.external-dependency-manager": "1.2.177"
           }
         }
       }

--- a/unity_packer/debug_single_export_json/functions.json
+++ b/unity_packer/debug_single_export_json/functions.json
@@ -188,7 +188,7 @@
         "manifest": {
           "unity": "2019.1",
           "dependencies": {
-            "com.google.external-dependency-manager": "1.2.176"
+            "com.google.external-dependency-manager": "1.2.177"
           }
         }
       }

--- a/unity_packer/debug_single_export_json/installations.json
+++ b/unity_packer/debug_single_export_json/installations.json
@@ -188,7 +188,7 @@
         "manifest": {
           "unity": "2019.1",
           "dependencies": {
-            "com.google.external-dependency-manager": "1.2.176"
+            "com.google.external-dependency-manager": "1.2.177"
           }
         }
       }

--- a/unity_packer/debug_single_export_json/messaging.json
+++ b/unity_packer/debug_single_export_json/messaging.json
@@ -188,7 +188,7 @@
         "manifest": {
           "unity": "2019.1",
           "dependencies": {
-            "com.google.external-dependency-manager": "1.2.176"
+            "com.google.external-dependency-manager": "1.2.177"
           }
         }
       }

--- a/unity_packer/debug_single_export_json/remote_config.json
+++ b/unity_packer/debug_single_export_json/remote_config.json
@@ -188,7 +188,7 @@
         "manifest": {
           "unity": "2019.1",
           "dependencies": {
-            "com.google.external-dependency-manager": "1.2.176"
+            "com.google.external-dependency-manager": "1.2.177"
           }
         }
       }

--- a/unity_packer/debug_single_export_json/storage.json
+++ b/unity_packer/debug_single_export_json/storage.json
@@ -188,7 +188,7 @@
         "manifest": {
           "unity": "2019.1",
           "dependencies": {
-            "com.google.external-dependency-manager": "1.2.176"
+            "com.google.external-dependency-manager": "1.2.177"
           }
         }
       }

--- a/unity_packer/exports.json
+++ b/unity_packer/exports.json
@@ -147,7 +147,7 @@
         "manifest" : {
           "unity": "2019.1",
           "dependencies": {
-            "com.google.external-dependency-manager" : "1.2.176"
+            "com.google.external-dependency-manager" : "1.2.177"
           }
         }
       }


### PR DESCRIPTION
### Description
> Provide details of the change, and generalize the change in the PR title above.

Update EDM4U dependency to 1.2.177, which fix iOS resolver issue on M1 mac.
See https://github.com/googlesamples/unity-jar-resolver/releases/tag/v1.2.177

***
### Testing
> Describe how you've tested these changes.


GHA
***

### Type of Change
Place an `x` the applicable box:
- [ ] Bug fix. Add the issue # below if applicable.
- [ ] New feature. A non-breaking change which adds functionality.
- [x] Other, such as a build process or documentation change.
***

