### PR TITLE
Fix build report not parsing the last line

### DIFF
--- a/scripts/gha/report_build_status.py
+++ b/scripts/gha/report_build_status.py
@@ -178,6 +178,8 @@ def analyze_log(text, url, firestore_only):
   #
   # Assuming that each product begins with no spaces, and all subsequent lines will be indented
   regex_line = r"firestore:\n(  .[^\n]*\n)*"
+  # Add a newline at the end, to help the regex format check the last line
+  text = text + "\n"
   if firestore_only:
     # Reduce the text log to just what is matched (if no match, just use everything)
     match = re.search(regex_line, text, re.MULTILINE)


### PR DESCRIPTION
### Description
> Provide details of the change, and generalize the change in the PR title above.

The regex check to split firestore and not depended on the lines ending with a newline, so add an extra newline to the text to parse beforehand.
***
### Testing
> Describe how you've tested these changes.

Running locally
***

### Type of Change
Place an `x` the applicable box:
- [ ] Bug fix. Add the issue # below if applicable.
- [ ] New feature. A non-breaking change which adds functionality.
- [x] Other, such as a build process or documentation change.
***

