### PR TITLE
Change Ubuntu GitHub runners to ubuntu-22.04.

### DIFF
--- a/scripts/gha/print_matrix_configuration.py
+++ b/scripts/gha/print_matrix_configuration.py
@@ -57,7 +57,7 @@ PLAYMODE = "Playmode"
 # GitHub Runner
 WINDOWS_RUNNER = "windows-latest"
 MACOS_RUNNER = "macos-13"
-LINUX_RUNNER = "ubuntu-20.04"
+LINUX_RUNNER = "ubuntu-22.04"
 
 PARAMETERS = {
   "integration_tests": {


### PR DESCRIPTION
### Description
Update Ubuntu runners to 22.04, since 20 is going away.

***
### Testing
> Describe how you've tested these changes.

***

### Type of Change
Place an `x` the applicable box:
- [ ] Bug fix. Add the issue # below if applicable.
- [ ] New feature. A non-breaking change which adds functionality.
- [ ] Other, such as a build process or documentation change.
***

