### PR TITLE
Change how Messaging testapp gets registration token

### DIFF
--- a/messaging/testapp/Assets/Firebase/Sample/Messaging/UIHandler.cs
+++ b/messaging/testapp/Assets/Firebase/Sample/Messaging/UIHandler.cs
@@ -209,9 +209,10 @@ namespace Firebase.Sample.Messaging {
             task => {
               token = task.Result;
               LogTaskCompletion(task, "GetTokenAsync");
+              DebugLog("GetTokenAsync result: " + token);
             }
           );
-          DebugLog("GetTokenAsync " + token);
+          DebugLog("GetTokenAsync called");
         }
 
         if (GUILayout.Button("DeleteToken")) {

--- a/messaging/testapp/Assets/Firebase/Sample/Messaging/UIHandlerAutomated.cs
+++ b/messaging/testapp/Assets/Firebase/Sample/Messaging/UIHandlerAutomated.cs
@@ -141,7 +141,8 @@ namespace Firebase.Sample.Messaging {
     // Guarantee that the registration token is set, before running other tests.
     Task TestGetRegistrationToken() {
       // The registration token might already be set, if gotten via OnTokenReceived
-      if (registrationToken != null) {
+      if (!string.IsNullOrEmpty(registrationToken)) {
+        DebugLog("Already have a registration token, skipping GetTokenAsync call");
         return Task.CompletedTask;
       }
 
@@ -159,7 +160,9 @@ namespace Firebase.Sample.Messaging {
     // If the registration token is missing, throw an exception.
     // Use for tests that require a registration token to function properly.
     void ThrowIfMissingRegistrationToken() {
-      throw new InvalidOperationException("Registration Token is missing.");
+      if (string.IsNullOrEmpty(registrationToken)) {
+        throw new InvalidOperationException("Registration Token is missing.");
+      }
     }
 
     // Sends a plaintext message to the server, setting this device as the addressee, waits until the

--- a/messaging/testapp/Assets/Firebase/Sample/Messaging/UIHandlerAutomated.cs
+++ b/messaging/testapp/Assets/Firebase/Sample/Messaging/UIHandlerAutomated.cs
@@ -42,8 +42,6 @@ namespace Firebase.Sample.Messaging {
     }
 
     protected override void Start() {
-      Firebase.FirebaseApp.LogLevel = Firebase.LogLevel.Verbose;
-
 #if FIREBASE_RUNNING_FROM_CI && (UNITY_IOS || UNITY_TVOS)
       // Messaging on iOS requires user interaction to give permissions
       // So if running on CI, just run a dummy test instead.

--- a/messaging/testapp/Assets/Firebase/Sample/Messaging/UIHandlerAutomated.cs
+++ b/messaging/testapp/Assets/Firebase/Sample/Messaging/UIHandlerAutomated.cs
@@ -65,10 +65,9 @@ namespace Firebase.Sample.Messaging {
 #else // FIREBASE_RUNNING_FROM_CI && (UNITY_IOS || UNITY_TVOS)
 
       Func<Task>[] tests = {
-        // Disable these tests on desktop, as desktop never receives a token, and so WaitForToken
-        // (called by all of these tests) stalls forever.
+        // Disable these tests on desktop, as desktop uses a stub implementation.
 #if (UNITY_IOS || UNITY_TVOS || UNITY_ANDROID)
-        MakeTest(TestWaitForToken),
+        TestGetRegistrationToken,
 #if !(UNITY_IOS || UNITY_TVOS)
         // TODO(b/130674454) This test times out on iOS, disabling until fixed.
         MakeTest(TestSendPlaintextMessageToDevice),
@@ -85,10 +84,9 @@ namespace Firebase.Sample.Messaging {
       };
 
       string[] customTests = {
-        // Disable these tests on desktop, as desktop never receives a token, and so WaitForToken
-        // (called by all of these tests) stalls forever.
+        // Disable these tests on desktop, as desktop uses a stub implementation.
 #if (UNITY_IOS || UNITY_TVOS || UNITY_ANDROID)
-        "TestWaitForToken",
+        "TestGetRegistrationToken",
 #if !(UNITY_IOS || UNITY_TVOS)
         // TODO(b/130674454) This test times out on iOS, disabling until fixed.
         "TestSendPlaintextMessageToDevice",
@@ -142,24 +140,34 @@ namespace Firebase.Sample.Messaging {
       };
     }
 
-    // Waits until the app is given a registration token, expected shortly after startup.
-    IEnumerator TestWaitForToken(TaskCompletionSource<string> tcs) {
-      yield return StartCoroutine(WaitForToken());
-      tcs.SetResult(registrationToken);
+    // Guarantee that the registration token is set, before running other tests.
+    Task TestGetRegistrationToken() {
+      // The registration token might already be set, if gotten via OnTokenReceived
+      if (registrationToken != null) {
+        return Task.CompletedTask;
+      }
+
+      // Otherwise, call GetTokenAsync, to fetch one. This can happen if the app
+      // already had a token from a previous run, and thus didn't need a new token.
+      return Firebase.Messaging.FirebaseMessaging.GetTokenAsync().ContinueWithOnMainThread(t => {
+        if (t.IsFaulted) {
+          throw t.Exception;
+        }
+
+        registrationToken = t.Result;
+      });
     }
 
-    // Blocks until registrationToken is non-empty. Trying to send a message without a registration
-    // token will fail.
-    IEnumerator WaitForToken() {
-      while (String.IsNullOrEmpty(registrationToken)) {
-        yield return new WaitForSeconds(0.5f);
-      }
+    // If the registration token is missing, throw an exception.
+    // Use for tests that require a registration token to function properly.
+    void ThrowIfMissingRegistrationToken() {
+      throw new InvalidOperationException("Registration Token is missing.");
     }
 
     // Sends a plaintext message to the server, setting this device as the addressee, waits until the
     // app receives the message and verifies the contents are the same as were sent.
     IEnumerator TestSendPlaintextMessageToDevice(TaskCompletionSource<string> tcs) {
-      yield return StartCoroutine(WaitForToken());
+      ThrowIfMissingRegistrationToken();
       SendPlaintextMessageToDeviceAsync(PlaintextMessage, registrationToken);
       // TODO(b/65218400): check message id.
       while (lastReceivedMessage == null) {
@@ -172,7 +180,7 @@ namespace Firebase.Sample.Messaging {
     // Sends a JSON message to the server, setting this device as the addressee, waits until the app
     // receives the message and verifies the contents are the same as were sent.
     IEnumerator TestSendJsonMessageToDevice(TaskCompletionSource<string> tcs) {
-      yield return StartCoroutine(WaitForToken());
+      ThrowIfMissingRegistrationToken();
       SendJsonMessageToDeviceAsync(JsonMessageA, registrationToken);
       // TODO(b/65218400): check message id.
       while (lastReceivedMessage == null) {
@@ -185,7 +193,7 @@ namespace Firebase.Sample.Messaging {
     // Sends a JSON message to the server, specifying a topic to which this device is subscribed,
     // waits until the app receives the message and verifies the contents are the same as were sent.
     IEnumerator TestSendJsonMessageToSubscribedTopic(TaskCompletionSource<string> tcs) {
-      yield return StartCoroutine(WaitForToken());
+      ThrowIfMissingRegistrationToken();
       // Note: Ideally this would use a more unique topic, but topic creation and subscription
       // takes additional time, so instead this only subscribes during this one test, and doesn't
       // fully test unsubscribing.

--- a/messaging/testapp/Assets/Firebase/Sample/Messaging/UIHandlerAutomated.cs
+++ b/messaging/testapp/Assets/Firebase/Sample/Messaging/UIHandlerAutomated.cs
@@ -42,6 +42,8 @@ namespace Firebase.Sample.Messaging {
     }
 
     protected override void Start() {
+      Firebase.FirebaseApp.LogLevel = Firebase.LogLevel.Verbose;
+
 #if FIREBASE_RUNNING_FROM_CI && (UNITY_IOS || UNITY_TVOS)
       // Messaging on iOS requires user interaction to give permissions
       // So if running on CI, just run a dummy test instead.


### PR DESCRIPTION
### Description
> Provide details of the change, and generalize the change in the PR title above.

The OnTokenReceived callback is only called for new Messaging Tokens, so if the App has a cached token, it would not receive a new token, and thus the tests would timeout while waiting for it.  Change the tests to use GetTokenAsync if necessary to get a token, and throw exceptions if the token is still missing.
***
### Testing
> Describe how you've tested these changes.

https://github.com/firebase/firebase-unity-sdk/actions/runs/6028673810
***

### Type of Change
Place an `x` the applicable box:
- [x] Bug fix. Add the issue # below if applicable.
- [ ] New feature. A non-breaking change which adds functionality.
- [ ] Other, such as a build process or documentation change.
***

