### PR TITLE
Remove property tags from Android builds

### DIFF
--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -243,6 +243,7 @@ jobs:
             --plugin_dir ~/Downloads/firebase_unity_sdk \
             --output_directory "${{ github.workspace }}" \
             --artifact_name "${{ steps.matrix_info.outputs.info }}" \
+            --notimestamp \
             --force_latest_runtime \
             --ci
       - name: Return Unity license
@@ -420,6 +421,7 @@ jobs:
             --plugin_dir ~/Downloads/firebase_unity_sdk \
             --output_directory "${{ github.workspace }}" \
             --artifact_name "${{ steps.matrix_info.outputs.info }}" \
+            --notimestamp \
             --force_latest_runtime \
             --ci
       - name: Return Unity license

--- a/editor/app/CMakeLists.txt
+++ b/editor/app/CMakeLists.txt
@@ -24,6 +24,7 @@ else()
 endif()
 
 set(firebase_app_editor_src
+    src/AnalyticsFixPropertyRemover.cs
     src/AndroidAPILevelChecker.cs
     src/ApiInfo.cs
     src/AssemblyInfo.cs

--- a/editor/app/src/AnalyticsFixPropertyRemover.cs
+++ b/editor/app/src/AnalyticsFixPropertyRemover.cs
@@ -1,0 +1,103 @@
+/*
+ * Copyright 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Firebase.Editor {
+  using System;
+  using System.IO;
+  using System.Xml;
+  using UnityEngine;
+  using UnityEditor;
+  using UnityEditor.Build;
+  using UnityEditor.Build.Reporting;
+
+  internal class AnalyticsFixPropertyRemover : IPreprocessBuildWithReport {
+    private static string DefaultAndroidManifestContents = String.Join("\n",
+      "<?xml version=\"1.0\" encoding=\"utf-8\"?>",
+      "<manifest",
+      "    xmlns:android=\"http://schemas.android.com/apk/res/android\"",
+      "    package=\"com.unity3d.player\"",
+      "    xmlns:tools=\"http://schemas.android.com/tools\">",
+      "  <application>",
+      "    <activity android:name=\"com.unity3d.player.UnityPlayerActivity\"",
+      "              android:theme=\"@style/UnityThemeSelector\">",
+      "      <intent-filter>",
+      "        <action android:name=\"android.intent.action.MAIN\" />",
+      "        <category android:name=\"android.intent.category.LAUNCHER\" />",
+      "      </intent-filter>",
+      "      <meta-data android:name=\"unityplayer.UnityActivity\" android:value=\"true\" />",
+      "    </activity>",
+      "  </application>",
+      "</manifest>"
+    );
+
+    private static string SearchTag = "AnalyticsFixPropertyRemover";
+    private static string CommentToAdd = "This was added by the AnalyticsFixPropertyRemover. " + 
+        "If you want to prevent the generation of this, have \"" + SearchTag +
+        "\" included in a comment";
+
+    public int callbackOrder { get { return 0; } }
+
+    public void OnPreprocessBuild(BuildReport report) {
+      // Only run this logic when building for Android.
+      if (EditorUserBuildSettings.activeBuildTarget != BuildTarget.Android) {
+        return;
+      }
+
+      // Locate the AndroidManifest file.
+      string androidPluginsDir = Path.Combine(Application.dataPath, "Plugins", "Android");
+      string androidManifestPath = Path.Combine(androidPluginsDir, "AndroidManifest.xml");
+
+      // If the AndroidManifest file doesn't exist, generate it.
+      if (!File.Exists(androidManifestPath)) {
+        File.WriteAllText(androidManifestPath, DefaultAndroidManifestContents);
+      }
+
+      // Check for the SearchTag, and if present there is nothing to do.
+      if (File.ReadAllText(androidManifestPath).Contains(SearchTag)) {
+        return;
+      }
+
+      XmlDocument doc = new XmlDocument();
+      doc.Load(androidManifestPath);
+
+      // Find the "application" node
+      XmlNode applicationNode = doc.SelectSingleNode("/manifest/application");
+
+      if (applicationNode != null) {
+        // Create the new "property" node
+        XmlElement propertyNode = doc.CreateElement("property");
+
+        // Create and add the attribute (with namespace)
+        XmlAttribute toolsAttribute = doc.CreateAttribute("tools", "node", "http://schemas.android.com/tools");
+        toolsAttribute.Value = "removeAll";
+        propertyNode.Attributes.Append(toolsAttribute);
+
+        // Create a comment node, and add it before the property node
+        XmlComment comment = doc.CreateComment(CommentToAdd);
+
+        // Add the new node to the "application" node
+        applicationNode.AppendChild(propertyNode);
+        applicationNode.InsertBefore(comment, propertyNode);
+
+        // Save the modified XML document
+        doc.Save(androidManifestPath);
+      }
+      else {
+        Debug.LogError("Could not find the 'application' node in the AndroidManifest.xml file.");
+      }
+    }
+  }
+}


### PR DESCRIPTION
### Description
> Provide details of the change, and generalize the change in the PR title above.

Android Analytics has added a special <property> tag to its AndroidManifest file, which requires a newer version of Gradle than most Unity versions ship with.  Add logic to remove the tag by default, and if users want to maintain the tag they can by following the instructions in the modified AndroidManifest file that this logic creates.
***
### Testing
> Describe how you've tested these changes.

Testing in other branches, since this also requires changes to EDM4U that aren't in yet for Android to fully work.

This branch:
https://github.com/firebase/firebase-unity-sdk/actions/runs/7850328827
***

### Type of Change
Place an `x` the applicable box:
- [ ] Bug fix. Add the issue # below if applicable.
- [ ] New feature. A non-breaking change which adds functionality.
- [x] Other, such as a build process or documentation change.
***

