### PR TITLE
[VertexAI] Add response modality to GenerateContent

### DIFF
--- a/vertexai/src/GenerationConfig.cs
+++ b/vertexai/src/GenerationConfig.cs
@@ -16,6 +16,8 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
+using Firebase.VertexAI.Internal;
 
 namespace Firebase.VertexAI {
 
@@ -34,6 +36,7 @@ public readonly struct GenerationConfig {
   private readonly string[] _stopSequences;
   private readonly string _responseMimeType;
   private readonly Schema _responseSchema;
+  private readonly List<ResponseModality> _responseModalities;
 
   /// <summary>
   /// Creates a new `GenerationConfig` value.
@@ -146,7 +149,8 @@ public readonly struct GenerationConfig {
       float? frequencyPenalty = null,
       string[] stopSequences = null,
       string responseMimeType = null,
-      Schema responseSchema = null) {
+      Schema responseSchema = null,
+      IEnumerable<ResponseModality> responseModalities = null) {
     _temperature = temperature;
     _topP = topP;
     _topK = topK;
@@ -157,6 +161,8 @@ public readonly struct GenerationConfig {
     _stopSequences = stopSequences;
     _responseMimeType = responseMimeType;
     _responseSchema = responseSchema;
+    _responseModalities = responseModalities != null ?
+        new List<ResponseModality>(responseModalities) : null;
   }
 
   /// <summary>
@@ -175,6 +181,10 @@ public readonly struct GenerationConfig {
     if (_stopSequences != null && _stopSequences.Length > 0) jsonDict["stopSequences"] = _stopSequences;
     if (!string.IsNullOrWhiteSpace(_responseMimeType)) jsonDict["responseMimeType"] = _responseMimeType;
     if (_responseSchema != null) jsonDict["responseSchema"] = _responseSchema.ToJson();
+    if (_responseModalities != null && _responseModalities.Count > 0) {
+      jsonDict["responseModalities"] =
+          _responseModalities.Select(EnumConverters.ResponseModalityToString).ToList();
+    }
 
     return jsonDict;
   }


### PR DESCRIPTION
### Description
> Provide details of the change, and generalize the change in the PR title above.

Add the ability to set the response modality to the GenerateContent call, and a test for Image generation with it.
***
### Testing
> Describe how you've tested these changes.

Running tests locally
***

### Type of Change
Place an `x` the applicable box:
- [ ] Bug fix. Add the issue # below if applicable.
- [x] New feature. A non-breaking change which adds functionality.
- [ ] Other, such as a build process or documentation change.
***

