### PR TITLE
Change how Messaging Activity cleans up in 2023

### DIFF
--- a/messaging/activity/FirebaseMessagingActivityGenerator.cs
+++ b/messaging/activity/FirebaseMessagingActivityGenerator.cs
@@ -110,7 +110,7 @@ public class FirebaseMessagingActivityGenerator : IPreprocessBuildWithReport {
 "  @Override",
 "  protected void onCreate(Bundle savedInstanceState) {{",
 "    if (mUnityPlayer != null) {{",
-"      mUnityPlayer.quit();",
+"      mUnityPlayer.{1}();",
 "      mUnityPlayer = null;",
 "    }}",
 "    super.onCreate(savedInstanceState);",
@@ -120,6 +120,12 @@ public class FirebaseMessagingActivityGenerator : IPreprocessBuildWithReport {
   private readonly string BaseActivityClass = "UnityPlayerActivity";
 #if UNITY_2023_1_OR_NEWER
   private readonly string BaseGameActivityClass = "UnityPlayerGameActivity";
+#endif
+
+#if UNITY_2023_1_OR_NEWER
+  private readonly string UnityPlayerQuitFunction = "destroy";
+#else
+  private readonly string UnityPlayerQuitFunction = "quit";
 #endif
 
   private readonly string GeneratedFileTag = "FirebaseMessagingActivityGenerated";
@@ -144,7 +150,8 @@ public class FirebaseMessagingActivityGenerator : IPreprocessBuildWithReport {
       baseClass = BaseGameActivityClass;
     }
 #endif
-    string fileContents = System.String.Format(System.String.Join("\n", ActivityClassContents), baseClass);
+    string fileContents = System.String.Format(System.String.Join("\n", ActivityClassContents),
+                                               baseClass, UnityPlayerQuitFunction);
 
     // Check if the file has already been generated.
     string[] oldAssetGuids = AssetDatabase.FindAssets("l:" + GeneratedFileTag);


### PR DESCRIPTION
### Description
> Provide details of the change, and generalize the change in the PR title above.

The Unity 2023.2 beta is seemingly removing mUnityActivity's quit().  Change it to use destroy(), which should have the same overall effect.

***
### Testing
> Describe how you've tested these changes.

https://github.com/firebase/firebase-unity-sdk/actions/runs/6043471004
***

### Type of Change
Place an `x` the applicable box:
- [x] Bug fix. Add the issue # below if applicable.
- [ ] New feature. A non-breaking change which adds functionality.
- [ ] Other, such as a build process or documentation change.
***

https://github.com/firebase/firebase-unity-sdk/issues/842
