### PR TITLE
Set Android common page size to 16 KB

### DIFF
--- a/cmake/build_shared.cmake
+++ b/cmake/build_shared.cmake
@@ -108,6 +108,7 @@ function(build_firebase_shared LIBRARY_NAME ARTIFACT_NAME OUTPUT_NAME)
         "-static-libstdc++"
         # Set the max page size to 16KB, needed by Android 15
         "-Wl,-z,max-page-size=16384"
+        "-Wl,-z,common-page-size=16384"
     )
     add_custom_command(TARGET ${shared_target} POST_BUILD
       COMMAND "${ANDROID_TOOLCHAIN_PREFIX}strip" -g -S -d --strip-debug --verbose

--- a/cmake/build_universal.cmake
+++ b/cmake/build_universal.cmake
@@ -88,6 +88,7 @@ function(build_uni TARGET_LINK_LIB_NAMES PROJECT_LIST_HEADER_VARIABLE)
         "-static-libstdc++"
         # Set the max page size to 16KB, needed by Android 15
         "-Wl,-z,max-page-size=16384"
+        "-Wl,-z,common-page-size=16384"
     )
     add_custom_command(TARGET firebase_app_uni POST_BUILD
       COMMAND "${ANDROID_TOOLCHAIN_PREFIX}strip" -g -S -d --strip-debug --verbose

--- a/docs/readme.md
+++ b/docs/readme.md
@@ -71,6 +71,11 @@ Support
 
 Release Notes
 -------------
+### Upcoming
+-   Changes
+    - General (Android): Fix a crash with 16 KB page sizes.
+      ([#1259](https://github.com/firebase/firebase-unity-sdk/issues/1259)).
+
 ### 12.9.0
 -   Changes
     - General: Update to EDM4U version 1.2.186.


### PR DESCRIPTION
### Description
> Provide details of the change, and generalize the change in the PR title above.

Set the common-page-size to 16 KB as well. Since we currently use an older NDK version (r21e), this additional flag needs to be set to guarantee that some of the internals are aligned correctly to the new file size. https://developer.android.com/guide/practices/page-sizes#compile-r26-lower

Fixes #1259 
***
### Testing
> Describe how you've tested these changes.

Testing locally via emulator
https://github.com/firebase/firebase-unity-sdk/actions/runs/15406475092
***

### Type of Change
Place an `x` the applicable box:
- [x] Bug fix. Add the issue # below if applicable.
- [ ] New feature. A non-breaking change which adds functionality.
- [ ] Other, such as a build process or documentation change.
***

