### PR TITLE
Add sleeps after Unity calls in testapp builder

### DIFF
--- a/scripts/gha/build_testapps.py
+++ b/scripts/gha/build_testapps.py
@@ -821,6 +821,7 @@ def _switch_to_latest_runtime(dir_helper, arg_builder):
   dir_helper.copy_editor_script("RuntimeSwitcher.cs")
   arg_builder.set_log_file(dir_helper.make_log_path("switch_runtime"))
   _run(arg_builder.get_args_for_method("RuntimeSwitcher.SwitchToLatest"))
+  time.sleep(0.5)
 
 
 def _create_unity_project(dir_helper):
@@ -845,6 +846,7 @@ def _import_unity_plugins(dir_helper, arg_builder):
     name = os.path.splitext(os.path.basename(plugin_path))[0]
     arg_builder.set_log_file(dir_helper.make_log_path("import_" + name))
     _run(arg_builder.get_args_for_import(plugin_path))
+    time.sleep(0.5)
 
 
 # Unity Package Manager is Unity's newer style of packaging.
@@ -861,6 +863,7 @@ def _import_upm_packages(dir_helper, arg_builder):
         arg_builder.get_args_for_method(
             method="PackageImporter.Import",
             method_args=["-PackageImporter.package", package]))
+    time.sleep(0.5)
 
 
 # In an automated context with batchmode, it was found that these
@@ -877,6 +880,7 @@ def _enable_firebase_assemblies(dir_helper, arg_builder):
           method_args=[
               "-PluginToggler.plugins",
               "Firebase.Editor.dll,Google.VersionHandlerImpl"]))
+  time.sleep(0.5)
 
 
 def _edm4u_update(dir_helper, arg_builder):
@@ -884,6 +888,7 @@ def _edm4u_update(dir_helper, arg_builder):
   arg_builder.set_log_file(dir_helper.make_log_path("versionhandler_update"))
   logging.info("Running VersionHandler.UpdateNow...")
   _run(arg_builder.get_args_for_method("Google.VersionHandler.UpdateNow"))
+  time.sleep(0.5)
 
 
 def _copy_unity_assets(dir_helper, files_to_ignore):


### PR DESCRIPTION
### Description
> Provide details of the change, and generalize the change in the PR title above.

The testapp builder has occasionally been having issues where after one Unity call (with -quit), when it gets to the next call Unity still seems to be running, causing an error.  Adding a small sleep, to give the previous call a chance to close properly.
***
### Testing
> Describe how you've tested these changes.


***

### Type of Change
Place an `x` the applicable box:
- [ ] Bug fix. Add the issue # below if applicable.
- [ ] New feature. A non-breaking change which adds functionality.
- [x] Other, such as a build process or documentation change.
***

