### PR TITLE
[FirebaseAI] Shorten namespace to Firebase.AI

### DIFF
--- a/firebaseai/src/Candidate.cs
+++ b/firebaseai/src/Candidate.cs
@@ -18,9 +18,9 @@ using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Linq;
-using Firebase.FirebaseAI.Internal;
+using Firebase.AI.Internal;
 
-namespace Firebase.FirebaseAI {
+namespace Firebase.AI {
 
 /// <summary>
 /// Represents the reason why the model stopped generating content.
@@ -108,16 +108,16 @@ public readonly struct Candidate {
 
   private static FinishReason ParseFinishReason(string str) {
     return str switch {
-      "STOP" => Firebase.FirebaseAI.FinishReason.Stop,
-      "MAX_TOKENS" => Firebase.FirebaseAI.FinishReason.MaxTokens,
-      "SAFETY" => Firebase.FirebaseAI.FinishReason.Safety,
-      "RECITATION" => Firebase.FirebaseAI.FinishReason.Recitation,
-      "OTHER" => Firebase.FirebaseAI.FinishReason.Other,
-      "BLOCKLIST" => Firebase.FirebaseAI.FinishReason.Blocklist,
-      "PROHIBITED_CONTENT" => Firebase.FirebaseAI.FinishReason.ProhibitedContent,
-      "SPII" => Firebase.FirebaseAI.FinishReason.SPII,
-      "MALFORMED_FUNCTION_CALL" => Firebase.FirebaseAI.FinishReason.MalformedFunctionCall,
-      _ => Firebase.FirebaseAI.FinishReason.Unknown,
+      "STOP" => Firebase.AI.FinishReason.Stop,
+      "MAX_TOKENS" => Firebase.AI.FinishReason.MaxTokens,
+      "SAFETY" => Firebase.AI.FinishReason.Safety,
+      "RECITATION" => Firebase.AI.FinishReason.Recitation,
+      "OTHER" => Firebase.AI.FinishReason.Other,
+      "BLOCKLIST" => Firebase.AI.FinishReason.Blocklist,
+      "PROHIBITED_CONTENT" => Firebase.AI.FinishReason.ProhibitedContent,
+      "SPII" => Firebase.AI.FinishReason.SPII,
+      "MALFORMED_FUNCTION_CALL" => Firebase.AI.FinishReason.MalformedFunctionCall,
+      _ => Firebase.AI.FinishReason.Unknown,
     };
   }
 
@@ -132,7 +132,7 @@ public readonly struct Candidate {
       jsonDict.ParseObjectList("safetyRatings", SafetyRating.FromJson),
       jsonDict.ParseNullableEnum("finishReason", ParseFinishReason),
       jsonDict.ParseNullableObject("citationMetadata",
-          (d) => Firebase.FirebaseAI.CitationMetadata.FromJson(d, backend)));
+          (d) => Firebase.AI.CitationMetadata.FromJson(d, backend)));
   }
 }
 

--- a/firebaseai/src/Chat.cs
+++ b/firebaseai/src/Chat.cs
@@ -20,9 +20,9 @@ using System.Linq;
 using System.Runtime.CompilerServices;
 using System.Threading;
 using System.Threading.Tasks;
-using Firebase.FirebaseAI.Internal;
+using Firebase.AI.Internal;
 
-namespace Firebase.FirebaseAI {
+namespace Firebase.AI {
 
 /// <summary>
 /// An object that represents a back-and-forth chat with a model, capturing the history and saving

--- a/firebaseai/src/Citation.cs
+++ b/firebaseai/src/Citation.cs
@@ -17,9 +17,9 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
-using Firebase.FirebaseAI.Internal;
+using Firebase.AI.Internal;
 
-namespace Firebase.FirebaseAI {
+namespace Firebase.AI {
 
 /// <summary>
 /// A collection of source attributions for a piece of content.

--- a/firebaseai/src/CountTokensResponse.cs
+++ b/firebaseai/src/CountTokensResponse.cs
@@ -17,9 +17,9 @@
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using Google.MiniJSON;
-using Firebase.FirebaseAI.Internal;
+using Firebase.AI.Internal;
 
-namespace Firebase.FirebaseAI {
+namespace Firebase.AI {
 
 /// <summary>
 /// The model's response to a count tokens request.

--- a/firebaseai/src/FirebaseAI.cs
+++ b/firebaseai/src/FirebaseAI.cs
@@ -17,7 +17,7 @@
 using System;
 using System.Collections.Concurrent;
 
-namespace Firebase.FirebaseAI {
+namespace Firebase.AI {
 
 /// <summary>
 /// The entry point for all Firebase AI SDK functionality.

--- a/firebaseai/src/FirebaseAIException.cs
+++ b/firebaseai/src/FirebaseAIException.cs
@@ -17,7 +17,7 @@
 using System;
 using System.Linq;
 
-namespace Firebase.FirebaseAI {
+namespace Firebase.AI {
 
 public class FirebaseAIException : Exception {
   internal FirebaseAIException(string message) : base(message) { }

--- a/firebaseai/src/FunctionCalling.cs
+++ b/firebaseai/src/FunctionCalling.cs
@@ -17,9 +17,9 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using Firebase.FirebaseAI.Internal;
+using Firebase.AI.Internal;
 
-namespace Firebase.FirebaseAI {
+namespace Firebase.AI {
 
 /// <summary>
 /// Structured representation of a function declaration.

--- a/firebaseai/src/GenerateContentResponse.cs
+++ b/firebaseai/src/GenerateContentResponse.cs
@@ -18,9 +18,9 @@ using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Linq;
 using Google.MiniJSON;
-using Firebase.FirebaseAI.Internal;
+using Firebase.AI.Internal;
 
-namespace Firebase.FirebaseAI {
+namespace Firebase.AI {
 
 /// <summary>
 /// The model's response to a generate content request.
@@ -92,9 +92,9 @@ public readonly struct GenerateContentResponse {
     return new GenerateContentResponse(
       jsonDict.ParseObjectList("candidates", (d) => Candidate.FromJson(d, backend)),
       jsonDict.ParseNullableObject("promptFeedback",
-          Firebase.FirebaseAI.PromptFeedback.FromJson),
+          Firebase.AI.PromptFeedback.FromJson),
       jsonDict.ParseNullableObject("usageMetadata",
-          Firebase.FirebaseAI.UsageMetadata.FromJson));
+          Firebase.AI.UsageMetadata.FromJson));
   }
 }
 
@@ -154,11 +154,11 @@ public readonly struct PromptFeedback {
 
   private static BlockReason ParseBlockReason(string str) {
     return str switch {
-      "SAFETY" => Firebase.FirebaseAI.BlockReason.Safety,
-      "OTHER" => Firebase.FirebaseAI.BlockReason.Other,
-      "BLOCKLIST" => Firebase.FirebaseAI.BlockReason.Blocklist,
-      "PROHIBITED_CONTENT" => Firebase.FirebaseAI.BlockReason.ProhibitedContent,
-      _ => Firebase.FirebaseAI.BlockReason.Unknown,
+      "SAFETY" => Firebase.AI.BlockReason.Safety,
+      "OTHER" => Firebase.AI.BlockReason.Other,
+      "BLOCKLIST" => Firebase.AI.BlockReason.Blocklist,
+      "PROHIBITED_CONTENT" => Firebase.AI.BlockReason.ProhibitedContent,
+      _ => Firebase.AI.BlockReason.Unknown,
     };
   }
 

--- a/firebaseai/src/GenerationConfig.cs
+++ b/firebaseai/src/GenerationConfig.cs
@@ -17,9 +17,9 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using Firebase.FirebaseAI.Internal;
+using Firebase.AI.Internal;
 
-namespace Firebase.FirebaseAI {
+namespace Firebase.AI {
 
 /// <summary>
 /// A struct defining model parameters to be used when sending generative AI

--- a/firebaseai/src/GenerativeModel.cs
+++ b/firebaseai/src/GenerativeModel.cs
@@ -24,9 +24,9 @@ using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using Google.MiniJSON;
-using Firebase.FirebaseAI.Internal;
+using Firebase.AI.Internal;
 
-namespace Firebase.FirebaseAI {
+namespace Firebase.AI {
 
 /// <summary>
 /// A type that represents a remote multimodal model (like Gemini), with the ability to generate

--- a/firebaseai/src/Internal/EnumConverters.cs
+++ b/firebaseai/src/Internal/EnumConverters.cs
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-namespace Firebase.FirebaseAI.Internal {
+namespace Firebase.AI.Internal {
 
 // Contains extension methods for converting shared enums to strings.
 internal static class EnumConverters {

--- a/firebaseai/src/Internal/FirebaseInterops.cs
+++ b/firebaseai/src/Internal/FirebaseInterops.cs
@@ -20,7 +20,7 @@ using System.Net.WebSockets;
 using System.Reflection;
 using System.Threading.Tasks;
 
-namespace Firebase.FirebaseAI.Internal {
+namespace Firebase.AI.Internal {
 
 // Contains internal helper methods for interacting with other Firebase libraries.
 internal static class FirebaseInterops {

--- a/firebaseai/src/Internal/InternalHelpers.cs
+++ b/firebaseai/src/Internal/InternalHelpers.cs
@@ -18,7 +18,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 
-namespace Firebase.FirebaseAI.Internal {
+namespace Firebase.AI.Internal {
 
 // Include this to just shorthand it in this file
 using JsonDict = Dictionary<string, object>;

--- a/firebaseai/src/LiveGenerationConfig.cs
+++ b/firebaseai/src/LiveGenerationConfig.cs
@@ -16,9 +16,9 @@
 
 using System.Collections.Generic;
 using System.Linq;
-using Firebase.FirebaseAI.Internal;
+using Firebase.AI.Internal;
 
-namespace Firebase.FirebaseAI {
+namespace Firebase.AI {
 
 /// <summary>
 /// A struct used to configure speech generation settings.

--- a/firebaseai/src/LiveGenerativeModel.cs
+++ b/firebaseai/src/LiveGenerativeModel.cs
@@ -21,10 +21,10 @@ using System.Net.WebSockets;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
-using Firebase.FirebaseAI.Internal;
+using Firebase.AI.Internal;
 using Google.MiniJSON;
 
-namespace Firebase.FirebaseAI {
+namespace Firebase.AI {
 
 /// <summary>
 /// A live, generative AI model for real-time interaction.

--- a/firebaseai/src/LiveSession.cs
+++ b/firebaseai/src/LiveSession.cs
@@ -24,7 +24,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Google.MiniJSON;
 
-namespace Firebase.FirebaseAI {
+namespace Firebase.AI {
 
 /// <summary>
 /// Manages asynchronous communication with Gemini model over a WebSocket

--- a/firebaseai/src/LiveSessionResponse.cs
+++ b/firebaseai/src/LiveSessionResponse.cs
@@ -17,12 +17,12 @@
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using Google.MiniJSON;
-using Firebase.FirebaseAI.Internal;
+using Firebase.AI.Internal;
 using System.Linq;
 using System;
 using System.Text;
 
-namespace Firebase.FirebaseAI {
+namespace Firebase.AI {
 
 /// <summary>
 /// Represents the response from the model for live content updates.

--- a/firebaseai/src/ModalityTokenCount.cs
+++ b/firebaseai/src/ModalityTokenCount.cs
@@ -15,9 +15,9 @@
  */
 
 using System.Collections.Generic;
-using Firebase.FirebaseAI.Internal;
+using Firebase.AI.Internal;
 
-namespace Firebase.FirebaseAI {
+namespace Firebase.AI {
 
 /// <summary>
 /// Content part modality.

--- a/firebaseai/src/ModelContent.cs
+++ b/firebaseai/src/ModelContent.cs
@@ -18,9 +18,9 @@ using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Linq;
-using Firebase.FirebaseAI.Internal;
+using Firebase.AI.Internal;
 
-namespace Firebase.FirebaseAI {
+namespace Firebase.AI {
 
 /// <summary>
 /// A type describing data in media formats interpretable by an AI model. Each generative AI

--- a/firebaseai/src/RequestOptions.cs
+++ b/firebaseai/src/RequestOptions.cs
@@ -16,7 +16,7 @@
 
 using System;
 
-namespace Firebase.FirebaseAI {
+namespace Firebase.AI {
 
 /// <summary>
 /// Configuration parameters for sending requests to the backend.

--- a/firebaseai/src/ResponseModality.cs
+++ b/firebaseai/src/ResponseModality.cs
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-namespace Firebase.FirebaseAI {
+namespace Firebase.AI {
 
 /// <summary>
 /// The response type the model should return with.

--- a/firebaseai/src/Safety.cs
+++ b/firebaseai/src/Safety.cs
@@ -16,9 +16,9 @@
 
 using System;
 using System.Collections.Generic;
-using Firebase.FirebaseAI.Internal;
+using Firebase.AI.Internal;
 
-namespace Firebase.FirebaseAI {
+namespace Firebase.AI {
 
 /// <summary>
 /// Categories describing the potential harm a piece of content may pose.

--- a/firebaseai/src/Schema.cs
+++ b/firebaseai/src/Schema.cs
@@ -19,7 +19,7 @@ using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Linq;
 
-namespace Firebase.FirebaseAI {
+namespace Firebase.AI {
 
 /// <summary>
 /// A `Schema` object allows the definition of input and output data types.

--- a/firebaseai/testapp/Assets/Firebase/Sample/FirebaseAI/UIHandlerAutomated.cs
+++ b/firebaseai/testapp/Assets/Firebase/Sample/FirebaseAI/UIHandlerAutomated.cs
@@ -18,7 +18,7 @@
 namespace Firebase.Sample.FirebaseAI {
   using Firebase;
   using Firebase.Extensions;
-  using Firebase.FirebaseAI;
+  using Firebase.AI;
   using System;
   using System.Collections.Generic;
   using System.Linq;


### PR DESCRIPTION
### Description
> Provide details of the change, and generalize the change in the PR title above.

Changing the namespace from Firebase.FirebaseAI to Firebase.AI.  The longer one was causing confusion with the class FirebaseAI, and general C# advice is to try to avoid that type of conflict.
***
### Testing
> Describe how you've tested these changes.

Running tests locally
***

### Type of Change
Place an `x` the applicable box:
- [ ] Bug fix. Add the issue # below if applicable.
- [x] New feature. A non-breaking change which adds functionality.
- [ ] Other, such as a build process or documentation change.
***

