### PR TITLE
Remove version specifier from brew swig logic

### DIFF
--- a/.github/workflows/build_android.yml
+++ b/.github/workflows/build_android.yml
@@ -94,7 +94,7 @@ jobs:
           cd ..
           echo "NDK_ROOT=/tmp/android-ndk-r21e" >> $GITHUB_ENV
           echo "ANDROID_NDK_HOME=/tmp/android-ndk-r21e" >> $GITHUB_ENV
-          brew install swig@4.2
+          brew install swig
       
       - name: Force Java 8 (macOS)
         shell: bash

--- a/.github/workflows/build_ios.yml
+++ b/.github/workflows/build_ios.yml
@@ -77,7 +77,7 @@ jobs:
           cd firebase-cpp-sdk
           python scripts/gha/install_prereqs_desktop.py
           cd ..
-          brew install swig@4.2
+          brew install swig
 
       - name: Install python deps
         shell: bash

--- a/.github/workflows/build_macos.yml
+++ b/.github/workflows/build_macos.yml
@@ -81,7 +81,7 @@ jobs:
           cd firebase-cpp-sdk
           python scripts/gha/install_prereqs_desktop.py
           cd ..
-          brew install swig@4.2
+          brew install swig
 
       - name: Install python deps
         shell: bash

--- a/.github/workflows/build_tvos.yml
+++ b/.github/workflows/build_tvos.yml
@@ -98,7 +98,7 @@ jobs:
           cd firebase-cpp-sdk
           python scripts/gha/install_prereqs_desktop.py
           cd ..
-          brew install swig@4.2
+          brew install swig
 
       - name: Install python deps
         shell: bash


### PR DESCRIPTION
### Description
> Provide details of the change, and generalize the change in the PR title above.

The brew install logic is failing to find the specified swig version. Use the latest stable instead.
***
### Testing
> Describe how you've tested these changes.


[replace this line]: # (Describe your testing in detail.)
***

### Type of Change
Place an `x` the applicable box:
- [ ] Bug fix. Add the issue # below if applicable.
- [ ] New feature. A non-breaking change which adds functionality.
- [x] Other, such as a build process or documentation change.
***

