### PR TITLE
Disable new SWIG string helper functions

### DIFF
--- a/cmake/firebase_swig.cmake
+++ b/cmake/firebase_swig.cmake
@@ -154,6 +154,10 @@ macro(firebase_swig_add_library name)
     # https://github.com/swig/swig/issues/672#issuecomment-400577864
     final=
     USE_EXPORT_FIX
+    # SWIG 4.3 added a C# class, SWIGStringWithLengthHelper, but is missing
+    # the corresponding C++ symbols, which can cause issues. We don't
+    # rely on this class anyway, so just disable it.
+    SWIG_CSHARP_NO_STRING_WITH_LENGTH_HELPER
   )
 
   set_property(TARGET ${name} PROPERTY SWIG_GENERATED_COMPILE_DEFINITIONS

--- a/docs/readme.md
+++ b/docs/readme.md
@@ -71,6 +71,11 @@ Support
 
 Release Notes
 -------------
+### Upcoming
+- Changes
+    - General: Remove unresolved SWIG string symbols.
+      ([#1139](https://github.com/firebase/firebase-unity-sdk/issues/1139)).
+
 ### 12.4.0
 - Changes
     - General: Update to Firebase C++ SDK version 12.4.0.


### PR DESCRIPTION
### Description
> Provide details of the change, and generalize the change in the PR title above.

SWIG 4.3 added a class SWIGStringWithLengthHelper, https://github.com/swig/swig/blob/d9edb22d1c896186b41505376c77a2d296447396/Lib/csharp/csharphead.swg#L329, which is causing some users to have build errors, because it isn't defining the native symbols correctly. Disable it via the provided compile flag, which should prevent it from adding the C# symbols, and the dependency on the missing C++ symbols.

Bug: https://github.com/firebase/firebase-unity-sdk/issues/1139
***
### Testing
> Describe how you've tested these changes.

Verifying that the generated output is missing the C# symbols

https://github.com/firebase/firebase-unity-sdk/actions/runs/11826822953
***

### Type of Change
Place an `x` the applicable box:
- [x] Bug fix. Add the issue # below if applicable.
- [ ] New feature. A non-breaking change which adds functionality.
- [ ] Other, such as a build process or documentation change.
***

