### PR TITLE
Update future swig file preprocessor logic

### DIFF
--- a/.github/workflows/build_android.yml
+++ b/.github/workflows/build_android.yml
@@ -119,6 +119,12 @@ jobs:
           # TODO add handling cmake_extras
           python scripts/build_scripts/build_zips.py --gha --platform=android --unity_root=$UNITY_ROOT_DIR --apis=${{ inputs.apis }}
 
+      - name: Print info
+        shell: bash
+        if: always()
+        run: |
+          cat android_unity/arm64-v8a/app/swig/Firebase.App_fixed.cs
+
       - name: Check zip file
         shell: bash
         run: |

--- a/.github/workflows/build_android.yml
+++ b/.github/workflows/build_android.yml
@@ -119,12 +119,6 @@ jobs:
           # TODO add handling cmake_extras
           python scripts/build_scripts/build_zips.py --gha --platform=android --unity_root=$UNITY_ROOT_DIR --apis=${{ inputs.apis }}
 
-      - name: Print info
-        shell: bash
-        if: always()
-        run: |
-          cat android_unity/arm64-v8a/app/swig/Firebase.App_fixed.cs
-
       - name: Check zip file
         shell: bash
         run: |

--- a/app/src/swig/app.i
+++ b/app/src/swig/app.i
@@ -351,7 +351,9 @@ static firebase::AppOptions* AppOptionsLoadFromJsonConfig(const char* config) {
 
 %SWIG_FUTURE(FutureString, string, internal,
              std::string, FirebaseException)  // Future<std::string>
+#ifndef USE_FIRESTORE_FUTURE_VOID
 %SWIG_FUTURE(FutureVoid, void, internal, void, FirebaseException)
+#endif  // USE_FIRESTORE_FUTURE_VOID
 %SWIG_FUTURE(FutureBool, bool, internal, bool, FirebaseException) // Future<bool>
 
 // Internal

--- a/app/src/swig/future.i
+++ b/app/src/swig/future.i
@@ -113,7 +113,7 @@ namespace firebase {
 // Detect when the CTYPE is void by checking "TYPE_" + CTYPE, which yields:
 // TYPE_void. TYPE_void is only defined for "void" which allows this macro
 // mostly to be used but with some specializations for void.
-#if %mangle(CTYPE)==void
+#if "CTYPE"=="void"
 
 %typemap(cstype, out="System.Threading.Tasks.Task")
   firebase::Future<CTYPE> "CSNAME";
@@ -136,7 +136,7 @@ namespace firebase {
     return CSNAME.GetTask(new CSNAME(future, true));
   }
 
-#endif  //  %mangle(CTYPE)==void
+#endif  //  "CTYPE"=="void"
 
 // Replace the default Dispose() method to delete the callback data if
 // allocated.
@@ -181,7 +181,7 @@ namespace firebase {
 %define %SWIG_FUTURE_GET_TASK(CSNAME, CSTYPE, CTYPE, EXTYPE)
   // Helper for csout typemap to convert futures into tasks.
   // This would be internal, but we need to share it accross assemblies.
-#if %mangle(CTYPE)==void
+#if "CTYPE"=="void"
   static public System.Threading.Tasks.Task GetTask(CSNAME fu) {
     System.Threading.Tasks.TaskCompletionSource<int> tcs =
         new System.Threading.Tasks.TaskCompletionSource<int>();
@@ -189,7 +189,7 @@ namespace firebase {
   static public System.Threading.Tasks.Task<CSTYPE> GetTask(CSNAME fu) {
     System.Threading.Tasks.TaskCompletionSource<CSTYPE> tcs =
         new System.Threading.Tasks.TaskCompletionSource<CSTYPE>();
-#endif  // %mangle(CTYPE)==void
+#endif  // "CTYPE"=="void"
 
     // Check if an exception has occurred previously and propagate it if it has.
     // This has to be done before accessing the future because the future object
@@ -223,11 +223,11 @@ namespace firebase {
             tcs.SetException(new EXTYPE(error, fu.error_message()));
           } else {
             // Success!
-#if %mangle(CTYPE)==void
+#if "CTYPE"=="void"
             tcs.SetResult(0);
 #else
             tcs.SetResult(fu.GetResult());
-#endif  // %mangle(CTYPE)==void
+#endif  // "CTYPE"=="void"
           }
         }
       } catch (System.Exception e) {
@@ -405,7 +405,7 @@ namespace firebase {
 // Detect when the CTYPE is void by checking "TYPE_" + CTYPE, which yields:
 // TYPE_void. TYPE_void is only defined for "void" which allows the result()
 // method to only be generated for non-void types.
-#if %mangle(CTYPE)!=void
+#if "CTYPE"!="void"
 
   // This method copies the value return by Future::result() so that it's
   // possible to marshal the return value to C#.

--- a/app/src/swig/future.i
+++ b/app/src/swig/future.i
@@ -136,7 +136,7 @@ namespace firebase {
     return CSNAME.GetTask(new CSNAME(future, true));
   }
 
-#endif  //  TYPE_## %mangle(CTYPE)
+#endif  //  %mangle(CTYPE)==void
 
 // Replace the default Dispose() method to delete the callback data if
 // allocated.
@@ -181,7 +181,7 @@ namespace firebase {
 %define %SWIG_FUTURE_GET_TASK(CSNAME, CSTYPE, CTYPE, EXTYPE)
   // Helper for csout typemap to convert futures into tasks.
   // This would be internal, but we need to share it accross assemblies.
-#ifdef TYPE_## %mangle(CTYPE)
+#if %mangle(CTYPE)==void
   static public System.Threading.Tasks.Task GetTask(CSNAME fu) {
     System.Threading.Tasks.TaskCompletionSource<int> tcs =
         new System.Threading.Tasks.TaskCompletionSource<int>();
@@ -189,7 +189,7 @@ namespace firebase {
   static public System.Threading.Tasks.Task<CSTYPE> GetTask(CSNAME fu) {
     System.Threading.Tasks.TaskCompletionSource<CSTYPE> tcs =
         new System.Threading.Tasks.TaskCompletionSource<CSTYPE>();
-#endif  // TYPE_## %mangle(CTYPE)
+#endif  // %mangle(CTYPE)==void
 
     // Check if an exception has occurred previously and propagate it if it has.
     // This has to be done before accessing the future because the future object
@@ -223,11 +223,11 @@ namespace firebase {
             tcs.SetException(new EXTYPE(error, fu.error_message()));
           } else {
             // Success!
-#ifdef TYPE_## %mangle(CTYPE)
+#if %mangle(CTYPE)==void
             tcs.SetResult(0);
 #else
             tcs.SetResult(fu.GetResult());
-#endif  // TYPE_## %mangle(CTYPE)
+#endif  // %mangle(CTYPE)==void
           }
         }
       } catch (System.Exception e) {
@@ -405,7 +405,7 @@ namespace firebase {
 // Detect when the CTYPE is void by checking "TYPE_" + CTYPE, which yields:
 // TYPE_void. TYPE_void is only defined for "void" which allows the result()
 // method to only be generated for non-void types.
-#ifndef TYPE_## %mangle(CTYPE)
+#if %mangle(CTYPE)!=void
 
   // This method copies the value return by Future::result() so that it's
   // possible to marshal the return value to C#.

--- a/app/src/swig/future.i
+++ b/app/src/swig/future.i
@@ -53,12 +53,6 @@ namespace firebase {
 %include "app/src/swig/null_check_this.i"
 %include "app/src/swig/serial_dispose.i"
 
-// This is defined so that it's possible to conditionally generate code that is
-// aware of type void. This allows us to different code for the void type as
-// required by "%extend Future<CTYPE>::result" below.
-%ignore TYPE_void;
-#define TYPE_void 1
-
 // The Future implementation is assembled in a series of three macros,
 // The HEADER, the GET_TASK implementation, and the FOOTER. This componentized
 // approach allows for custom GET_TASK implementations for various SDKs
@@ -110,9 +104,7 @@ namespace firebase {
 // 4) The user's callback executes.
 
 
-// Detect when the CTYPE is void by checking "TYPE_" + CTYPE, which yields:
-// TYPE_void. TYPE_void is only defined for "void" which allows this macro
-// mostly to be used but with some specializations for void.
+// void is a special type since it isn't a real returnable type.
 #if "CTYPE"=="void"
 
 %typemap(cstype, out="System.Threading.Tasks.Task")
@@ -402,9 +394,7 @@ namespace firebase {
     delete reinterpret_cast<CSNAME##CallbackData*>(data);
   }
 
-// Detect when the CTYPE is void by checking "TYPE_" + CTYPE, which yields:
-// TYPE_void. TYPE_void is only defined for "void" which allows the result()
-// method to only be generated for non-void types.
+// Only generate the return logic for non-void types.
 #if "CTYPE"!="void"
 
   // This method copies the value return by Future::result() so that it's
@@ -417,7 +407,7 @@ namespace firebase {
     return *$self->result();
   }
 
-#endif // !TYPE_void
+#endif // "CTYPE"!="void"
 }
 
 } // namespace firebase

--- a/app/src/swig/future.i
+++ b/app/src/swig/future.i
@@ -113,7 +113,7 @@ namespace firebase {
 // Detect when the CTYPE is void by checking "TYPE_" + CTYPE, which yields:
 // TYPE_void. TYPE_void is only defined for "void" which allows this macro
 // mostly to be used but with some specializations for void.
-#ifdef TYPE_## %mangle(CTYPE)
+#if %mangle(CTYPE)==void
 
 %typemap(cstype, out="System.Threading.Tasks.Task")
   firebase::Future<CTYPE> "CSNAME";

--- a/firestore/src/swig/firestore.i
+++ b/firestore/src/swig/firestore.i
@@ -67,6 +67,12 @@
 // processing meant for `public` methods doesn't get applied.
 %csmethodmodifiers firebase::firestore::Firestore::GetInstance "internal";
 
+// Override the default FutureVoid with a version that throws FirestoreException.
+// Do this before app.i, since that also defined FutureVoid, and newer versions
+// of swig only use the first definition of templates.
+%include "app/src/swig/future.i"
+%SWIG_FUTURE(Future_FirestoreVoid, void, internal, void, FirestoreException)
+
 %import "app/src/swig/app.i"
 %import "firestore/src/swig/proxy_helpers.i"
 %include "app/src/swig/init_result.i"
@@ -200,7 +206,6 @@ SWIG_MAP_CFUNC_TO_CSDELEGATE(::firebase::firestore::csharp::LoadBundleTaskProgre
                              Firebase.Firestore.FirebaseFirestore.LoadBundleTaskProgressDelegate)
 
 // Generate Future instantiations, must be before other wrappers.
-%include "app/src/swig/future.i"
 %SWIG_FUTURE(Future_AggregateQuerySnapshot, AggregateQuerySnapshotProxy, internal,
              firebase::firestore::AggregateQuerySnapshot, FirestoreException)
 %SWIG_FUTURE(Future_QuerySnapshot, QuerySnapshotProxy, internal,

--- a/firestore/src/swig/firestore.i
+++ b/firestore/src/swig/firestore.i
@@ -72,6 +72,7 @@
 // of swig only use the first definition of templates.
 %include "app/src/swig/future.i"
 %SWIG_FUTURE(Future_FirestoreVoid, void, internal, void, FirestoreException)
+#define USE_FIRESTORE_FUTURE_VOID 1
 
 %import "app/src/swig/app.i"
 %import "firestore/src/swig/proxy_helpers.i"
@@ -214,8 +215,6 @@ SWIG_MAP_CFUNC_TO_CSDELEGATE(::firebase::firestore::csharp::LoadBundleTaskProgre
              firebase::firestore::DocumentSnapshot, FirestoreException)
 %SWIG_FUTURE(Future_DocumentReference, DocumentReferenceProxy, internal,
              firebase::firestore::DocumentReference, FirestoreException)
-// Override the default FutureVoid with a version that throws FirestoreException.
-%SWIG_FUTURE(Future_FirestoreVoid, void, internal, void, FirestoreException)
 %SWIG_FUTURE(Future_LoadBundleTaskProgress, LoadBundleTaskProgressProxy,
              internal, firebase::firestore::LoadBundleTaskProgress,
              FirestoreException)

--- a/firestore/src/swig/firestore.i
+++ b/firestore/src/swig/firestore.i
@@ -68,10 +68,8 @@
 %csmethodmodifiers firebase::firestore::Firestore::GetInstance "internal";
 
 // Override the default FutureVoid with a version that throws FirestoreException.
-// Do this before app.i, since that also defined FutureVoid, and newer versions
+// Do this before app.i, since that will define FutureVoid, and newer versions
 // of swig only use the first definition of templates.
-%include "app/src/swig/future.i"
-%SWIG_FUTURE(Future_FirestoreVoid, void, internal, void, FirestoreException)
 #define USE_FIRESTORE_FUTURE_VOID 1
 
 %import "app/src/swig/app.i"
@@ -207,6 +205,7 @@ SWIG_MAP_CFUNC_TO_CSDELEGATE(::firebase::firestore::csharp::LoadBundleTaskProgre
                              Firebase.Firestore.FirebaseFirestore.LoadBundleTaskProgressDelegate)
 
 // Generate Future instantiations, must be before other wrappers.
+%include "app/src/swig/future.i"
 %SWIG_FUTURE(Future_AggregateQuerySnapshot, AggregateQuerySnapshotProxy, internal,
              firebase::firestore::AggregateQuerySnapshot, FirestoreException)
 %SWIG_FUTURE(Future_QuerySnapshot, QuerySnapshotProxy, internal,
@@ -215,6 +214,8 @@ SWIG_MAP_CFUNC_TO_CSDELEGATE(::firebase::firestore::csharp::LoadBundleTaskProgre
              firebase::firestore::DocumentSnapshot, FirestoreException)
 %SWIG_FUTURE(Future_DocumentReference, DocumentReferenceProxy, internal,
              firebase::firestore::DocumentReference, FirestoreException)
+// Override the default FutureVoid with a version that throws FirestoreException.
+%SWIG_FUTURE(Future_FirestoreVoid, void, internal, void, FirestoreException)
 %SWIG_FUTURE(Future_LoadBundleTaskProgress, LoadBundleTaskProgressProxy,
              internal, firebase::firestore::LoadBundleTaskProgress,
              FirestoreException)


### PR DESCRIPTION
### Description
> Provide details of the change, and generalize the change in the PR title above.

Newer versions of swig changed some logic around preprocessors that causes future to fail how it was handling void types.
***
### Testing
> Describe how you've tested these changes.


https://github.com/firebase/firebase-unity-sdk/actions/runs/7730685234
***

### Type of Change
Place an `x` the applicable box:
- [ ] Bug fix. Add the issue # below if applicable.
- [ ] New feature. A non-breaking change which adds functionality.
- [x] Other, such as a build process or documentation change.
***

