### PR TITLE
Update Cocoapods version to 10.6.0

### DIFF
--- a/cmake/firebase_unity_version.cmake
+++ b/cmake/firebase_unity_version.cmake
@@ -17,7 +17,7 @@
 set(FIREBASE_UNITY_SDK_VERSION "11.6.0"
     CACHE STRING "The version of the Unity SDK, used in the names of files.")
 
-set(FIREBASE_IOS_POD_VERSION "10.15.0"
+set(FIREBASE_IOS_POD_VERSION "10.16.0"
     CACHE STRING "The version of the top-level Firebase Cocoapod to use.")
 
 # https://github.com/googlesamples/unity-jar-resolver


### PR DESCRIPTION
Fix for #886.

Based on the [release notes](https://firebase.google.com/support/release-notes/unity#version_1160_-_october_19_2023), it seems that the CocoaPods version was updated to 10.6.0 but it didn't reflect to the latest SDK version. 