### PR TITLE
Add a workaround for invalid test logs

### DIFF
--- a/scripts/gha/build_testapps.py
+++ b/scripts/gha/build_testapps.py
@@ -626,8 +626,12 @@ def perform_in_editor_tests(dir_helper, retry_on_license_check=True, remaining_r
     time.sleep(5)
     time_until_timeout -= 5
     if os.path.exists(log):
-      with open(log) as f:
-        text = f.read()
+      try:
+        with open(log, 'r', encoding='utf-8') as f:
+          text = f.read()
+      except UnicodeDecodeError:
+        with open(log, 'rb') as f:  # Open in binary mode
+          text = f.read().decode('utf-8', errors='replace') 
       test_finished = "All tests finished" in text
       if retry_on_license_check and "License updated successfully" in text:
         logging.info("License check caused assembly reload. Retrying tests.")


### PR DESCRIPTION
### Description
> Provide details of the change, and generalize the change in the PR title above.

Sometimes the Unity editor test logs have an invalid character for utf-8, which causes errors.  Add some error handling, replacing any bad characters discovered.
***
### Testing
> Describe how you've tested these changes.

https://github.com/firebase/firebase-unity-sdk/actions/runs/9182014476
***

### Type of Change
Place an `x` the applicable box:
- [ ] Bug fix. Add the issue # below if applicable.
- [ ] New feature. A non-breaking change which adds functionality.
- [x] Other, such as a build process or documentation change.
***

