### PR TITLE
Add support for Analytics Parameters of Lists

### DIFF
--- a/analytics/src/Parameter.cs
+++ b/analytics/src/Parameter.cs
@@ -82,8 +82,6 @@ public class Parameter : System.IDisposable {
     Value = parameterValue;
   }
 
-  // TODO: Implement accepting maps and vectors in C++ Analytics before enabling these.
-  /*
   public Parameter(string parameterName, IDictionary<string, object> parameterValue) {
     Name = parameterName;
     Value = parameterValue;
@@ -93,7 +91,6 @@ public class Parameter : System.IDisposable {
     Name = parameterName;
     Value = parameterValue;
   }
-  */
 
   /// @deprecated No longer needed, will be removed in the future.
   [System.Obsolete("No longer needed, will be removed in the future.")]

--- a/analytics/testapp/Assets/Firebase/Sample/Analytics/UIHandler.cs
+++ b/analytics/testapp/Assets/Firebase/Sample/Analytics/UIHandler.cs
@@ -118,6 +118,26 @@ namespace Firebase.Sample.Analytics {
         new Parameter("hit_accuracy", 3.14f));
     }
 
+    public void AnalyticsViewCart() {
+      // Log an event that includes a parameter with a list
+      DebugLog("Logging a view cart event.");
+      FirebaseAnalytics.LogEvent(
+        FirebaseAnalytics.EventViewCart,
+        new Parameter(FirebaseAnalytics.ParameterCurrency, "USD"),
+        new Parameter(FirebaseAnalytics.ParameterValue, 30.03),
+        new Parameter(FirebaseAnalytics.ParameterItems, new [] {
+          new Dictionary<string, object> {
+            { FirebaseAnalytics.ParameterItemID, "SKU_12345" },
+            { FirebaseAnalytics.ParameterItemName, "Horse Armor DLC" },
+          },
+          new Dictionary<string, object> {
+            { FirebaseAnalytics.ParameterItemID, "SKU_67890" },
+            { FirebaseAnalytics.ParameterItemName, "Gold Horse Armor DLC" },
+          }
+        })
+      );
+    }
+
     // Reset analytics data for this app instance.
     public void ResetAnalyticsData() {
       DebugLog("Reset analytics data.");
@@ -221,6 +241,9 @@ namespace Firebase.Sample.Analytics {
         }
         if (GUILayout.Button("Log Level Up")) {
           AnalyticsLevelUp();
+        }
+        if (GUILayout.Button("Log View Cart")) {
+          AnalyticsViewCart();
         }
         if (GUILayout.Button("Reset Analytics Data")) {
           ResetAnalyticsData();

--- a/analytics/testapp/Assets/Firebase/Sample/Analytics/UIHandlerAutomated.cs
+++ b/analytics/testapp/Assets/Firebase/Sample/Analytics/UIHandlerAutomated.cs
@@ -30,6 +30,7 @@ namespace Firebase.Sample.Analytics {
         TestAnalyticsScoreDoesNotThrow,
         TestAnalyticsGroupJoinDoesNotThrow,
         TestAnalyticsLevelUpDoesNotThrow,
+        TestAnalyticsViewCartDoesNotThrow,
         // This test regularly fails on iOS simulator, and there isn't a great way
         // to determine if this is on a device or simulator, so just disable on
         // GHA iOS and tvOS for now.
@@ -90,6 +91,13 @@ namespace Firebase.Sample.Analytics {
     Task TestAnalyticsLevelUpDoesNotThrow() {
       return WrapWithTask(() => {
         base.AnalyticsLevelUp();
+        return true;
+      });
+    }
+
+    Task TestAnalyticsViewCartDoesNotThrow() {
+      return WrapWithTask(() => {
+        base.AnalyticsViewCart();
         return true;
       });
     }

--- a/docs/readme.md
+++ b/docs/readme.md
@@ -73,6 +73,9 @@ Release Notes
 -------------
 ### Upcoming
 - Changes
+    - Analytics: Add support for Parameters of Lists of Dictionaries, needed
+      by some events such as ViewCart.
+      ([#1056](https://github.com/firebase/firebase-unity-sdk/issues/1056)).
     - Analytics: Renamed ParameterGroupId to ParameterGroupID, to be
       consistent with other similarly named variables. ParameterGroupId
       is considered deprecated, and will be removed in the future.


### PR DESCRIPTION
### Description
> Provide details of the change, and generalize the change in the PR title above.

Adds support for Analytics Parameters to take in Dictionaries and Lists of Dictionaries, which is needed for some Analytics events like ViewCart.

Most of the logic is in C++ here:
https://github.com/firebase/firebase-cpp-sdk/pull/1660

This has been a long missing feature, recently tracked via:
https://github.com/firebase/firebase-unity-sdk/issues/1056
***
### Testing
> Describe how you've tested these changes.

Running locally
***

### Type of Change
Place an `x` the applicable box:
- [ ] Bug fix. Add the issue # below if applicable.
- [x] New feature. A non-breaking change which adds functionality.
- [ ] Other, such as a build process or documentation change.
***

