### PR TITLE
Add null checks, and improve swig error handling

### DIFF
--- a/docs/readme.md
+++ b/docs/readme.md
@@ -71,6 +71,11 @@ Support
 
 Release Notes
 -------------
+### Upcoming
+- Changes
+    - Messaging: Fixed a crash when opening a push notification.
+      ([#1091](https://github.com/firebase/firebase-unity-sdk/issues/1091)).
+
 ### 12.2.0
 - Changes
     - General: Update to Firebase C++ SDK version 12.2.0.

--- a/messaging/src/FirebaseNotification.cs
+++ b/messaging/src/FirebaseNotification.cs
@@ -22,6 +22,8 @@ namespace Firebase.Messaging {
 /// implementation.
 public sealed class AndroidNotificationParams {
   internal static AndroidNotificationParams FromInternal(AndroidNotificationParamsInternal other) {
+    if (other == null) return null;
+
     AndroidNotificationParams android = new AndroidNotificationParams();
     android.ChannelId = other.channel_id;
     return android;
@@ -45,6 +47,8 @@ public sealed class AndroidNotificationParams {
 /// library.
 public sealed class FirebaseNotification {
   internal static FirebaseNotification FromInternal(FirebaseNotificationInternal other) {
+    if (other == null) return null;
+
     FirebaseNotification notification = new FirebaseNotification();
     notification.Android = AndroidNotificationParams.FromInternal(other.android);
     notification.Badge = other.badge;

--- a/messaging/src/swig/messaging.i
+++ b/messaging/src/swig/messaging.i
@@ -69,7 +69,7 @@ public:
   // OnMessage() callback in this class.  SWIGSTDCALL is used here as C#
   // delegates *must* be called using the stdcall calling convention rather
   // than whatever the compiler defines.
-  typedef int (SWIGSTDCALL *MessageReceivedCallback)(void* message);
+  typedef bool (SWIGSTDCALL *MessageReceivedCallback)(void* message);
   // Function which is used to reference a C# delegate which is called from
   // OnTokenReceived() callback in this class.  SWIGSTDCALL is used here as C#
   // delegates *must* be called using the stdcall calling convention rather
@@ -250,7 +250,7 @@ void SendPendingEvents() {
   // Listener.TokenReceivedDelegateMethod respectively.
   internal class Listener : System.IDisposable {
     // Delegate called from ListenerImpl::MessageReceivedCallback().
-    internal delegate int MessageReceivedDelegate(System.IntPtr message);
+    internal delegate bool MessageReceivedDelegate(System.IntPtr message);
     // Delegate called from ListenerImpl::TokenReceivedCallback().
     internal delegate void TokenReceivedDelegate(string token);
 
@@ -315,8 +315,8 @@ void SendPendingEvents() {
     // Called from ListenerImpl::MessageReceived() via the
     // messageReceivedDelegate.
     [MonoPInvokeCallback(typeof(MessageReceivedDelegate))]
-    private static int MessageReceivedDelegateMethod(System.IntPtr message) {
-      int tookOwnership = 0;
+    private static bool MessageReceivedDelegateMethod(System.IntPtr message) {
+      bool tookOwnership = false;
       return ExceptionAggregator.Wrap(() => {
           // Use a local copy so another thread cannot unset this before we use it.
           var handler = FirebaseMessagingInternal.MessageReceivedInternal;
@@ -324,13 +324,13 @@ void SendPendingEvents() {
             // Take ownership, and track it so that the caller of this knows, even
             // if an exception is thrown, since the C# object will still delete it.
             FirebaseMessageInternal messageInternal = new FirebaseMessageInternal(message, true);
-            tookOwnership = 1;
+            tookOwnership = true;
             handler(null, new Firebase.Messaging.MessageReceivedEventArgs(
                 FirebaseMessage.FromInternal(messageInternal)));
             messageInternal.Dispose();
-            return 1;
+            return true;
           }
-          return 0;
+          return false;
         }, tookOwnership);
     }
 


### PR DESCRIPTION
### Description
> Provide details of the change, and generalize the change in the PR title above.

Add missing null checks to new Messaging conversion logic, and improve the swig conversion logic to better handle if an exception is thrown, to prevent a double free.  This was causing a crash when opening a notification.
***
### Testing
> Describe how you've tested these changes.

Running locally.
GHA: https://github.com/firebase/firebase-unity-sdk/actions/runs/10691311630
***

### Type of Change
Place an `x` the applicable box:
- [x] Bug fix. Add the issue # below if applicable.
- [ ] New feature. A non-breaking change which adds functionality.
- [ ] Other, such as a build process or documentation change.
***

https://github.com/firebase/firebase-unity-sdk/issues/1091