### PR TITLE
Handle Future completion race condition

### DIFF
--- a/app/src/swig/future.i
+++ b/app/src/swig/future.i
@@ -295,9 +295,18 @@ namespace firebase {
   // Free data structure allocated in SetOnCompletionCallback() and save
   // a reference to the current data structure if specified.
   private void SetCompletionData(System.IntPtr data) {
-    ThrowIfDisposed();
-    SWIG_FreeCompletionData(callbackData);
-    callbackData = data;
+    lock (FirebaseApp.disposeLock) {
+      // The callback that was made could theoretically be triggered before this point,
+      // which would Dispose this object. In that case, we want to free the data we
+      // were given, since otherwise it would be leaked.
+      if (swigCPtr.Handle == System.IntPtr.Zero) {
+        SWIG_FreeCompletionData(data);
+      } else {
+        // Free the old data, before saving the new data for deletion
+        SWIG_FreeCompletionData(callbackData);
+        callbackData = data;
+      }
+    }
   }
 
   // Handles the C++ callback, and calls the cached C# callback.

--- a/app/src/swig/future.i
+++ b/app/src/swig/future.i
@@ -398,7 +398,7 @@ namespace firebase {
   }
 
   // Deallocate data allocated for the completion callback.
-  void SWIG_FreeCompletionData(void *data) {
+  static void SWIG_FreeCompletionData(void *data) {
     delete reinterpret_cast<CSNAME##CallbackData*>(data);
   }
 


### PR DESCRIPTION
### Description
> Provide details of the change, and generalize the change in the PR title above.

About once a week Installations tests seem to fail because of a race condition around completing Tasks that the underlying Future is already completed.  The problem seems to be that when registering the C++ callback, it completes immediately, thus deleting the Future object while C# is still working with it.  Fix this by checking if the object has been Disposed, and handling it, instead of throwing an exception.

***
### Testing
> Describe how you've tested these changes.

https://github.com/firebase/firebase-unity-sdk/actions/runs/5968360487
***

### Type of Change
Place an `x` the applicable box:
- [x] Bug fix. Add the issue # below if applicable.
- [ ] New feature. A non-breaking change which adds functionality.
- [ ] Other, such as a build process or documentation change.
***

