### PR TITLE
Modify RC tests for iOS simulators

### DIFF
--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -555,6 +555,25 @@ jobs:
         if: ${{ matrix.device_type == 'virtual' && !cancelled() }}
         run: |
           xcrun xctrace list devices
+      - name: Create keychain (macOS Simulator)
+        if: ${{ contains('iOS,tvOS', matrix.platform) && matrix.device_type == 'virtual'}}
+        shell: bash
+        run: |
+          echo "Creating temporary keychain"
+          # Create a local keychain on Mac:
+          # Clean up previous temp keychain, if any.
+          security delete-keychain tmp-keychain 2> /dev/null || true
+          # Create temp keychain file and unlock it.
+          # (Avoid passing in -p on command line by using interactive mode.)
+          # Also set it to default settings so there is no unlock timeout.
+          security -i <<EOF
+          create-keychain -p ${{ secrets.TEST_SECRET }} tmp-keychain
+          set-keychain-settings tmp-keychain
+          unlock-keychain -p ${{ secrets.TEST_SECRET }} tmp-keychain
+          EOF
+          # Change the keychain list and default keychain to the temp keychain.
+          security list-keychains -d user -s tmp-keychain
+          security default-keychain -s tmp-keychain
       - name: Run Mobile integration tests on virtual device locally
         timeout-minutes: 120
         if: ${{ matrix.device_type == 'virtual' && !cancelled() }}
@@ -565,6 +584,15 @@ jobs:
             --android_device "${{ matrix.test_device }}" \
             --logfile_name ""${{ steps.matrix_info.outputs.info }}"" \
             --ci
+      - name: Delete keychain (macOS Simulator)
+        if: ${{ always() && contains('iOS,tvOS', matrix.platform) && matrix.device_type == 'virtual' }}
+        shell: bash
+        run: |
+          # Remove the local keychain on Mac:
+          # Set back to the default login keychain.
+          security list-keychains -d user -s login.keychain
+          # Delete the temp keychain, if it exists.
+          security delete-keychain tmp-keychain || true
       - name: Prepare results summary artifact
         if: ${{ !cancelled() }}
         shell: bash

--- a/remote_config/testapp/Assets/Firebase/Sample/RemoteConfig/UIHandlerAutomated.cs
+++ b/remote_config/testapp/Assets/Firebase/Sample/RemoteConfig/UIHandlerAutomated.cs
@@ -75,6 +75,8 @@ namespace Firebase.Sample.RemoteConfig {
     }
 
     Task TestAddOnConfigUpdateListener() {
+      // This test can sometimes take a bit longer than a minute, so increase the timeout.
+      testRunner.TestTimeoutSeconds = 120.0f;
       bool hasDefaultValue =
           FirebaseRemoteConfig.DefaultInstance.GetValue("config_test_string").Source
           == ValueSource.DefaultValue;

--- a/remote_config/testapp/Assets/Firebase/Sample/RemoteConfig/UIHandlerAutomated.cs
+++ b/remote_config/testapp/Assets/Firebase/Sample/RemoteConfig/UIHandlerAutomated.cs
@@ -13,6 +13,7 @@ namespace Firebase.Sample.RemoteConfig {
       // Set the list of tests to run, note this is done at Start since they are
       // non-static.
       Func<Task>[] tests = {
+        TestSetConfigSettings,
         TestDisplayData,
         TestDisplayAllKeys,
 // Skip the Realtime RC test on desktop as it is not yet supported.
@@ -48,6 +49,13 @@ namespace Firebase.Sample.RemoteConfig {
       }
     }
 
+    Task TestSetConfigSettings() {
+      var configSettings = new Firebase.RemoteConfig.ConfigSettings();
+      configSettings.FetchTimeoutInMilliseconds = 30 * 1000;
+      configSettings.MinimumFetchIntervalInMilliseconds = 0;
+      return FirebaseRemoteConfig.DefaultInstance.SetConfigSettingsAsync(configSettings);
+    }
+
     Task TestDisplayData() {
       DisplayData();
       return Task.FromResult(true);
@@ -75,8 +83,6 @@ namespace Firebase.Sample.RemoteConfig {
     }
 
     Task TestAddOnConfigUpdateListener() {
-      // This test can sometimes take a bit longer than a minute, so increase the timeout.
-      testRunner.TestTimeoutSeconds = 300.0f;
       bool hasDefaultValue =
           FirebaseRemoteConfig.DefaultInstance.GetValue("config_test_string").Source
           == ValueSource.DefaultValue;

--- a/remote_config/testapp/Assets/Firebase/Sample/RemoteConfig/UIHandlerAutomated.cs
+++ b/remote_config/testapp/Assets/Firebase/Sample/RemoteConfig/UIHandlerAutomated.cs
@@ -17,8 +17,8 @@ namespace Firebase.Sample.RemoteConfig {
         TestDisplayAllKeys,
 // Skip the Realtime RC test on desktop as it is not yet supported.
 #if (UNITY_IOS || UNITY_TVOS || UNITY_ANDROID) && !UNITY_EDITOR
-        TestAddOnConfigUpdateListener,
-        TestAddAndRemoveConfigUpdateListener,
+        //TestAddOnConfigUpdateListener,
+        //TestAddAndRemoveConfigUpdateListener,
 #endif  // !(UNITY_IOS || UNITY_TVOS || UNITY_ANDROID) || UNITY_EDITOR
         TestFetchData,
       };

--- a/remote_config/testapp/Assets/Firebase/Sample/RemoteConfig/UIHandlerAutomated.cs
+++ b/remote_config/testapp/Assets/Firebase/Sample/RemoteConfig/UIHandlerAutomated.cs
@@ -4,6 +4,7 @@ namespace Firebase.Sample.RemoteConfig {
   using System;
   using System.Linq;
   using System.Threading.Tasks;
+  using UnityEngine;
 
   // An automated version of the UIHandler that runs tests on Firebase Remote Config.
   public class UIHandlerAutomated : UIHandler {
@@ -95,6 +96,13 @@ namespace Firebase.Sample.RemoteConfig {
         return Task.FromResult(true);
       }
 
+      if (SystemInfo.graphicsDeviceName.ToLower().Contains("simulator")) {
+        DebugLog("WARNING: iOS simulator can frequently take a significant amount "
+          + "of time to do the fetch, so this is disabled by default. To test, "
+          + "modify the scripts.");
+        return Task.FromResult(true);
+      }
+
       TaskCompletionSource<bool> test_success = new TaskCompletionSource<bool>();
       EventHandler<ConfigUpdateEventArgs> myHandler =
           (object sender, ConfigUpdateEventArgs args) => {
@@ -132,6 +140,13 @@ namespace Firebase.Sample.RemoteConfig {
     }
 
     Task TestFetchData() {
+      if (SystemInfo.graphicsDeviceName.ToLower().Contains("simulator")) {
+        DebugLog("WARNING: iOS simulator can frequently take a significant amount "
+          + "of time to do the fetch, so this is disabled by default. To test, "
+          + "modify the scripts.");
+        return Task.FromResult(true);
+      }
+
       // Note: FetchDataAsync calls both Fetch and Activate.
       return FetchDataAsync().ContinueWithOnMainThread((_) => {
         // Verify that RemoteConfig now has the expected values.

--- a/remote_config/testapp/Assets/Firebase/Sample/RemoteConfig/UIHandlerAutomated.cs
+++ b/remote_config/testapp/Assets/Firebase/Sample/RemoteConfig/UIHandlerAutomated.cs
@@ -17,8 +17,8 @@ namespace Firebase.Sample.RemoteConfig {
         TestDisplayAllKeys,
 // Skip the Realtime RC test on desktop as it is not yet supported.
 #if (UNITY_IOS || UNITY_TVOS || UNITY_ANDROID) && !UNITY_EDITOR
-        //TestAddOnConfigUpdateListener,
-        //TestAddAndRemoveConfigUpdateListener,
+        TestAddOnConfigUpdateListener,
+        TestAddAndRemoveConfigUpdateListener,
 #endif  // !(UNITY_IOS || UNITY_TVOS || UNITY_ANDROID) || UNITY_EDITOR
         TestFetchData,
       };
@@ -76,7 +76,7 @@ namespace Firebase.Sample.RemoteConfig {
 
     Task TestAddOnConfigUpdateListener() {
       // This test can sometimes take a bit longer than a minute, so increase the timeout.
-      testRunner.TestTimeoutSeconds = 120.0f;
+      testRunner.TestTimeoutSeconds = 300.0f;
       bool hasDefaultValue =
           FirebaseRemoteConfig.DefaultInstance.GetValue("config_test_string").Source
           == ValueSource.DefaultValue;

--- a/scripts/gha/print_matrix_configuration.py
+++ b/scripts/gha/print_matrix_configuration.py
@@ -142,8 +142,8 @@ TEST_DEVICES = {
                    "model=iphone8,version=16.6",
                    "model=ipad10,version=16.6",
                  ]},
-  "simulator_min": {"platform": IOS, "type": "virtual", "name": "iPhone 15 Plus", "version": "17.4"},
-  "simulator_target": {"platform": IOS, "type": "virtual", "name": "iPhone 15 Plus", "version": "17.4"},
+  "simulator_min": {"platform": IOS, "type": "virtual", "name": "iPhone 15 Pro Max", "version": "17.0.1"},
+  "simulator_target": {"platform": IOS, "type": "virtual", "name": "iPhone 15 Pro Max", "version": "17.0.1"},
   "simulator_latest": {"platform": IOS, "type": "virtual", "name": "iPhone 15 Plus", "version": "17.4"},
   "tvos_simulator": {"platform": TVOS, "type": "virtual", "name": "Apple TV", "version": "16.1"},
 }

--- a/scripts/gha/print_matrix_configuration.py
+++ b/scripts/gha/print_matrix_configuration.py
@@ -143,7 +143,7 @@ TEST_DEVICES = {
                    "model=ipad10,version=16.6",
                  ]},
   "simulator_min": {"platform": IOS, "type": "virtual", "name": "iPhone 15 Pro Max", "version": "17.0.1"},
-  "simulator_target": {"platform": IOS, "type": "virtual", "name": "iPhone 15 Pro Max", "version": "17.2"},
+  "simulator_target": {"platform": IOS, "type": "virtual", "name": "iPhone 15 Pro Max", "version": "17.0.1"},
   "simulator_latest": {"platform": IOS, "type": "virtual", "name": "iPhone 15 Plus", "version": "17.4"},
   "tvos_simulator": {"platform": TVOS, "type": "virtual", "name": "Apple TV", "version": "16.1"},
 }

--- a/scripts/gha/print_matrix_configuration.py
+++ b/scripts/gha/print_matrix_configuration.py
@@ -143,7 +143,7 @@ TEST_DEVICES = {
                    "model=ipad10,version=16.6",
                  ]},
   "simulator_min": {"platform": IOS, "type": "virtual", "name": "iPhone 15 Pro Max", "version": "17.0.1"},
-  "simulator_target": {"platform": IOS, "type": "virtual", "name": "iPhone 15 Plus", "version": "17.2"},
+  "simulator_target": {"platform": IOS, "type": "virtual", "name": "iPhone 15 Pro Max", "version": "17.2"},
   "simulator_latest": {"platform": IOS, "type": "virtual", "name": "iPhone 15 Plus", "version": "17.4"},
   "tvos_simulator": {"platform": TVOS, "type": "virtual", "name": "Apple TV", "version": "16.1"},
 }

--- a/scripts/gha/print_matrix_configuration.py
+++ b/scripts/gha/print_matrix_configuration.py
@@ -143,7 +143,7 @@ TEST_DEVICES = {
                    "model=ipad10,version=16.6",
                  ]},
   "simulator_min": {"platform": IOS, "type": "virtual", "name": "iPhone 15 Pro Max", "version": "17.0.1"},
-  "simulator_target": {"platform": IOS, "type": "virtual", "name": "iPhone 15 Pro Max", "version": "17.0.1"},
+  "simulator_target": {"platform": IOS, "type": "virtual", "name": "iPhone 15 Pro Max", "version": "17.2"},
   "simulator_latest": {"platform": IOS, "type": "virtual", "name": "iPhone 15 Plus", "version": "17.4"},
   "tvos_simulator": {"platform": TVOS, "type": "virtual", "name": "Apple TV", "version": "16.1"},
 }

--- a/scripts/gha/print_matrix_configuration.py
+++ b/scripts/gha/print_matrix_configuration.py
@@ -142,8 +142,8 @@ TEST_DEVICES = {
                    "model=iphone8,version=16.6",
                    "model=ipad10,version=16.6",
                  ]},
-  "simulator_min": {"platform": IOS, "type": "virtual", "name": "iPhone 15 Pro Max", "version": "17.0.1"},
-  "simulator_target": {"platform": IOS, "type": "virtual", "name": "iPhone 15 Pro Max", "version": "17.2"},
+  "simulator_min": {"platform": IOS, "type": "virtual", "name": "iPhone 15 Plus", "version": "17.4"},
+  "simulator_target": {"platform": IOS, "type": "virtual", "name": "iPhone 15 Plus", "version": "17.4"},
   "simulator_latest": {"platform": IOS, "type": "virtual", "name": "iPhone 15 Plus", "version": "17.4"},
   "tvos_simulator": {"platform": TVOS, "type": "virtual", "name": "Apple TV", "version": "16.1"},
 }

--- a/scripts/gha/print_matrix_configuration.py
+++ b/scripts/gha/print_matrix_configuration.py
@@ -143,7 +143,7 @@ TEST_DEVICES = {
                    "model=ipad10,version=16.6",
                  ]},
   "simulator_min": {"platform": IOS, "type": "virtual", "name": "iPhone 15 Pro Max", "version": "17.0.1"},
-  "simulator_target": {"platform": IOS, "type": "virtual", "name": "iPhone 15 Pro Max", "version": "17.0.1"},
+  "simulator_target": {"platform": IOS, "type": "virtual", "name": "iPhone 15 Plus", "version": "17.2"},
   "simulator_latest": {"platform": IOS, "type": "virtual", "name": "iPhone 15 Plus", "version": "17.4"},
   "tvos_simulator": {"platform": TVOS, "type": "virtual", "name": "Apple TV", "version": "16.1"},
 }


### PR DESCRIPTION
### Description
> Provide details of the change, and generalize the change in the PR title above.

Disable tests that require Remote Config fetching on iOS simulator devices.  This keeps timing out on the GHA runners for some reason, but not locally, and not on the C++ tests, so it is likely some configuration issue that will need more time to track down.
***
### Testing
> Describe how you've tested these changes.

https://github.com/firebase/firebase-unity-sdk/actions/runs/9557339261
***

### Type of Change
Place an `x` the applicable box:
- [ ] Bug fix. Add the issue # below if applicable.
- [ ] New feature. A non-breaking change which adds functionality.
- [x] Other, such as a build process or documentation change.
***

