### PR TITLE
[FirebaseAI] Add it to the nightly build process

### DIFF
--- a/.github/workflows/build_android.yml
+++ b/.github/workflows/build_android.yml
@@ -20,7 +20,7 @@ on:
         type: string
       apis:
         description: 'CSV of apis to build and test'
-        default: 'analytics,app_check,auth,crashlytics,database,dynamic_links,firestore,functions,installations,messaging,remote_config,storage'
+        default: 'analytics,app_check,auth,crashlytics,database,dynamic_links,firebaseai,firestore,functions,installations,messaging,remote_config,storage'
         required: true
         type: string
       unity_platform_name:

--- a/.github/workflows/build_ios.yml
+++ b/.github/workflows/build_ios.yml
@@ -20,7 +20,7 @@ on:
         type: string
       apis:
         description: 'CSV of apis to build and test'
-        default: 'analytics,app_check,auth,crashlytics,database,dynamic_links,firestore,functions,installations,messaging,remote_config,storage'
+        default: 'analytics,app_check,auth,crashlytics,database,dynamic_links,firebaseai,firestore,functions,installations,messaging,remote_config,storage'
         required: true
         type: string
       unity_platform_name:

--- a/.github/workflows/build_linux.yml
+++ b/.github/workflows/build_linux.yml
@@ -20,7 +20,7 @@ on:
         type: string
       apis:
         description: 'CSV of apis to build and test'
-        default: 'analytics,app_check,auth,crashlytics,database,dynamic_links,firestore,functions,installations,messaging,remote_config,storage'
+        default: 'analytics,app_check,auth,crashlytics,database,dynamic_links,firebaseai,firestore,functions,installations,messaging,remote_config,storage'
         required: true
         type: string
       unity_platform_name:

--- a/.github/workflows/build_macos.yml
+++ b/.github/workflows/build_macos.yml
@@ -20,7 +20,7 @@ on:
         type: string
       apis:
         description: 'CSV of apis to build and test'
-        default: 'analytics,app_check,auth,crashlytics,database,dynamic_links,firestore,functions,installations,messaging,remote_config,storage'
+        default: 'analytics,app_check,auth,crashlytics,database,dynamic_links,firebaseai,firestore,functions,installations,messaging,remote_config,storage'
         required: true
         type: string
       unity_platform_name:

--- a/.github/workflows/build_starter.yml
+++ b/.github/workflows/build_starter.yml
@@ -28,7 +28,7 @@ on:
         required: true
       apis:
         description: 'CSV of apis to build and test'
-        default: 'analytics,app_check,auth,crashlytics,database,dynamic_links,firestore,functions,installations,messaging,remote_config,storage'
+        default: 'analytics,app_check,auth,crashlytics,database,dynamic_links,firebaseai,firestore,functions,installations,messaging,remote_config,storage'
         required: true
       # Additional CMake flags to use
       additional_cmake_flags:
@@ -104,7 +104,7 @@ jobs:
             echo "platform='Android,iOS,tvOS,Windows,macOS,Linux,Playmode'" >> $GITHUB_OUTPUT
             echo "release_label=nightly-$(date "+%Y%m%d-%H%M%S")" >> $GITHUB_OUTPUT
             echo "release_version=NoVersion" >> $GITHUB_OUTPUT
-            echo "apis='analytics,app_check,auth,crashlytics,database,dynamic_links,firestore,functions,installations,messaging,remote_config,storage'" >> $GITHUB_OUTPUT
+            echo "apis='analytics,app_check,auth,crashlytics,database,dynamic_links,firebaseai,firestore,functions,installations,messaging,remote_config,storage'" >> $GITHUB_OUTPUT
             echo "unity_version=2021" >> $GITHUB_OUTPUT
             echo "should_trigger_package=true" >> $GITHUB_OUTPUT
             echo "firebase_cpp_sdk_version=" >> $GITHUB_OUTPUT

--- a/.github/workflows/build_tvos.yml
+++ b/.github/workflows/build_tvos.yml
@@ -20,7 +20,7 @@ on:
         type: string
       apis:
         description: 'CSV of apis to build and test'
-        default: 'analytics,app_check,auth,crashlytics,database,firestore,functions,installations,messaging,remote_config,storage'
+        default: 'analytics,app_check,auth,crashlytics,database,firebaseai,firestore,functions,installations,messaging,remote_config,storage'
         required: true
         type: string
       unity_platform_name:
@@ -47,7 +47,7 @@ on:
         type: string
       apis:
         description: 'CSV of apis to build and test'
-        default: 'analytics,app_check,auth,crashlytics,database,firestore,functions,installations,messaging,remote_config,storage'
+        default: 'analytics,app_check,auth,crashlytics,database,firebaseai,firestore,functions,installations,messaging,remote_config,storage'
         required: true
         type: string
       unity_platform_name:

--- a/.github/workflows/build_windows.yml
+++ b/.github/workflows/build_windows.yml
@@ -20,7 +20,7 @@ on:
         type: string
       apis:
         description: 'CSV of apis to build and test'
-        default: 'analytics,app_check,auth,crashlytics,database,dynamic_links,firestore,functions,installations,messaging,remote_config,storage'
+        default: 'analytics,app_check,auth,crashlytics,database,dynamic_links,firebaseai,firestore,functions,installations,messaging,remote_config,storage'
         required: true
         type: string
       unity_platform_name:

--- a/.github/workflows/generate_swig.yml
+++ b/.github/workflows/generate_swig.yml
@@ -16,7 +16,7 @@ on:
         type: string
       apis:
         description: 'CSV of apis to build and test'
-        default: 'analytics,app_check,auth,crashlytics,database,dynamic_links,firestore,functions,installations,messaging,remote_config,storage'
+        default: 'analytics,app_check,auth,crashlytics,database,dynamic_links,firebaseai,firestore,functions,installations,messaging,remote_config,storage'
         required: true
         type: string
       # Additional CMake flags to use

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -18,7 +18,7 @@ on:
         required: true
       apis:
         description: 'CSV of apis to build and test'
-        default: 'analytics,app_check,auth,crashlytics,database,dynamic_links,firestore,functions,installations,messaging,remote_config,storage'
+        default: 'analytics,app_check,auth,crashlytics,database,dynamic_links,firebaseai,firestore,functions,installations,messaging,remote_config,storage'
         required: true
       mobile_test_on:
         description: 'Run mobile tests on real and/or virtual devices? (value: real, virtual. separated by commas)'

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -33,7 +33,7 @@ on:
         type: string
       apis:
         description: 'CSV of apis to build and test'
-        default: 'analytics,app_check,auth,crashlytics,database,dynamic_links,firestore,functions,installations,messaging,remote_config,storage'
+        default: 'analytics,app_check,auth,crashlytics,database,dynamic_links,firebaseai,firestore,functions,installations,messaging,remote_config,storage'
         required: true
         type: string
 
@@ -42,7 +42,7 @@ permissions: write-all
 env:
   # Use SHA256 for hashing files.
   hashCommand: "sha256sum"
-  default_apis: 'analytics,app_check,auth,crashlytics,database,dynamic_links,firestore,functions,installations,messaging,remote_config,storage'
+  default_apis: 'analytics,app_check,auth,crashlytics,database,dynamic_links,firebaseai,firestore,functions,installations,messaging,remote_config,storage'
 
 jobs:
   package_sdks:

--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ Expected output artifact is
 python scripts/build_scripts/build_zips.py --platform=<target platform> --targets=<lib1> --targets=<lib2>
 ```
 
-> **Note:** Supported library names: analytics, app_check, auth, crashlytics, database, dynamic_links, firestore, functions, installations, messaging, remote_config, storage
+> **Note:** Supported library names: analytics, app_check, auth, crashlytics, database, dynamic_links, firebaseai, firestore, functions, installations, messaging, remote_config, storage
 
 ## Packaging
 

--- a/release_build_files/CMakeLists.txt
+++ b/release_build_files/CMakeLists.txt
@@ -56,6 +56,11 @@ unity_pack_file(
 )
 
 unity_pack_file(
+  "${FIREBASE_UNITY_DIR}/docs/firebaseai/FirebaseAIReadme.md"
+  PACK_PATH "Firebase/Editor"
+)
+
+unity_pack_file(
   "${FIREBASE_UNITY_DIR}/docs/firestore/FirestoreReadme.md"
   PACK_PATH "Firebase/Editor"
 )
@@ -82,10 +87,5 @@ unity_pack_file(
 
 unity_pack_file(
   "${FIREBASE_UNITY_DIR}/docs/storage/StorageReadme.md"
-  PACK_PATH "Firebase/Editor"
-)
-
-unity_pack_file(
-  "${FIREBASE_UNITY_DIR}/docs/firebaseai/FirebaseAIReadme.md"
   PACK_PATH "Firebase/Editor"
 )

--- a/scripts/build_scripts/build_package.py
+++ b/scripts/build_scripts/build_package.py
@@ -42,8 +42,8 @@ from absl import logging
 
 SUPPORT_TARGETS = [
     "analytics", "app_check", "auth", "crashlytics", "database", "dynamic_links",
-    "firestore", "functions", "installations", "messaging", "remote_config",
-    "storage", "firebaseai"
+    "firebaseai", "firestore", "functions", "installations", "messaging", "remote_config",
+    "storage"
 ]
 
 FLAGS = flags.FLAGS

--- a/scripts/build_scripts/build_zips.py
+++ b/scripts/build_scripts/build_zips.py
@@ -33,13 +33,12 @@ from absl import app, flags, logging
 SUPPORT_PLATFORMS = ("linux", "macos", "windows", "ios", "tvos", "android")
 SUPPORT_TARGETS = [
     "analytics", "app_check", "auth", "crashlytics", "database", "dynamic_links",
-    "firestore", "functions", "installations", "messaging", "remote_config",
-    "storage", "firebaseai"
+    "firebaseai", "firestore", "functions", "installations", "messaging", "remote_config",
+    "storage"
 ]
 TVOS_SUPPORT_TARGETS = [
-    "analytics", "app_check", "auth", "crashlytics", "database", "firestore",
-    "functions", "installations", "messaging", "remote_config", "storage",
-    "firebaseai"
+    "analytics", "app_check", "auth", "crashlytics", "database", "firebaseai", "firestore",
+    "functions", "installations", "messaging", "remote_config", "storage"
 ]
 SUPPORT_DEVICE = ["device", "simulator"]
 

--- a/scripts/create_debug_export.py
+++ b/scripts/create_debug_export.py
@@ -35,13 +35,13 @@ API_PACKAGE_MAP = {
     "crashlytics": "FirebaseCrashlytics.unitypackage",
     "database": "FirebaseDatabase.unitypackage",
     "dynamic_links": "FirebaseDynamicLinks.unitypackage",
+    "firebaseai": "FirebaseAI.unitypackage",
     "firestore": "FirebaseFirestore.unitypackage",
     "functions": "FirebaseFunctions.unitypackage",
     "installations": "FirebaseInstallations.unitypackage",
     "messaging": "FirebaseMessaging.unitypackage",
     "remote_config": "FirebaseRemoteConfig.unitypackage",
     "storage": "FirebaseStorage.unitypackage",
-    "firebaseai": "FirebaseAI.unitypackage",
 }
 
 default_package_names = [

--- a/scripts/gha/integration_testing/build_testapps.json
+++ b/scripts/gha/integration_testing/build_testapps.json
@@ -106,6 +106,23 @@
       ]
     },
     {
+      "name": "firebaseai",
+      "full_name": "FirebaseAI",
+      "captial_name": "FirebaseAI",
+      "bundle_id": "com.google.firebase.unity.firebaseai.testapp",
+      "testapp_path": "firebaseai/testapp",
+      "platforms": ["Android", "Playmode", "iOS", "tvOS", "Windows", "macOS", "Linux"],
+      "plugins": [
+        "FirebaseAI.unitypackage"
+      ],
+      "provision": "Firebase_Dev_Wildcard.mobileprovision",
+      "upm_packages": [
+        "com.google.external-dependency-manager-*.tgz",
+        "com.google.firebase.app-*.tgz",
+        "com.google.firebase.firebaseai-*.tgz"
+      ]
+    },
+    {
       "name": "firestore",
       "full_name": "FirebaseFirestore",
       "captial_name": "Firestore",
@@ -213,23 +230,6 @@
         "com.google.firebase.app-*.tgz",
         "com.google.firebase.auth-*.tgz",
         "com.google.firebase.storage-*.tgz"
-      ]
-    },
-    {
-      "name": "firebaseai",
-      "full_name": "FirebaseAI",
-      "captial_name": "FirebaseAI",
-      "bundle_id": "com.google.firebase.unity.firebaseai.testapp",
-      "testapp_path": "firebaseai/testapp",
-      "platforms": ["Android", "Playmode", "iOS", "tvOS", "Windows", "macOS", "Linux"],
-      "plugins": [
-        "FirebaseAI.unitypackage"
-      ],
-      "provision": "Firebase_Dev_Wildcard.mobileprovision",
-      "upm_packages": [
-        "com.google.external-dependency-manager-*.tgz",
-        "com.google.firebase.app-*.tgz",
-        "com.google.firebase.firebaseai-*.tgz"
       ]
     }
   ],

--- a/scripts/gha/restore_secrets.py
+++ b/scripts/gha/restore_secrets.py
@@ -58,13 +58,13 @@ CAPITALIZATIONS = {
   "crashlytics": "Crashlytics",
   "database": "Database",
   "dynamic_links": "DynamicLinks",
+  "firebaseai": "FirebaseAI",
   "firestore": "Firestore",
   "functions": "Functions",
   "installations": "Installations",
   "messaging": "Messaging",
   "remote_config": "RemoteConfig",
-  "storage": "Storage",
-  "firebaseai": "FirebaseAI"
+  "storage": "Storage"
 }
 
 

--- a/unity_packer/exports.json
+++ b/unity_packer/exports.json
@@ -2040,6 +2040,60 @@
           "unity": "2020.1"
         }
       }
+    },
+    {
+      "name": "FirebaseAI.unitypackage",
+      "imports": [
+        {
+          "importer": "DefaultImporter",
+          "paths": [
+            "Firebase/FirebaseAI/*"
+          ]
+        },
+        {
+          "importer": "DefaultImporter",
+          "sections": [
+            "samples",
+            "documentation"
+          ],
+          "paths": [
+            "Firebase/Editor/FirebaseAIReadme.md"
+          ]
+        }
+      ],
+      "includes": [
+        "FirebaseApp.unitypackage",
+        "SampleCommon.unitypackage"
+      ],
+      "manifest_path": "Firebase/Editor",
+      "readme": "Firebase/Editor/FirebaseAIReadme.md",
+      "changelog": "Firebase/Editor/readme.md",
+      "license": "Firebase/Editor/LICENSE",
+      "documentation": "Firebase/Editor/FirebaseAIReadme.md",
+      "common_manifest": {
+        "name": "com.google.firebase.firebaseai",
+        "display_name": "Firebase AI",
+        "description": [
+          "Build AI-powered mobile and web apps and features with ",
+          "the Gemini API using Firebase AI."
+        ],
+        "keywords": [
+          "Google",
+          "Firebase",
+          "Firebase AI",
+          "Vertex AI"
+        ],
+        "author": {
+          "name": "Google LLC",
+          "url": "https://firebase.google.com/docs/vertex-ai"
+        }
+      },
+      "export_upm": 1,
+      "upm_package_config": {
+        "manifest": {
+          "unity": "2020.1"
+        }
+      }
     }
   ]
 }


### PR DESCRIPTION
### Description
> Provide details of the change, and generalize the change in the PR title above.

Adds FirebaseAI to the nightly build process by default. Includes adding it to the large packaging process. Also fix the alphabetical ordering for some of the things from the rename from VertexAI.
***
### Testing
> Describe how you've tested these changes.

https://github.com/firebase/firebase-unity-sdk/actions/runs/14896247284
***

### Type of Change
Place an `x` the applicable box:
- [ ] Bug fix. Add the issue # below if applicable.
- [ ] New feature. A non-breaking change which adds functionality.
- [x] Other, such as a build process or documentation change.
***

