### PR TITLE
Support 16 KB page sizes on Android

### DIFF
--- a/cmake/build_shared.cmake
+++ b/cmake/build_shared.cmake
@@ -106,6 +106,8 @@ function(build_firebase_shared LIBRARY_NAME ARTIFACT_NAME OUTPUT_NAME)
         "-Wl,--no-undefined"
         # Link against the static libc++, which is the default done by Gradle.
         "-static-libstdc++"
+        # Set the max page size to 16KB, needed by Android 15
+        "-Wl,-z,max-page-size=16384"
     )
     add_custom_command(TARGET ${shared_target} POST_BUILD
       COMMAND "${ANDROID_TOOLCHAIN_PREFIX}strip" -g -S -d --strip-debug --verbose

--- a/cmake/build_universal.cmake
+++ b/cmake/build_universal.cmake
@@ -86,6 +86,8 @@ function(build_uni TARGET_LINK_LIB_NAMES PROJECT_LIST_HEADER_VARIABLE)
         "-Wl,--no-undefined"
         # Link against the static libc++, which is the default done by Gradle.
         "-static-libstdc++"
+        # Set the max page size to 16KB, needed by Android 15
+        "-Wl,-z,max-page-size=16384"
     )
     add_custom_command(TARGET firebase_app_uni POST_BUILD
       COMMAND "${ANDROID_TOOLCHAIN_PREFIX}strip" -g -S -d --strip-debug --verbose

--- a/docs/readme.md
+++ b/docs/readme.md
@@ -71,6 +71,11 @@ Support
 
 Release Notes
 -------------
+### Upcoming
+- Changes
+    - General (Android): Support 16 KB page sizes, needed by Android 15.
+      For more info, see https://developer.android.com/guide/practices/page-sizes
+
 ### 12.5.0
 - Changes
     - General: Update to Firebase C++ SDK version 12.5.0.


### PR DESCRIPTION
### Description
> Provide details of the change, and generalize the change in the PR title above.

Android 15 is starting to support 16 KB page sizes, which in turn requires shared libraries to be built to support them. Update the shared libraries to it, based on instructions from https://developer.android.com/guide/practices/page-sizes

Might fix https://github.com/firebase/firebase-unity-sdk/issues/1180, but haven't been able to reproduce the initial problem reliably to test.
***
### Testing
> Describe how you've tested these changes.

Checking the shared libraries after building via llvm-objdump, again as instructed on that page.
***

### Type of Change
Place an `x` the applicable box:
- [x] Bug fix. Add the issue # below if applicable.
- [ ] New feature. A non-breaking change which adds functionality.
- [ ] Other, such as a build process or documentation change.
***

