### PR TITLE
Set NOMINMAX for Firestore Windows builds

### DIFF
--- a/firestore/CMakeLists.txt
+++ b/firestore/CMakeLists.txt
@@ -95,6 +95,12 @@ set(firebase_firestore_src
   src/ValueSerializer.cs
 )
 
+# Ensure min/max macros don't get declared on Windows
+# (so we can use std::min/max).
+if(MSVC)
+  add_definitions(-DNOMINMAX)
+endif()
+
 add_subdirectory(src/swig)
 
 firebase_swig_add_library(firebase_firestore_swig

--- a/firestore/src/swig/CMakeLists.txt
+++ b/firestore/src/swig/CMakeLists.txt
@@ -30,6 +30,12 @@ add_library(firebase_firestore_swig_cpp STATIC
 
 set_property(TARGET firebase_firestore_swig_cpp PROPERTY FOLDER "Firebase Cpp")
 
+# Ensure min/max macros don't get declared on Windows
+# (so we can use std::min/max).
+if(MSVC)
+  add_definitions(-DNOMINMAX)
+endif()
+
 target_link_libraries(firebase_firestore_swig_cpp
   PUBLIC
     firebase_app


### PR DESCRIPTION
### Description
> Provide details of the change, and generalize the change in the PR title above.

Windows defines min/max macros which can cause build issues, which are normally disabled by setting NOMINMAX. We do this a lot in C++, but a recent change in the iOS repo exposes the problem at the Unity level, so add it here as well.
***
### Testing
> Describe how you've tested these changes.

https://github.com/firebase/firebase-unity-sdk/actions/runs/13294040512
***

### Type of Change
Place an `x` the applicable box:
- [x] Bug fix. Add the issue # below if applicable.
- [ ] New feature. A non-breaking change which adds functionality.
- [ ] Other, such as a build process or documentation change.
***

