### PR TITLE
Analytics SetDefaultParameters

### DIFF
--- a/analytics/src/FirebaseAnalytics.cs
+++ b/analytics/src/FirebaseAnalytics.cs
@@ -248,6 +248,30 @@ public static partial class FirebaseAnalytics {
     FirebaseAnalyticsInternal.SetConsentWithInts(consentSettingsMap);
   }
 
+  /// @brief Sets default event parameters.
+  ///
+  /// These parameters are logged with all events, in addition to the parameters passed to the
+  /// LogEvent() call. They are useful for logging common parameters with all events.
+  /// Default event parameters are overridden by event-specific parameters if the names are the
+  /// same. Default parameters are removed if the dictionary is null or empty.
+  ///
+  /// @param[in] parameters The dictionary of parameters to set.
+  ///   If null, clears all default parameters.
+  public static void SetDefaultParameters(
+      System.Collections.Generic.IDictionary<string, object> parameters) {
+    if (parameters == null || parameters.Count == 0) {
+      FirebaseAnalyticsInternal.ClearDefaultEventParameters();
+    } else {
+      StringList parameterNames = new StringList();
+      VariantList parameterValues = new VariantList();
+      foreach (var kvp in parameters) {
+        parameterNames.Add(kvp.Key);
+        parameterValues.Add(Firebase.Variant.FromObject(kvp.Value));
+      }
+      FirebaseAnalyticsInternal.SetDefaultEventParametersHelper(parameterNames, parameterValues);
+    }
+  }
+
   /// @brief Sets the duration of inactivity that terminates the current session.
   ///
   /// @note The default value is 30 minutes.

--- a/analytics/src/swig/analytics.i
+++ b/analytics/src/swig/analytics.i
@@ -87,6 +87,24 @@ void SetConsentWithInts(const std::map<int, int>& settings) {
   SetConsent(converted);
 }
 
+// Helper function to set default event parameters from vectors of strings and variants.
+void SetDefaultEventParametersHelper(
+    const std::vector<std::string>& parameter_names,
+    const std::vector<firebase::Variant>& parameter_values) {
+  if (parameter_names.size() != parameter_values.size()) {
+    firebase::LogError(
+        "SetDefaultEventParametersHelper given different list sizes (%d, %d)",
+        parameter_names.size(), parameter_values.size());
+    return;
+  }
+
+  std::map<std::string, firebase::Variant> default_parameters;
+  for (size_t i = 0; i < parameter_names.size(); ++i) {
+    default_parameters[parameter_names[i]] = parameter_values[i];
+  }
+  SetDefaultEventParameters(default_parameters);
+}
+
 }  // namespace analytics
 }  // namespace firebase
 
@@ -100,6 +118,10 @@ void SetConsentWithInts(const std::map<int, int>& settings) {
 %ignore firebase::analytics::LogEvent(const char*, const Parameter*, size_t);
 // Ignore SetConsent, in order to convert the types with our own function.
 %ignore firebase::analytics::SetConsent;
+// Ignore SetDefaultEventParameters and ClearDefaultEventParameters, as we handle them
+// with a custom version or re-expose ClearDefaultEventParameters.
+%ignore firebase::analytics::SetDefaultEventParameters;
+%ignore firebase::analytics::ClearDefaultEventParameters;
 // Ignore the Parameter class, as we don't want to expose that to C# at all.
 %ignore firebase::analytics::Parameter;
 
@@ -121,5 +143,9 @@ namespace analytics {
 void LogEvent(const char* name, std::vector<std::string> parameter_names,
               std::vector<firebase::Variant> parameter_values);
 void SetConsentWithInts(const std::map<int, int>& settings);
+void SetDefaultEventParametersHelper(
+    const std::vector<std::string>& parameter_names,
+    const std::vector<firebase::Variant>& parameter_values);
+void ClearDefaultEventParameters();
 }  // namespace analytics
 }  // namespace firebase

--- a/analytics/src/swig/analytics.i
+++ b/analytics/src/swig/analytics.i
@@ -121,7 +121,6 @@ void SetDefaultEventParametersHelper(
 // Ignore SetDefaultEventParameters and ClearDefaultEventParameters, as we handle them
 // with a custom version or re-expose ClearDefaultEventParameters.
 %ignore firebase::analytics::SetDefaultEventParameters;
-%ignore firebase::analytics::ClearDefaultEventParameters;
 // Ignore the Parameter class, as we don't want to expose that to C# at all.
 %ignore firebase::analytics::Parameter;
 

--- a/analytics/testapp/Assets/Firebase/Sample/Analytics/UIHandler.cs
+++ b/analytics/testapp/Assets/Firebase/Sample/Analytics/UIHandler.cs
@@ -162,6 +162,32 @@ namespace Firebase.Sample.Analytics {
       });
     }
 
+    public void TestSetDefaultParameters() {
+      DebugLog("Starting TestSetDefaultParameters...");
+
+      DebugLog("Setting single default string parameter: {'default_param_string', 'default_value_1'}");
+      FirebaseAnalytics.SetDefaultParameters(new Dictionary<string, object>
+      {
+          { "default_param_string", "default_value_1" }
+      });
+
+      DebugLog("Setting multiple default parameters: {'default_param_int', 123, 'default_param_double', 45.67, 'default_param_bool', true}");
+      FirebaseAnalytics.SetDefaultParameters(new Dictionary<string, object>
+      {
+          { "default_param_int", 123 },
+          { "default_param_double", 45.67 },
+          { "default_param_bool", true }
+      });
+
+      DebugLog("Clearing default parameters with null.");
+      FirebaseAnalytics.SetDefaultParameters(null);
+
+      DebugLog("Clearing default parameters with empty dictionary.");
+      FirebaseAnalytics.SetDefaultParameters(new Dictionary<string, object>());
+
+      DebugLog("TestSetDefaultParameters completed.");
+    }
+
     // Get the current app instance ID.
     public Task<string> DisplayAnalyticsInstanceId() {
       return FirebaseAnalytics.GetAnalyticsInstanceIdAsync().ContinueWithOnMainThread(task => {
@@ -256,6 +282,9 @@ namespace Firebase.Sample.Analytics {
 	}
         if (GUILayout.Button("Test SetConsent")) {
           AnalyticsSetConsent();
+        }
+        if (GUILayout.Button("Test SetDefaultParameters")) {
+          TestSetDefaultParameters();
         }
         GUILayout.EndVertical();
         GUILayout.EndScrollView();

--- a/analytics/testapp/Assets/Firebase/Sample/Analytics/UIHandlerAutomated.cs
+++ b/analytics/testapp/Assets/Firebase/Sample/Analytics/UIHandlerAutomated.cs
@@ -40,6 +40,7 @@ namespace Firebase.Sample.Analytics {
         TestAnalyticsSetConsentDoesNotThrow,
         TestInstanceIdChangeAfterReset,
         TestResetAnalyticsData,
+        TestSetDefaultParametersAutomated, // Added new test here
         // Temporarily disabled until this test is deflaked. b/143603151
         //TestCheckAndFixDependenciesInvalidOperation,
         TestCheckAndFixDependenciesDoubleCall,
@@ -108,6 +109,34 @@ namespace Firebase.Sample.Analytics {
         return true;
       });
     }
+
+    Task TestSetDefaultParametersAutomated() {
+      DebugLog("Automated Test: Starting TestSetDefaultParametersAutomated...");
+
+      DebugLog("Automated Test: Setting single default string parameter: {'auto_default_param_string', 'auto_value_1'}");
+      FirebaseAnalytics.SetDefaultParameters(new Dictionary<string, object>
+      {
+          { "auto_default_param_string", "auto_value_1" }
+      });
+
+      DebugLog("Automated Test: Setting multiple default parameters: {'auto_default_param_int', 789, 'auto_default_param_double', 12.34, 'auto_default_param_bool', false}");
+      FirebaseAnalytics.SetDefaultParameters(new Dictionary<string, object>
+      {
+          { "auto_default_param_int", 789 },
+          { "auto_default_param_double", 12.34 },
+          { "auto_default_param_bool", false }
+      });
+
+      DebugLog("Automated Test: Clearing default parameters with null.");
+      FirebaseAnalytics.SetDefaultParameters(null);
+
+      DebugLog("Automated Test: Clearing default parameters with empty dictionary.");
+      FirebaseAnalytics.SetDefaultParameters(new Dictionary<string, object>());
+
+      DebugLog("Automated Test: TestSetDefaultParametersAutomated completed.");
+      return Task.FromResult(true); // Indicate successful completion
+    }
+
     Task TestCheckAndFixDependenciesInvalidOperation() {
       // Only run the test on Android, as CheckAndFixDependenciesAsync is short
       // lived on other platforms, and thus could finish before the extra call.


### PR DESCRIPTION
### Description
> Provide details of the change, and generalize the change in the PR title above.

Add SetDefaultParameters API to Firebase Analytics Unity SDK.

This commit introduces the `FirebaseAnalytics.SetDefaultParameters()` method to the Unity SDK, wrapping the underlying C++ `firebase::analytics::SetDefaultEventParameters()` and `firebase::analytics::ClearDefaultEventParameters()` functions.

***
### Testing
> Describe how you've tested these changes.

Calls to the new API have been integrated into the existing TestApp (UIHandler.cs) for manual verification and TestAppAutomated (UIHandlerAutomated.cs) for automated execution. These tests will exercise the API surface but not programmatically verify results from the Unity side.

***

### Type of Change
Place an `x` the applicable box:
- [ ] Bug fix. Add the issue # below if applicable.
- [X] New feature. A non-breaking change which adds functionality.
- [ ] Other, such as a build process or documentation change.
***

