### PR TITLE
Fix App Check crash if there is a config problem

### DIFF
--- a/app_check/src/FirebaseAppCheck.cs
+++ b/app_check/src/FirebaseAppCheck.cs
@@ -162,12 +162,14 @@ public sealed class FirebaseAppCheck {
       AppCheckUtil.FinishGetTokenCallback(key, "", 0,
         (int)AppCheckError.InvalidConfiguration,
         "Missing IAppCheckProviderFactory.");
+      return;
     }
     FirebaseApp app = FirebaseApp.GetInstance(appName);
     if (app == null) {
       AppCheckUtil.FinishGetTokenCallback(key, "", 0,
         (int)AppCheckError.Unknown,
         "Unable to find App with name: " + appName);
+      return;
     }
     IAppCheckProvider provider;
     if (!providerMap.TryGetValue(app.Name, out provider)) {
@@ -176,6 +178,7 @@ public sealed class FirebaseAppCheck {
         AppCheckUtil.FinishGetTokenCallback(key, "", 0,
           (int)AppCheckError.InvalidConfiguration,
           "Failed to create IAppCheckProvider for App: " + appName);
+        return;
       }
       providerMap[app.Name] = provider;
     }

--- a/docs/readme.md
+++ b/docs/readme.md
@@ -71,6 +71,11 @@ Support
 
 Release Notes
 -------------
+### Upcoming
+- Changes
+    - App Check: Fixed a crash when there are errors creating a provider.
+      ([#877](https://github.com/firebase/firebase-unity-sdk/issues/877))
+
 ### 11.5.0
 - Changes
     - General: Update to Firebase C++ SDK version 11.5.0.


### PR DESCRIPTION
### Description
> Provide details of the change, and generalize the change in the PR title above.

The Unity class was not returning after calling into C++ when dealing with an error, which could accidentally result in multiple callbacks, which would raise an error.
***
### Testing
> Describe how you've tested these changes.

https://github.com/firebase/firebase-unity-sdk/actions/runs/6473902284
***

### Type of Change
Place an `x` the applicable box:
- [x] Bug fix. Add the issue # below if applicable.
- [ ] New feature. A non-breaking change which adds functionality.
- [ ] Other, such as a build process or documentation change.
***

https://github.com/firebase/firebase-unity-sdk/issues/877