### PR TITLE
Add new method to update Auth User's email

### DIFF
--- a/auth/src/FirebaseUser.cs
+++ b/auth/src/FirebaseUser.cs
@@ -278,10 +278,14 @@ public sealed class FirebaseUser : UserInfoInterface {
     return GetValidFirebaseUserInternal().TokenAsync(forceRefresh);
   }
 
+  /// @deprecated This method is deprecated. Please use
+  /// @ref SendEmailVerificationBeforeUpdatingEmailAsync(string) instead.
+  /// 
   /// Sets the email address for the user.
   ///
   /// May fail if there is already an email/password-based account for the same
   /// email address.
+  [System.Obsolete("Please use `Task SendEmailVerificationBeforeUpdatingEmailAsync(string)` instead", false)]
   public Task UpdateEmailAsync(string email) {
     return GetValidFirebaseUserInternal().UpdateEmailAsync(email);
   }
@@ -307,6 +311,12 @@ public sealed class FirebaseUser : UserInfoInterface {
   /// Initiates email verification for the user.
   public Task SendEmailVerificationAsync() {
     return GetValidFirebaseUserInternal().SendEmailVerificationAsync();
+  }
+
+  /// Send an email to verify the ownership of the account, then update
+  /// to the new email.
+  public Task SendEmailVerificationBeforeUpdatingEmailAsync(string email) {
+    return GetValidFirebaseUserInternal().SendEmailVerificationBeforeUpdatingEmailAsync(email);
   }
 
   /// Updates a subset of user profile information.

--- a/docs/readme.md
+++ b/docs/readme.md
@@ -74,6 +74,9 @@ Release Notes
 ### Upcoming release
 - Changes
     - General (Android): Improve how property tag logic handles Unity 2022+.
+    - Auth: Add FirebaseUser.SendEmailVerificationBeforeUpdatingEmailAsync,
+      a new method to verify and change the User's email.
+    - Auth: Deprecate the older method of updating emails, UpdateEmail.
     - Dynamic Links: The Dynamic Links SDK is now deprecated. See the [support
       documentation](https://firebase.google.com/support/dynamic-links-faq)
       for more information.


### PR DESCRIPTION
### Description
> Provide details of the change, and generalize the change in the PR title above.

Add FirebaseUser.SendEmailVerificationBeforeUpdatingEmailAsync, which is the new method to update user emails,
and deprecate UpdateEmailAsync, which no longer works when Email Enumeration Protection is turned on.
***
### Testing
> Describe how you've tested these changes.

Building and testing locally, plus
https://github.com/firebase/firebase-unity-sdk/actions/runs/8103734621
***

### Type of Change
Place an `x` the applicable box:
- [ ] Bug fix. Add the issue # below if applicable.
- [x] New feature. A non-breaking change which adds functionality.
- [ ] Other, such as a build process or documentation change.
***

