### PR TITLE
Update Xcode minimum to 16.2

### DIFF
--- a/firebaseai/testapp/readme.md
+++ b/firebaseai/testapp/readme.md
@@ -9,7 +9,7 @@ inside the Unity Editor.
 ## Requirements
 
 * [Unity](http://unity3d.com/) The quickstart project requires 2021.3 or higher.
-* [Xcode](https://developer.apple.com/xcode/) 15.1 or higher
+* [Xcode](https://developer.apple.com/xcode/) 16.2 or higher
   (when developing for iOS).
 * [Android SDK](https://developer.android.com/studio/index.html#downloads)
   (when developing for Android).


### PR DESCRIPTION
### Description
>After the App Store started requiring Xcode 16 in April 2025, Firebase now requires at least 16.2
***
### Testing
> Describe how you've tested these changes.


[replace this line]: # (Describe your testing in detail.)
***

### Type of Change
Place an `x` the applicable box:
- [ ] Bug fix. Add the issue # below if applicable.
- [ ] New feature. A non-breaking change which adds functionality.
- [ x] Other, such as a build process or documentation change.
***

