### PR TITLE
Remove deprecated RC ConfigSettings field

### DIFF
--- a/docs/readme.md
+++ b/docs/readme.md
@@ -71,6 +71,11 @@ Support
 
 Release Notes
 -------------
+### Upcoming
+- Changes
+    - Remote Config: Remove deprecated `ConfigSettings.MinimumFetchInternalInMilliseconds`,
+      use `ConfigSettings.MinimumFetchIntervalInMilliseconds` instead.
+
 ### 11.9.0
 - Changes
     - General: Update to Firebase C++ SDK version 11.10.0.

--- a/remote_config/src/ConfigSettings.cs
+++ b/remote_config/src/ConfigSettings.cs
@@ -32,15 +32,6 @@ namespace Firebase.RemoteConfig {
     /// fetch. Default is 12 hours.
     public ulong MinimumFetchIntervalInMilliseconds { get; set; }
 
-    /// The minimum interval between successive fetch calls.
-    ///
-    /// @deprecated Use MinimumFetchIntervalInMilliseconds instead. This will be
-    /// removed in the next major release.
-    public ulong MinimumFetchInternalInMilliseconds {
-      get { return MinimumFetchIntervalInMilliseconds; }
-      set { MinimumFetchIntervalInMilliseconds = value; }
-    }
-
     internal static ConfigSettings FromInternal(ConfigSettingsInternal csInternal) {
       return new ConfigSettings {
         FetchTimeoutInMilliseconds = csInternal.fetch_timeout_in_milliseconds,


### PR DESCRIPTION
### Description
> Provide details of the change, and generalize the change in the PR title above.

Remove the deprecated ConfigSettings.MinimumFetchInternalInMilliseconds in prep for the next major release, as it has been deprecated for more than a year now.  Use ConfigSettings.MinimumFetchIntervalInMilliseconds instead (the difference is Internal vs Interval).
***
### Testing
> Describe how you've tested these changes.


***

### Type of Change
Place an `x` the applicable box:
- [ ] Bug fix. Add the issue # below if applicable.
- [ ] New feature. A non-breaking change which adds functionality.
- [x] Other, such as a build process or documentation change.
***

