### PR TITLE
Add a workaround to tvOS testapp build

### DIFF
--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -204,7 +204,7 @@ jobs:
           password: ${{ secrets.UNITY_PASSWORD }}
           serial_ids: ${{ secrets.SERIAL_ID }}
       - name: Workaround tvOS XCode 15 issue
-        if: ${{ contains(matrix.platform, 'tvOS') }}
+        if: ${{ contains(matrix.platform, 'tvOS') && contains(matrix.unity_version, '2020') }}
         shell: bash
         run: |
           find /Applications/Unity/Hub/Editor -type f -name 'UnityViewControllerBase.h' -exec sed -i '' 's/#import <GameController\/GCController.h>/#import <GameController\/GCEventViewController.h>/g' {} \;

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -203,6 +203,11 @@ jobs:
           username: ${{ secrets.UNITY_USERNAME }}
           password: ${{ secrets.UNITY_PASSWORD }}
           serial_ids: ${{ secrets.SERIAL_ID }}
+      - name: Workaround tvOS XCode 15 issue
+        if: ${{ contains(matrix.platform, 'tvOS') }}
+        shell: bash
+        run: |
+          find /Applications/Unity/Hub/Editor -type f -name 'UnityViewControllerBase.h' -exec sed -i '' 's/#import <GameController\/GCController.h>/#import <GameController\/GCEventViewController.h>/g' {} \;
       - name: Prepare for integration tests
         timeout-minutes: 10
         shell: bash


### PR DESCRIPTION
### Description
> Provide details of the change, and generalize the change in the PR title above.

There was an issue with tvOS builds and XCode 15, here:
https://issuetracker.unity3d.com/issues/tvos-unable-to-build-any-tvos-project-using-xcode-15-beta

We still run tests on a 2020 version, so we can duplicate the fix in the workflow as a workaround.

***
### Testing
> Describe how you've tested these changes.

https://github.com/firebase/firebase-unity-sdk/actions/runs/8993239723
***

### Type of Change
Place an `x` the applicable box:
- [ ] Bug fix. Add the issue # below if applicable.
- [ ] New feature. A non-breaking change which adds functionality.
- [x] Other, such as a build process or documentation change.
***

