### PR TITLE
Temporarily remove the Android on Mac test runs

### DIFF
--- a/scripts/gha/print_matrix_configuration.py
+++ b/scripts/gha/print_matrix_configuration.py
@@ -266,6 +266,11 @@ def get_testapp_build_matrix(matrix_type, unity_versions, platforms, build_os, i
     platform = li[1]
     os = li[2] if li[2] else (MACOS_RUNNER if (platform in [IOS, TVOS]) else WINDOWS_RUNNER)
 
+    # TODO: Remove this when we can get it working on GHA again
+    # Skip the MacOS + Android combo, because it has been having configuration issues on the GHA machines
+    if platform==ANDROID and os==MACOS_RUNNER:
+      continue
+
     if platform in [IOS, TVOS]:
       # for iOS, tvOS platforms, exclude non macOS build_os
       if os==MACOS_RUNNER:


### PR DESCRIPTION
### Description
> Provide details of the change, and generalize the change in the PR title above.

The GHA machines have been giving errors on Mac when trying to build the Android testapps, primarily around NDK and JDK issues.  Disable these tests for now, until we can track down the root cause of the issue.
***
### Testing
> Describe how you've tested these changes.

https://github.com/firebase/firebase-unity-sdk/actions/runs/8760959333
***

### Type of Change
Place an `x` the applicable box:
- [ ] Bug fix. Add the issue # below if applicable.
- [ ] New feature. A non-breaking change which adds functionality.
- [x] Other, such as a build process or documentation change.
***

