### PR TITLE
Add retries to the FTL integration test runs

### DIFF
--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -526,6 +526,8 @@ jobs:
           testapp_dir: testapps
           test_type: "game-loop"
           test_devices: ${{ matrix.device_detail }}
+          max_attempts: 3
+          validator: ${GITHUB_WORKSPACE}/scripts/gha/read_ftl_test_result.py
       - name: Read FTL Test Result
         if: ${{ matrix.device_type == 'real' && !cancelled() }}
         timeout-minutes: 60

--- a/analytics/testapp/Assets/Firebase/Sample/Analytics/UIHandlerAutomated.cs
+++ b/analytics/testapp/Assets/Firebase/Sample/Analytics/UIHandlerAutomated.cs
@@ -25,6 +25,8 @@ namespace Firebase.Sample.Analytics {
       // Set the list of tests to run, note this is done at Start since they are
       // non-static.
       Func<Task>[] tests = {
+        TestIntentionalFail,
+        /*
         TestAnalyticsLoginDoesNotThrow,
         TestAnalyticsProgressDoesNotThrow,
         TestAnalyticsScoreDoesNotThrow,
@@ -41,7 +43,7 @@ namespace Firebase.Sample.Analytics {
         TestResetAnalyticsData,
         // Temporarily disabled until this test is deflaked. b/143603151
         //TestCheckAndFixDependenciesInvalidOperation,
-        TestCheckAndFixDependenciesDoubleCall,
+        TestCheckAndFixDependenciesDoubleCall,*/
       };
       testRunner = AutomatedTestRunner.CreateTestRunner(
         testsToRun: tests,
@@ -57,6 +59,10 @@ namespace Firebase.Sample.Analytics {
       if (firebaseInitialized) {
         testRunner.Update();
       }
+    }
+
+    Task TestIntentionalFail() {
+      return Task.FromException(new Exception());
     }
 
     Task TestAnalyticsLoginDoesNotThrow() {

--- a/analytics/testapp/Assets/Firebase/Sample/Analytics/UIHandlerAutomated.cs
+++ b/analytics/testapp/Assets/Firebase/Sample/Analytics/UIHandlerAutomated.cs
@@ -25,8 +25,6 @@ namespace Firebase.Sample.Analytics {
       // Set the list of tests to run, note this is done at Start since they are
       // non-static.
       Func<Task>[] tests = {
-        TestIntentionalFail,
-        /*
         TestAnalyticsLoginDoesNotThrow,
         TestAnalyticsProgressDoesNotThrow,
         TestAnalyticsScoreDoesNotThrow,
@@ -43,7 +41,7 @@ namespace Firebase.Sample.Analytics {
         TestResetAnalyticsData,
         // Temporarily disabled until this test is deflaked. b/143603151
         //TestCheckAndFixDependenciesInvalidOperation,
-        TestCheckAndFixDependenciesDoubleCall,*/
+        TestCheckAndFixDependenciesDoubleCall,
       };
       testRunner = AutomatedTestRunner.CreateTestRunner(
         testsToRun: tests,
@@ -59,10 +57,6 @@ namespace Firebase.Sample.Analytics {
       if (firebaseInitialized) {
         testRunner.Update();
       }
-    }
-
-    Task TestIntentionalFail() {
-      return Task.FromException(new Exception());
     }
 
     Task TestAnalyticsLoginDoesNotThrow() {

--- a/scripts/gha/__init__.py
+++ b/scripts/gha/__init__.py
@@ -1,0 +1,1 @@
+# Copyright 2023 Google

--- a/scripts/gha/integration_testing/__init__.py
+++ b/scripts/gha/integration_testing/__init__.py
@@ -1,0 +1,1 @@
+# Copyright 2023 Google

--- a/scripts/gha/read_ftl_test_result.py
+++ b/scripts/gha/read_ftl_test_result.py
@@ -32,11 +32,13 @@ import os
 import attr
 import subprocess
 import json
+import sys
 
 from absl import app
 from absl import flags
 from absl import logging
 
+sys.path.append(os.path.dirname(os.path.realpath(__file__)))
 from integration_testing import test_validation
 from integration_testing import gcs
 

--- a/scripts/gha/read_ftl_test_result.py
+++ b/scripts/gha/read_ftl_test_result.py
@@ -59,18 +59,7 @@ def main(argv):
   test_result = json.loads(FLAGS.test_result)
   tests = []
   for app in test_result.get("apps"):
-    app_path = app.get("testapp_path")
-    return_code = app.get("return_code")
-    logging.info("testapp: %s\nreturn code: %s" % (app_path, return_code))
-    if return_code == 0:
-      gcs_dir = app.get("raw_result_link").replace("https://console.developers.google.com/storage/browser/", "gs://")
-      logging.info("gcs_dir: %s" % gcs_dir)
-      logs = _get_testapp_log_text_from_gcs(gcs_dir)
-      logging.info("Test result: %s", logs)
-      tests.append(Test(testapp_path=app_path, logs=logs))
-    else:
-      logging.error("Test failed: %s", app)
-      tests.append(Test(testapp_path=app_path, logs=None))
+    tests.append(_parse_testapp_to_test(app))
 
   (output_dir, file_name) = os.path.split(os.path.abspath(FLAGS.output_path))
   return test_validation.summarize_test_results(
@@ -78,6 +67,22 @@ def main(argv):
     "unity", 
     output_dir, 
     file_name=file_name)
+
+
+def _parse_testapp_to_test(app):
+  """Parsed the given testapp run into a Test object."""
+  app_path = app.get("testapp_path")
+  return_code = app.get("return_code")
+  logging.info("testapp: %s\nreturn code: %s" % (app_path, return_code))
+  if return_code == 0:
+    gcs_dir = app.get("raw_result_link").replace("https://console.developers.google.com/storage/browser/", "gs://")
+    logging.info("gcs_dir: %s" % gcs_dir)
+    logs = _get_testapp_log_text_from_gcs(gcs_dir)
+    logging.info("Test result: %s", logs)
+    return Test(testapp_path=app_path, logs=logs)
+  else:
+    logging.error("Test failed: %s", app)
+    return Test(testapp_path=app_path, logs=None)
 
 
 def _get_testapp_log_text_from_gcs(gcs_path):
@@ -128,6 +133,18 @@ def _gcs_read_file(gcs_path):
   logging.info("Reading GCS file: %s", " ".join(args))
   result = subprocess.run(args=args, capture_output=True, text=True, check=True)
   return result.stdout
+
+
+
+def validate(test_summary):
+  """Validates a given test summary, assuming it is from a Unity testapp."""
+  if not test_summary:
+    logging.error("Nothing to be validate! Please provide test_summary")
+    return False
+  
+  test = _parse_testapp_to_test(test_summary)
+  result = test_validation.validate_results(test.logs, "unity")
+  return result.complete and result.fails == 0
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
### Description
> Provide details of the change, and generalize the change in the PR title above.

Add retry attempts to the FTL integration tests running on GHA, to work around device flakiness.  Adds a custom validator, since the FTL run reports success regardless of if the tests contained succeeded or failed.
***
### Testing
> Describe how you've tested these changes.

Run with intentional failure to see the retries: https://github.com/firebase/firebase-unity-sdk/actions/runs/6475956332
Normal run: https://github.com/firebase/firebase-unity-sdk/actions/runs/6476383922
***

### Type of Change
Place an `x` the applicable box:
- [ ] Bug fix. Add the issue # below if applicable.
- [ ] New feature. A non-breaking change which adds functionality.
- [x] Other, such as a build process or documentation change.
***

