### PR TITLE
Update Windows runner in build_windows action to windows-latest (from windows-2019)

### DIFF
--- a/.github/workflows/build_windows.yml
+++ b/.github/workflows/build_windows.yml
@@ -65,6 +65,10 @@ jobs:
       - name: Support longpaths
         run: git config --system core.longpaths true
 
+      - uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '4.5.x'
+
       - name: Setup python
         uses: actions/setup-python@v4
         with:

--- a/.github/workflows/build_windows.yml
+++ b/.github/workflows/build_windows.yml
@@ -108,13 +108,13 @@ jobs:
       - name: Remove zlib
         shell: bash
         run: |
-          rm C:/msys64/mingw64/lib/libz*
+          rm -f C:/msys64/mingw64/lib/libz*
 
       # Strawberry Perl has zlib within, so we also remove it
       - name: Remove Strawberry
         shell: bash
         run: |
-          rm -r C:/Strawberry
+          rm -rf C:/Strawberry
       
       - name: Build SDK (Windows)
         timeout-minutes: 90

--- a/.github/workflows/build_windows.yml
+++ b/.github/workflows/build_windows.yml
@@ -65,10 +65,6 @@ jobs:
       - name: Support longpaths
         run: git config --system core.longpaths true
 
-      - uses: actions/setup-dotnet@v4
-        with:
-          dotnet-version: '4.5.x'
-
       - name: Setup python
         uses: actions/setup-python@v4
         with:

--- a/.github/workflows/build_windows.yml
+++ b/.github/workflows/build_windows.yml
@@ -108,7 +108,8 @@ jobs:
       - name: Remove zlib
         shell: bash
         run: |
-          find "C:/" -name 'libz*'
+          rm -f C:/mingw32/i686-w64-mingw32/lib/libz*
+          rm -f C:/mingw64/x86_64-w64-mingw32/lib/libz*
           rm -f C:/msys64/mingw64/lib/libz*
 
       # Strawberry Perl has zlib within, so we also remove it

--- a/.github/workflows/build_windows.yml
+++ b/.github/workflows/build_windows.yml
@@ -108,7 +108,7 @@ jobs:
       - name: Remove zlib
         shell: bash
         run: |
-	  find "C:/" -name 'libz*'
+          find "C:/" -name 'libz*'
           rm -f C:/msys64/mingw64/lib/libz*
 
       # Strawberry Perl has zlib within, so we also remove it

--- a/.github/workflows/build_windows.yml
+++ b/.github/workflows/build_windows.yml
@@ -40,7 +40,7 @@ permissions: write-all
 jobs:
   build_desktop:
     name: build-windows-unity${{inputs.unity_version}}-CPP${{ inputs.firebase_cpp_sdk_version }}
-    runs-on: windows-2019
+    runs-on: windows-latest
     strategy:
       fail-fast: false
  

--- a/.github/workflows/build_windows.yml
+++ b/.github/workflows/build_windows.yml
@@ -108,6 +108,7 @@ jobs:
       - name: Remove zlib
         shell: bash
         run: |
+	  find "C:/" -name 'libz*'
           rm -f C:/msys64/mingw64/lib/libz*
 
       # Strawberry Perl has zlib within, so we also remove it

--- a/cmake/unity_mono.cmake
+++ b/cmake/unity_mono.cmake
@@ -204,7 +204,7 @@ endmacro()
 #  sys_references: System CSharp libraries this depends on
 #  dep_targets: Targets this target depends on and need to be linked/built first
 #  guid: MSBuild project guid (for use with solution files)
-#  framework_version: .net framework version, defaults to 4.5
+#  framework_version: .net framework version, defaults to 4.7.2
 #  defines: Extra defines to add to the project file
 #  assembly_name: Name of the output assembly. Defaults to module
 #  xbuild: Path to xbuild executable. Defaults to XBUILD_EXE global var
@@ -259,7 +259,7 @@ macro(mono_add_internal name output_type)
   endif()
 
   if ("${UNITY_MONO_FRAMEWORK_VERSION}" STREQUAL "")
-    set(UNITY_MONO_FRAMEWORK_VERSION "4.5")
+    set(UNITY_MONO_FRAMEWORK_VERSION "4.7.2")
   endif()
 
   if ("${UNITY_MONO_ASSEMBLY_NAME}" STREQUAL "")

--- a/scripts/build_scripts/build_zips.py
+++ b/scripts/build_scripts/build_zips.py
@@ -430,7 +430,7 @@ def get_windows_args():
       cmake args for windows platform.
   """
   result_args = []
-  result_args.append('-G Visual Studio 16 2019')
+  result_args.append('-G Visual Studio 17 2022')
   result_args.append('-A x64') # TODO flexibily for x32
   result_args.append("-DFIREBASE_PYTHON_HOST_EXECUTABLE:FILEPATH=%s" % sys.executable)
   # Use a newer version of the Windows SDK, as the default one has build issues with grpc


### PR DESCRIPTION
### Description
> Provide details of the change, and generalize the change in the PR title above.

This is the only place that windows-2019 is hard coded; these machines are going away at the end of June.
***
### Testing
> Describe how you've tested these changes.

Succeeded here: https://github.com/firebase/firebase-unity-sdk/actions/runs/15452657745
***

### Type of Change
Place an `x` the applicable box:
- [ ] Bug fix. Add the issue # below if applicable.
- [ ] New feature. A non-breaking change which adds functionality.
- [ ] Other, such as a build process or documentation change.
***

