### PR TITLE
Fix formatting exception for unknown property

### DIFF
--- a/firestore/src/Converters/AttributedTypeConverter.cs
+++ b/firestore/src/Converters/AttributedTypeConverter.cs
@@ -136,7 +136,8 @@ namespace Firebase.Firestore.Converters {
                     "No writable property for Firestore field {0} in type {1}", key, TargetType.FullName));
                 break;
               case UnknownPropertyHandling.Throw:
-                throw new ArgumentException(String.Format("No writable property for Firestore field {key} in type {0}", TargetType.FullName));
+                throw new ArgumentException(String.Format(
+                    "No writable property for Firestore field {0} in type {1}", key, TargetType.FullName));
             }
           }
         }


### PR DESCRIPTION
### Description
> Provide details of the change, and generalize the change in the PR title above.

When an annotated class is set to `UnknownPropertyHandling.Throw`, an unexpected exception is thrown rather than the intended readable one. `string.Format()` has an invalid format string, as it expects exclusively argument indexes.
 
***
### Testing
> Describe how you've tested these changes.


Tested by running the same scenario with the patch, and the expected exception is thrown to the calling code.
***

### Type of Change
Place an `x` the applicable box:
- [x] Bug fix. Add the issue # below if applicable.
- [ ] New feature. A non-breaking change which adds functionality.
- [ ] Other, such as a build process or documentation change.
***

