### PR TITLE
VertexAI - Change packaging logic to use a source library

### DIFF
--- a/scripts/gha/integration_testing/build_testapps.json
+++ b/scripts/gha/integration_testing/build_testapps.json
@@ -214,6 +214,23 @@
         "com.google.firebase.auth-*.tgz",
         "com.google.firebase.storage-*.tgz"
       ]
+    },
+    {
+      "name": "vertexai",
+      "full_name": "FirebaseVertexAI",
+      "captial_name": "VertexAI",
+      "bundle_id": "com.google.firebase.unity.vertexai.testapp",
+      "testapp_path": "vertexai/testapp",
+      "platforms": ["Android", "Playmode", "iOS", "tvOS", "Windows", "macOS", "Linux"],
+      "plugins": [
+        "FirebaseVertexAI.unitypackage"
+      ],
+      "provision": "Firebase_Dev_Wildcard.mobileprovision",
+      "upm_packages": [
+        "com.google.external-dependency-manager-*.tgz",
+        "com.google.firebase.app-*.tgz",
+        "com.google.firebase.vertexai-*.tgz"
+      ]
     }
   ],
   "skipped_testapp_files": [

--- a/unity_packer/debug_single_export_json/vertexai.json
+++ b/unity_packer/debug_single_export_json/vertexai.json
@@ -215,18 +215,9 @@
       "name": "FirebaseVertexAI.unitypackage",
       "imports": [
         {
-          "importer": "PluginImporter",
-          "platforms": [
-            "Editor",
-            "Standalone",
-            "Android",
-            "iOS",
-            "tvOS"
-          ],
-          "cpu": "AnyCPU",
+          "importer": "DefaultImporter",
           "paths": [
-            "Firebase/Plugins/Firebase.VertexAI.dll",
-            "Firebase/Plugins/Firebase.VertexAI.pdb"
+            "Firebase/VertexAI/*"
           ]
         },
         {

--- a/vertexai/CMakeLists.txt
+++ b/vertexai/CMakeLists.txt
@@ -14,41 +14,19 @@
 
 # CMake file for the Vertex AI in Firebase library
 
-# Vertex AI in Firebase CSharp files
-set(firebase_vertexai_src
-  src/Candidate.cs
-  src/Chat.cs
-  src/Citation.cs
-  src/CountTokensResponse.cs
-  src/FunctionCalling.cs
-  src/GenerateContentResponse.cs
-  src/GenerationConfig.cs
-  src/GenerativeModel.cs
-  src/ModelContent.cs
-  src/RequestOptions.cs
-  src/Safety.cs
-  src/Schema.cs
-  src/VertexAI.cs
-  src/VertexAIException.cs
+# Vertex AI in Firebase is different from the other Firebase libraries,
+# as instead of prebuilding, we provide it as a source library.
+
+# Package every file under src, including subfolders, since we want them all.
+unity_pack_folder(
+  "${FIREBASE_UNITY_DIR}/vertexai/src/"
+  PACK_PATH "Firebase/VertexAI"
 )
 
+# For documentation, get only the C# files at the top level,
+# which make up the public API.
+file(GLOB firebase_vertexai_doc_src "src/*.cs")
 unity_pack_documentation_sources(vertexai
   DOCUMENTATION_SOURCES
     ${firebase_vertexai_src}
-)
-
-mono_add_library(firebase_vertexai
-  MODULE
-    Firebase.VertexAI
-  SOURCES
-    ${firebase_vertexai_src}
-  REFERENCES
-    ${FIREBASE_PLATFORM_REF}
-)
-
-unity_pack_cs(firebase_vertexai)
-
-set_property(TARGET firebase_vertexai
-  PROPERTY FOLDER
-  "Firebase ${FIREBASE_PLATFORM_NAME}"
 )

--- a/vertexai/src/Candidate.cs
+++ b/vertexai/src/Candidate.cs
@@ -121,6 +121,9 @@ public readonly struct Candidate {
     };
   }
 
+  /// <summary>
+  /// Intended for internal use only.
+  /// </summary>
   internal static Candidate FromJson(Dictionary<string, object> jsonDict) {
     return new Candidate(
       jsonDict.ParseObject("content", ModelContent.FromJson, defaultValue: new ModelContent("model")),

--- a/vertexai/src/Candidate.cs
+++ b/vertexai/src/Candidate.cs
@@ -123,6 +123,7 @@ public readonly struct Candidate {
 
   /// <summary>
   /// Intended for internal use only.
+  /// This method is used for deserializing JSON responses and should not be called directly.
   /// </summary>
   internal static Candidate FromJson(Dictionary<string, object> jsonDict) {
     return new Candidate(

--- a/vertexai/src/Candidate.cs.meta
+++ b/vertexai/src/Candidate.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 753a5f290a3e94d43ab8f3a4ef088317
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/vertexai/src/Chat.cs.meta
+++ b/vertexai/src/Chat.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 79ddb6505f26c4186bd80ba9962eb02a
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/vertexai/src/Citation.cs
+++ b/vertexai/src/Citation.cs
@@ -40,6 +40,7 @@ public readonly struct CitationMetadata {
 
   /// <summary>
   /// Intended for internal use only.
+  /// This method is used for deserializing JSON responses and should not be called directly.
   /// </summary>
   internal static CitationMetadata FromJson(Dictionary<string, object> jsonDict) {
     return new CitationMetadata(
@@ -89,6 +90,7 @@ public readonly struct Citation {
 
   /// <summary>
   /// Intended for internal use only.
+  /// This method is used for deserializing JSON responses and should not be called directly.
   /// </summary>
   internal static Citation FromJson(Dictionary<string, object> jsonDict) {
     // If there is a Uri, need to convert it.

--- a/vertexai/src/Citation.cs
+++ b/vertexai/src/Citation.cs
@@ -38,6 +38,9 @@ public readonly struct CitationMetadata {
     _citations = new ReadOnlyCollection<Citation>(citations ?? new List<Citation>());
   }
 
+  /// <summary>
+  /// Intended for internal use only.
+  /// </summary>
   internal static CitationMetadata FromJson(Dictionary<string, object> jsonDict) {
     return new CitationMetadata(
       jsonDict.ParseObjectList("citations", Citation.FromJson));
@@ -84,6 +87,9 @@ public readonly struct Citation {
     PublicationDate = publicationDate;
   }
 
+  /// <summary>
+  /// Intended for internal use only.
+  /// </summary>
   internal static Citation FromJson(Dictionary<string, object> jsonDict) {
     // If there is a Uri, need to convert it.
     Uri uri = null;

--- a/vertexai/src/Citation.cs.meta
+++ b/vertexai/src/Citation.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 1f64f3d6fd12141b7ae80e9ef6bf4742
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/vertexai/src/CountTokensResponse.cs.meta
+++ b/vertexai/src/CountTokensResponse.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: e279f91330cc94b7e93e3d2a1e159403
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/vertexai/src/FunctionCalling.cs.meta
+++ b/vertexai/src/FunctionCalling.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: d7036bad0c20443bc83375b3dd9f7b96
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/vertexai/src/GenerateContentResponse.cs
+++ b/vertexai/src/GenerateContentResponse.cs
@@ -76,6 +76,7 @@ public readonly struct GenerateContentResponse {
 
   /// <summary>
   /// Intended for internal use only.
+  /// This method is used for deserializing JSON responses and should not be called directly.
   /// </summary>
   internal static GenerateContentResponse FromJson(string jsonString) {
     return FromJson(Json.Deserialize(jsonString) as Dictionary<string, object>);
@@ -83,6 +84,7 @@ public readonly struct GenerateContentResponse {
 
   /// <summary>
   /// Intended for internal use only.
+  /// This method is used for deserializing JSON responses and should not be called directly.
   /// </summary>
   internal static GenerateContentResponse FromJson(Dictionary<string, object> jsonDict) {
     return new GenerateContentResponse(
@@ -160,6 +162,7 @@ public readonly struct PromptFeedback {
 
   /// <summary>
   /// Intended for internal use only.
+  /// This method is used for deserializing JSON responses and should not be called directly.
   /// </summary>
   internal static PromptFeedback FromJson(Dictionary<string, object> jsonDict) {
     return new PromptFeedback(
@@ -197,6 +200,7 @@ public readonly struct UsageMetadata {
 
   /// <summary>
   /// Intended for internal use only.
+  /// This method is used for deserializing JSON responses and should not be called directly.
   /// </summary>
   internal static UsageMetadata FromJson(Dictionary<string, object> jsonDict) {
     return new UsageMetadata(

--- a/vertexai/src/GenerateContentResponse.cs
+++ b/vertexai/src/GenerateContentResponse.cs
@@ -74,10 +74,16 @@ public readonly struct GenerateContentResponse {
     UsageMetadata = usageMetadata;
   }
 
+  /// <summary>
+  /// Intended for internal use only.
+  /// </summary>
   internal static GenerateContentResponse FromJson(string jsonString) {
     return FromJson(Json.Deserialize(jsonString) as Dictionary<string, object>);
   }
 
+  /// <summary>
+  /// Intended for internal use only.
+  /// </summary>
   internal static GenerateContentResponse FromJson(Dictionary<string, object> jsonDict) {
     return new GenerateContentResponse(
       jsonDict.ParseObjectList("candidates", Candidate.FromJson),
@@ -152,6 +158,9 @@ public readonly struct PromptFeedback {
     };
   }
 
+  /// <summary>
+  /// Intended for internal use only.
+  /// </summary>
   internal static PromptFeedback FromJson(Dictionary<string, object> jsonDict) {
     return new PromptFeedback(
       jsonDict.ParseNullableEnum("blockReason", ParseBlockReason),
@@ -186,6 +195,9 @@ public readonly struct UsageMetadata {
     TotalTokenCount = totalTC;
   }
 
+  /// <summary>
+  /// Intended for internal use only.
+  /// </summary>
   internal static UsageMetadata FromJson(Dictionary<string, object> jsonDict) {
     return new UsageMetadata(
       jsonDict.ParseValue<int>("promptTokenCount"),

--- a/vertexai/src/GenerateContentResponse.cs.meta
+++ b/vertexai/src/GenerateContentResponse.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 76e344bed23d0443ab380371627114f2
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/vertexai/src/GenerationConfig.cs
+++ b/vertexai/src/GenerationConfig.cs
@@ -159,6 +159,9 @@ public readonly struct GenerationConfig {
     _responseSchema = responseSchema;
   }
 
+  /// <summary>
+  /// Intended for internal use only.
+  /// </summary>
   internal Dictionary<string, object> ToJson() {
     Dictionary<string, object> jsonDict = new();
     if (_temperature.HasValue) jsonDict["temperature"] = _temperature.Value;

--- a/vertexai/src/GenerationConfig.cs
+++ b/vertexai/src/GenerationConfig.cs
@@ -161,6 +161,7 @@ public readonly struct GenerationConfig {
 
   /// <summary>
   /// Intended for internal use only.
+  /// This method is used for serializing the object to JSON for the API request.
   /// </summary>
   internal Dictionary<string, object> ToJson() {
     Dictionary<string, object> jsonDict = new();

--- a/vertexai/src/GenerationConfig.cs.meta
+++ b/vertexai/src/GenerationConfig.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: c1b22da39415747f68b2d899cabcc864
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/vertexai/src/GenerativeModel.cs
+++ b/vertexai/src/GenerativeModel.cs
@@ -47,7 +47,8 @@ public class GenerativeModel {
   private readonly HttpClient _httpClient;
 
   /// <summary>
-  /// Intended for internal use only. Use `VertexAI.GetInstance` instead.
+  /// Intended for internal use only.
+  /// Use `VertexAI.GetInstance` instead to ensure proper initialization and configuration of the `GenerativeModel`.
   /// </summary>
   internal GenerativeModel(FirebaseApp firebaseApp,
                            string location,

--- a/vertexai/src/GenerativeModel.cs
+++ b/vertexai/src/GenerativeModel.cs
@@ -46,6 +46,9 @@ public class GenerativeModel {
 
   private readonly HttpClient _httpClient;
 
+  /// <summary>
+  /// Intended for internal use only. Use `VertexAI.GetInstance` instead.
+  /// </summary>
   internal GenerativeModel(FirebaseApp firebaseApp,
                            string location,
                            string modelName,

--- a/vertexai/src/GenerativeModel.cs.meta
+++ b/vertexai/src/GenerativeModel.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 94e46896812e7418c8132c5ec1c963c1
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/vertexai/src/Internal.meta
+++ b/vertexai/src/Internal.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 31e41d46085b24149b7cf509decaa9b1
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/vertexai/src/Internal/InternalHelpers.cs.meta
+++ b/vertexai/src/Internal/InternalHelpers.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: dc22b072c909243daa757c5241086143
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/vertexai/src/ModelContent.cs
+++ b/vertexai/src/ModelContent.cs
@@ -232,6 +232,9 @@ public readonly struct ModelContent {
     };
   }
 
+  /// <summary>
+  /// Intended for internal use only.
+  /// </summary>
   internal static ModelContent FromJson(Dictionary<string, object> jsonDict) {
     // Both role and parts are required keys
     return new ModelContent(

--- a/vertexai/src/ModelContent.cs
+++ b/vertexai/src/ModelContent.cs
@@ -225,6 +225,9 @@ public readonly struct ModelContent {
 
 #endregion
 
+  /// <summary>
+  /// Intended for internal use only.
+  /// </summary>
   internal Dictionary<string, object> ToJson() {
     return new Dictionary<string, object>() {
       ["role"] = Role,

--- a/vertexai/src/ModelContent.cs
+++ b/vertexai/src/ModelContent.cs
@@ -118,6 +118,7 @@ public readonly struct ModelContent {
 #if !DOXYGEN
     /// <summary>
     /// Intended for internal use only.
+    /// This method is used for serializing the object to JSON for the API request.
     /// </summary>
     Dictionary<string, object> ToJson();
 #endif
@@ -127,8 +128,15 @@ public readonly struct ModelContent {
   /// A text part containing a string value.
   /// </summary>
   public readonly struct TextPart : Part {
+    /// <summary>
+    /// Text value.
+    /// </summary>
     public string Text { get; }
 
+    /// <summary>
+    /// Creates a `TextPart` with the given text.
+    /// </summary>
+    /// <param name="text">The text value to use.</param>
     public TextPart(string text) { Text = text; }
 
     Dictionary<string, object> Part.ToJson() {
@@ -141,13 +149,39 @@ public readonly struct ModelContent {
   /// Note: Not all media types may be supported by the AI model.
   /// </summary>
   public readonly struct InlineDataPart : Part {
-    public string Mimetype { get; }
+    /// <summary>
+    /// The IANA standard MIME type of the data.
+    /// </summary>
+    public string MimeType { get; }
+    /// <summary>
+    /// The data provided in the inline data part.
+    /// </summary>
     public ReadOnlyMemory<byte> Data { get; }
 
-    public InlineDataPart(string mimetype, byte[] data) { Mimetype = mimetype; Data = data; }
+    /// <summary>
+    /// Creates an `InlineDataPart` from data and a MIME type.
+    ///
+    /// > Important: Supported input types depend on the model on the model being used; see [input
+    ///  files and requirements](https://firebase.google.com/docs/vertex-ai/input-file-requirements)
+    ///  for more details.
+    /// </summary>
+    /// <param name="mimeType">The IANA standard MIME type of the data, for example, `"image/jpeg"` or
+    ///     `"video/mp4"`; see [input files and
+    ///     requirements](https://firebase.google.com/docs/vertex-ai/input-file-requirements) for
+    ///     supported values.</param>
+    /// <param name="data">The data representation of an image, video, audio or document; see [input files and
+    ///     requirements](https://firebase.google.com/docs/vertex-ai/input-file-requirements) for
+    ///     supported media types.</param>
+    public InlineDataPart(string mimeType, byte[] data) { MimeType = mimeType; Data = data; }
 
     Dictionary<string, object> Part.ToJson() {
-      throw new NotImplementedException();
+      return new Dictionary<string, object>() {
+        { "inlineData", new Dictionary<string, object>() {
+            { "mimeType", MimeType },
+            { "data", Convert.ToBase64String(Data.ToArray()) }
+          }
+        }
+      };
     }
   }
 
@@ -155,7 +189,13 @@ public readonly struct ModelContent {
   /// File data stored in Cloud Storage for Firebase, referenced by a URI.
   /// </summary>
   public readonly struct FileDataPart : Part {
+    /// <summary>
+    /// The IANA standard MIME type of the data.
+    /// </summary>
     public string MimeType { get; }
+    /// <summary>
+    /// The URI of the file.
+    /// </summary>
     public System.Uri Uri { get; }
 
     /// <summary>
@@ -170,7 +210,13 @@ public readonly struct ModelContent {
     public FileDataPart(string mimeType, System.Uri uri) { MimeType = mimeType; Uri = uri; }
 
     Dictionary<string, object> Part.ToJson() {
-      throw new NotImplementedException();
+      return new Dictionary<string, object>() {
+        { "inlineData", new Dictionary<string, object>() {
+            { "mimeType", MimeType },
+            { "fileUri", Uri.AbsoluteUri }
+          }
+        }
+      };
     }
   }
 
@@ -186,14 +232,23 @@ public readonly struct ModelContent {
     /// The function parameters and values, matching the registered schema.
     /// </summary>
     public IReadOnlyDictionary<string, object> Args { get; }
-
-    public FunctionCallPart(string name, IDictionary<string, object> args) {
+    
+    /// <summary>
+    /// Intended for internal use only.
+    /// </summary>
+    internal FunctionCallPart(string name, IDictionary<string, object> args) {
       Name = name;
       Args = new Dictionary<string, object>(args);
     }
 
     Dictionary<string, object> Part.ToJson() {
-      throw new NotImplementedException();
+      return new Dictionary<string, object>() {
+        { "functionCall", new Dictionary<string, object>() {
+            { "name", Name },
+            { "args", Args }
+          }
+        }
+      };
     }
   }
 
@@ -205,7 +260,13 @@ public readonly struct ModelContent {
   /// result of a `FunctionCallPart` made based on model prediction.
   /// </summary>
   public readonly struct FunctionResponsePart : Part {
+    /// <summary>
+    /// The name of the function that was called.
+    /// </summary>
     public string Name { get; }
+    /// <summary>
+    /// The function's response or return value.
+    /// </summary>
     public IReadOnlyDictionary<string, object> Response { get; }
 
     /// <summary>
@@ -219,7 +280,13 @@ public readonly struct ModelContent {
     }
 
     Dictionary<string, object> Part.ToJson() {
-      throw new NotImplementedException();
+      return new Dictionary<string, object>() {
+        { "functionResponse", new Dictionary<string, object>() {
+            { "name", Name },
+            { "response", Response }
+          }
+        }
+      };
     }
   }
 
@@ -227,6 +294,7 @@ public readonly struct ModelContent {
 
   /// <summary>
   /// Intended for internal use only.
+  /// This method is used for serializing the object to JSON for the API request.
   /// </summary>
   internal Dictionary<string, object> ToJson() {
     return new Dictionary<string, object>() {
@@ -237,6 +305,7 @@ public readonly struct ModelContent {
 
   /// <summary>
   /// Intended for internal use only.
+  /// This method is used for deserializing JSON responses and should not be called directly.
   /// </summary>
   internal static ModelContent FromJson(Dictionary<string, object> jsonDict) {
     // Both role and parts are required keys

--- a/vertexai/src/ModelContent.cs.meta
+++ b/vertexai/src/ModelContent.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 3ca3fe7e24ab94c3f9d54a735c7dea32
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/vertexai/src/RequestOptions.cs
+++ b/vertexai/src/RequestOptions.cs
@@ -27,9 +27,14 @@ public readonly struct RequestOptions {
   // to determine if it should be 180.
   private readonly TimeSpan? _timeout;
 
+  /// <summary>
+  /// Intended for internal use only.
+  /// </summary>
   internal static TimeSpan DefaultTimeout => TimeSpan.FromSeconds(180);
 
-  // Intentionally not public, as users don't need it.
+  /// <summary>
+  /// Intended for internal use only.
+  /// </summary>
   internal TimeSpan Timeout => _timeout ?? DefaultTimeout;
 
   /// <summary>

--- a/vertexai/src/RequestOptions.cs
+++ b/vertexai/src/RequestOptions.cs
@@ -29,11 +29,13 @@ public readonly struct RequestOptions {
 
   /// <summary>
   /// Intended for internal use only.
+  /// This provides access to the default timeout value.
   /// </summary>
   internal static TimeSpan DefaultTimeout => TimeSpan.FromSeconds(180);
 
   /// <summary>
   /// Intended for internal use only.
+  /// This provides access to the timeout value used for API requests.
   /// </summary>
   internal TimeSpan Timeout => _timeout ?? DefaultTimeout;
 

--- a/vertexai/src/RequestOptions.cs.meta
+++ b/vertexai/src/RequestOptions.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: fdbe4c58c158143cca4e7afef4172f5c
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/vertexai/src/Safety.cs
+++ b/vertexai/src/Safety.cs
@@ -140,6 +140,9 @@ public readonly struct SafetySetting {
     };
   }
 
+  /// <summary>
+  /// Intended for internal use only.
+  /// </summary>
   internal Dictionary<string, object> ToJson() {
     Dictionary<string, object> jsonDict = new () {
       ["category"] = ConvertCategory(_category),
@@ -297,6 +300,9 @@ public readonly struct SafetyRating {
     };
   }
 
+  /// <summary>
+  /// Intended for internal use only.
+  /// </summary>
   internal static SafetyRating FromJson(Dictionary<string, object> jsonDict) {
     return new SafetyRating(
       jsonDict.ParseEnum("category", ParseCategory),

--- a/vertexai/src/Safety.cs
+++ b/vertexai/src/Safety.cs
@@ -142,6 +142,7 @@ public readonly struct SafetySetting {
 
   /// <summary>
   /// Intended for internal use only.
+  /// This method is used for serializing the object to JSON for the API request.
   /// </summary>
   internal Dictionary<string, object> ToJson() {
     Dictionary<string, object> jsonDict = new () {
@@ -302,6 +303,7 @@ public readonly struct SafetyRating {
 
   /// <summary>
   /// Intended for internal use only.
+  /// This method is used for deserializing JSON responses and should not be called directly.
   /// </summary>
   internal static SafetyRating FromJson(Dictionary<string, object> jsonDict) {
     return new SafetyRating(

--- a/vertexai/src/Safety.cs.meta
+++ b/vertexai/src/Safety.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: afdcd193c694e46f383938f481826214
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/vertexai/src/Schema.cs.meta
+++ b/vertexai/src/Schema.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 67b1940eba1d747c698990cd7a56db3d
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/vertexai/src/VertexAI.cs.meta
+++ b/vertexai/src/VertexAI.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 2494e766f7a634f94a10f71b0e5c3c56
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/vertexai/src/VertexAIException.cs.meta
+++ b/vertexai/src/VertexAIException.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: db9ba6cd82611434d92cb60215162ea1
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
### Description
> Provide details of the change, and generalize the change in the PR title above.

Since the VertexAI library will be a pure C# library, package the source code directly, instead of prebuilding it to a DLL. This will also users to have an easier time debugging, and allow the integration tests to test some of the internal logic.

The caveat here is that the "internal" keyword no longer does anything, and technically those are visible to users. Thus, we will add comments that they are meant for internal use, and they will still be excluded from reference docs.

Also, add VertexAI to the automated test logic, and fill out more of ModelContent parts
***
### Testing
> Describe how you've tested these changes.

GHA build: https://github.com/firebase/firebase-unity-sdk/actions/runs/13533744685
GHA tests: https://github.com/firebase/firebase-unity-sdk/actions/runs/13553327150
***

### Type of Change
Place an `x` the applicable box:
- [ ] Bug fix. Add the issue # below if applicable.
- [x] New feature. A non-breaking change which adds functionality.
- [ ] Other, such as a build process or documentation change.
***

