### PR TITLE
Firestore: Small Count API documentation improvements

### DIFF
--- a/firestore/src/AggregateSource.cs
+++ b/firestore/src/AggregateSource.cs
@@ -24,7 +24,7 @@ namespace Firebase.Firestore {
     /// considering any local state. That is, documents in the local cache are not
     /// taken into consideration, neither are local modifications not yet
     /// synchronized with the server. Previously-downloaded results, if any, are
-    /// not used: every request using this source necessarily involves a round trip
+    /// not used. Every request using this source necessarily involves a round trip
     /// to the server.
     ///
     /// The AggregateQuery will fail if the server cannot be reached, such as if

--- a/firestore/src/Query.cs
+++ b/firestore/src/Query.cs
@@ -61,8 +61,8 @@ namespace Firebase.Firestore {
     ///
     /// Using the returned query to count the documents is efficient because only
     /// the final count, not the documents' data, is downloaded. The returned query
-    /// can even count the documents if the result set would be prohibitively large
-    /// to download entirely (e.g. thousands of documents).
+    /// can count the documents if the result set would be prohibitively large
+    /// to download entirely (thousands of documents).
     /// </summary>
     /// <returns>
     /// An aggregate query that counts the documents in the result set of this query.

--- a/firestore/src/Query.cs
+++ b/firestore/src/Query.cs
@@ -61,7 +61,7 @@ namespace Firebase.Firestore {
     ///
     /// Using the returned query to count the documents is efficient because only
     /// the final count, not the documents' data, is downloaded. The returned query
-    /// can count the documents if the result set would be prohibitively large
+    /// can count the documents in cases where the result set is prohibitively large
     /// to download entirely (thousands of documents).
     /// </summary>
     /// <returns>


### PR DESCRIPTION
Apply the feedback to the count API documentation as suggested in https://github.com/firebase/firebase-js-sdk/pull/6608. This is a port of https://github.com/firebase/firebase-js-sdk/pull/7933.