### PR TITLE
Install CMake 3.31.x on runners to override new GitHub default of CMake 4.

### DIFF
--- a/.github/workflows/build_android.yml
+++ b/.github/workflows/build_android.yml
@@ -47,6 +47,9 @@ jobs:
       CCACHE_DIR: ${{ github.workspace }}/ccache_dir
   
     steps:
+      - uses: lukka/get-cmake@latest
+        with:
+          cmakeVersion: "~3.31.0"
       - name: Checkout Unity Repo
         uses: actions/checkout@v3
         with:

--- a/.github/workflows/build_ios.yml
+++ b/.github/workflows/build_ios.yml
@@ -48,6 +48,9 @@ jobs:
       xcodeVersion: "15.1"
   
     steps:
+      - uses: lukka/get-cmake@latest
+        with:
+          cmakeVersion: "~3.31.0"
       - name: Checkout Unity Repo
         uses: actions/checkout@v3
         with:

--- a/.github/workflows/build_linux.yml
+++ b/.github/workflows/build_linux.yml
@@ -45,6 +45,9 @@ jobs:
       fail-fast: false
       
     steps:
+      - uses: lukka/get-cmake@latest
+        with:
+          cmakeVersion: "~3.31.0"
       - uses: actions/checkout@v3
         with:
           submodules: true

--- a/.github/workflows/build_macos.yml
+++ b/.github/workflows/build_macos.yml
@@ -45,6 +45,9 @@ jobs:
       fail-fast: false
 
     steps:
+      - uses: lukka/get-cmake@latest
+        with:
+          cmakeVersion: "~3.31.0"
       - uses: actions/checkout@v3
         with:
           submodules: true

--- a/.github/workflows/build_tvos.yml
+++ b/.github/workflows/build_tvos.yml
@@ -69,6 +69,9 @@ jobs:
       xcodeVersion: "15.1"
 
     steps:
+      - uses: lukka/get-cmake@latest
+        with:
+          cmakeVersion: "~3.31.0"
       - name: Checkout Unity Repo
         uses: actions/checkout@v3
         with:

--- a/.github/workflows/build_windows.yml
+++ b/.github/workflows/build_windows.yml
@@ -45,6 +45,9 @@ jobs:
       fail-fast: false
  
     steps:
+      - uses: lukka/get-cmake@latest
+        with:
+          cmakeVersion: "~3.31.0"
       - uses: actions/checkout@v3
         with:
           submodules: true

--- a/.github/workflows/generate_swig.yml
+++ b/.github/workflows/generate_swig.yml
@@ -36,6 +36,9 @@ jobs:
       fail-fast: false
       
     steps:
+      - uses: lukka/get-cmake@latest
+        with:
+          cmakeVersion: "~3.31.0"
       - uses: actions/checkout@v3
         with:
           submodules: true

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -178,6 +178,9 @@ jobs:
     env:
       xcodeVersion: "15.1"
     steps:
+      - uses: lukka/get-cmake@latest
+        with:
+          cmakeVersion: "~3.31.0"
       - id: matrix_info
         shell: bash
         run: |


### PR DESCRIPTION
### Description
> Provide details of the change, and generalize the change in the PR title above.

Change CMake to an explicit version to avoid incompatibility with new GitHub default version CMake 4.
***
### Testing
> Describe how you've tested these changes.


[replace this line]: # (Describe your testing in detail.)
***

### Type of Change
Place an `x` the applicable box:
- [ ] Bug fix. Add the issue # below if applicable.
- [ ] New feature. A non-breaking change which adds functionality.
- [ ] Other, such as a build process or documentation change.
***

