### PR TITLE
Pin the mac runners to 12

### DIFF
--- a/.github/workflows/build_android.yml
+++ b/.github/workflows/build_android.yml
@@ -38,7 +38,7 @@ on:
 jobs:
   build_android:
     name: build-android-unity${{ inputs.unity_version }}-CPP${{ inputs.firebase_cpp_sdk_version }}
-    runs-on: macos-latest
+    runs-on: macos-12
     strategy:
       fail-fast: false
     env:

--- a/.github/workflows/build_macos.yml
+++ b/.github/workflows/build_macos.yml
@@ -38,7 +38,7 @@ on:
 jobs:
   build_desktop:
     name: build-macOS-unity${{ inputs.unity_version}}-CPP${{ inputs.firebase_cpp_sdk_version }}
-    runs-on: macos-latest
+    runs-on: macos-12
     strategy:
       fail-fast: false
 

--- a/scripts/gha/print_matrix_configuration.py
+++ b/scripts/gha/print_matrix_configuration.py
@@ -56,7 +56,7 @@ PLAYMODE = "Playmode"
 
 # GitHub Runner
 WINDOWS_RUNNER = "windows-latest"
-MACOS_RUNNER = "macos-latest"
+MACOS_RUNNER = "macos-12"
 LINUX_RUNNER = "ubuntu-latest"
 
 PARAMETERS = {


### PR DESCRIPTION
### Description
> Provide details of the change, and generalize the change in the PR title above.

macos-latest used to refer to macos-12, but has since changed to macos-14-arm64.  It'll take some effort to upgrade the logic for that jump, so for now pin back to 12.
***
### Testing
> Describe how you've tested these changes.


https://github.com/firebase/firebase-unity-sdk/actions/runs/8824930809
***

### Type of Change
Place an `x` the applicable box:
- [ ] Bug fix. Add the issue # below if applicable.
- [ ] New feature. A non-breaking change which adds functionality.
- [x] Other, such as a build process or documentation change.
***

