### PR TITLE
Improve logic around removeAll tag and newer gradle versions

### DIFF
--- a/docs/readme.md
+++ b/docs/readme.md
@@ -73,6 +73,7 @@ Release Notes
 -------------
 ### Upcoming release
 - Changes
+    - General (Android): Improve how property tag logic handles Unity 2022+.
     - Dynamic Links: The Dynamic Links SDK is now deprecated. See the [support
       documentation](https://firebase.google.com/support/dynamic-links-faq)
       for more information.

--- a/editor/app/src/AnalyticsFixPropertyRemover.cs
+++ b/editor/app/src/AnalyticsFixPropertyRemover.cs
@@ -56,7 +56,7 @@ namespace Firebase.Editor {
         return;
       }
 
-      Debug.Log("====== Found the following Gradle Version: " + GooglePlayServices.PlayServicesResolver.AndroidGradlePluginVersion);
+      Debug.Log("=-=-= Found the following Gradle Version: " + GooglePlayServices.PlayServicesResolver.AndroidGradlePluginVersion);
 
       // If the gradle version is newer than 7.0.0, which should have support
       // for the property tag, there is no reason to add the removeAll logic.
@@ -64,6 +64,7 @@ namespace Firebase.Editor {
       if (versionComparer.Compare(
             GooglePlayServices.PlayServicesResolver.AndroidGradlePluginVersion,
             "7.0.0") >= 0) {
+        Debug.Log("=-=-=  Returning early because version is new enough");
         return;
       }
 
@@ -78,6 +79,7 @@ namespace Firebase.Editor {
 
       // Check for the SearchTag, and if present there is nothing to do.
       if (File.ReadAllText(androidManifestPath).Contains(SearchTag)) {
+        Debug.Log("=-=-=  Returning early because found the searchtag");
         return;
       }
 
@@ -109,6 +111,8 @@ namespace Firebase.Editor {
       else {
         Debug.LogError("Could not find the 'application' node in the AndroidManifest.xml file.");
       }
+
+      Debug.Log("=-=-=  The removeAll tag should be added");
     }
   }
 }

--- a/editor/app/src/AnalyticsFixPropertyRemover.cs
+++ b/editor/app/src/AnalyticsFixPropertyRemover.cs
@@ -56,15 +56,12 @@ namespace Firebase.Editor {
         return;
       }
 
-      Debug.Log("=-=-= Found the following Gradle Version: " + GooglePlayServices.PlayServicesResolver.AndroidGradlePluginVersion);
-
       // If the gradle version is newer than 7.0.0, which should have support
       // for the property tag, there is no reason to add the removeAll logic.
       var versionComparer = new Google.JarResolver.Dependency.VersionComparer();
       if (versionComparer.Compare(
             GooglePlayServices.PlayServicesResolver.AndroidGradlePluginVersion,
-            "7.0.0") >= 0) {
-        Debug.Log("=-=-=  Returning early because version is new enough");
+            "7.0.0") <= 0) {
         return;
       }
 
@@ -79,7 +76,6 @@ namespace Firebase.Editor {
 
       // Check for the SearchTag, and if present there is nothing to do.
       if (File.ReadAllText(androidManifestPath).Contains(SearchTag)) {
-        Debug.Log("=-=-=  Returning early because found the searchtag");
         return;
       }
 
@@ -111,8 +107,6 @@ namespace Firebase.Editor {
       else {
         Debug.LogError("Could not find the 'application' node in the AndroidManifest.xml file.");
       }
-
-      Debug.Log("=-=-=  The removeAll tag should be added");
     }
   }
 }

--- a/editor/app/src/AnalyticsFixPropertyRemover.cs
+++ b/editor/app/src/AnalyticsFixPropertyRemover.cs
@@ -56,6 +56,15 @@ namespace Firebase.Editor {
         return;
       }
 
+      // If the gradle version is newer than 7.0.0, which should have support
+      // for the property tag, there is no reason to add the removeAll logic.
+      var versionComparer = new Google.JarResolver.Dependency.VersionComparer();
+      if (versionComparer.Compare(
+            GooglePlayServices.PlayServicesResolver.AndroidGradlePluginVersion,
+            "7.0.0") >= 0) {
+        return;
+      }
+
       // Locate the AndroidManifest file.
       string androidPluginsDir = Path.Combine(Application.dataPath, "Plugins", "Android");
       string androidManifestPath = Path.Combine(androidPluginsDir, "AndroidManifest.xml");

--- a/editor/app/src/AnalyticsFixPropertyRemover.cs
+++ b/editor/app/src/AnalyticsFixPropertyRemover.cs
@@ -56,6 +56,8 @@ namespace Firebase.Editor {
         return;
       }
 
+      Debug.Log("====== Found the following Gradle Version: " + GooglePlayServices.PlayServicesResolver.AndroidGradlePluginVersion);
+
       // If the gradle version is newer than 7.0.0, which should have support
       // for the property tag, there is no reason to add the removeAll logic.
       var versionComparer = new Google.JarResolver.Dependency.VersionComparer();


### PR DESCRIPTION
### Description
> Provide details of the change, and generalize the change in the PR title above.

Improve the logic to only add the property removeAll tag if the gradle version being used is old enough that it doesn't support the property tag in the manifest merger.  By default this should apply to Unity 2022+.
***
### Testing
> Describe how you've tested these changes.

Testing this locally across both older and newer Unity versions.
***

### Type of Change
Place an `x` the applicable box:
- [x] Bug fix. Add the issue # below if applicable.
- [ ] New feature. A non-breaking change which adds functionality.
- [ ] Other, such as a build process or documentation change.
***

https://github.com/firebase/firebase-unity-sdk/issues/945