### PR TITLE
Fix macOS runner lightmap and metal issues

### DIFF
--- a/analytics/testapp/Assets/Firebase/Sample/Analytics/MainScene.unity
+++ b/analytics/testapp/Assets/Firebase/Sample/Analytics/MainScene.unity
@@ -50,8 +50,8 @@ LightmapSettings:
     m_AlbedoBoost: 1
     m_TemporalCoherenceThreshold: 1
     m_EnvironmentLightingMode: 0
-    m_EnableBakedLightmaps: 0
-    m_EnableRealtimeLightmaps: 0
+    m_EnableBakedLightmaps: 1
+    m_EnableRealtimeLightmaps: 1
   m_LightmapEditorSettings:
     serializedVersion: 4
     m_Resolution: 2

--- a/analytics/testapp/Assets/Firebase/Sample/Analytics/MainSceneAutomated.unity
+++ b/analytics/testapp/Assets/Firebase/Sample/Analytics/MainSceneAutomated.unity
@@ -42,7 +42,7 @@ RenderSettings:
 LightmapSettings:
   m_ObjectHideFlags: 0
   serializedVersion: 7
-  m_GIWorkflowMode: 0
+  m_GIWorkflowMode: 1
   m_GISettings:
     serializedVersion: 2
     m_BounceScale: 1

--- a/analytics/testapp/ProjectSettings/ProjectSettings.asset
+++ b/analytics/testapp/ProjectSettings/ProjectSettings.asset
@@ -229,7 +229,7 @@ PlayerSettings:
   macOSURLSchemes: []
   iOSBackgroundModes: 0
   iOSMetalForceHardShadows: 0
-  metalEditorSupport: 0
+  metalEditorSupport: 1
   metalAPIValidation: 1
   iOSRenderExtraFrameOnPause: 1
   iosCopyPluginsCodeInsteadOfSymlink: 0

--- a/auth/testapp/ProjectSettings/ProjectSettings.asset
+++ b/auth/testapp/ProjectSettings/ProjectSettings.asset
@@ -229,7 +229,7 @@ PlayerSettings:
   macOSURLSchemes: []
   iOSBackgroundModes: 0
   iOSMetalForceHardShadows: 0
-  metalEditorSupport: 0
+  metalEditorSupport: 1
   metalAPIValidation: 1
   iOSRenderExtraFrameOnPause: 1
   iosCopyPluginsCodeInsteadOfSymlink: 0

--- a/crashlytics/testapp/Assets/Firebase/Sample/Crashlytics/MainSceneAutomated.unity
+++ b/crashlytics/testapp/Assets/Firebase/Sample/Crashlytics/MainSceneAutomated.unity
@@ -42,7 +42,7 @@ RenderSettings:
 LightmapSettings:
   m_ObjectHideFlags: 0
   serializedVersion: 7
-  m_GIWorkflowMode: 0
+  m_GIWorkflowMode: 1
   m_GISettings:
     serializedVersion: 2
     m_BounceScale: 1

--- a/crashlytics/testapp/ProjectSettings/ProjectSettings.asset
+++ b/crashlytics/testapp/ProjectSettings/ProjectSettings.asset
@@ -229,7 +229,7 @@ PlayerSettings:
   macOSURLSchemes: []
   iOSBackgroundModes: 0
   iOSMetalForceHardShadows: 0
-  metalEditorSupport: 0
+  metalEditorSupport: 1
   metalAPIValidation: 1
   iOSRenderExtraFrameOnPause: 1
   iosCopyPluginsCodeInsteadOfSymlink: 0

--- a/database/testapp/ProjectSettings/ProjectSettings.asset
+++ b/database/testapp/ProjectSettings/ProjectSettings.asset
@@ -229,7 +229,7 @@ PlayerSettings:
   macOSURLSchemes: []
   iOSBackgroundModes: 0
   iOSMetalForceHardShadows: 0
-  metalEditorSupport: 0
+  metalEditorSupport: 1
   metalAPIValidation: 1
   iOSRenderExtraFrameOnPause: 1
   iosCopyPluginsCodeInsteadOfSymlink: 0

--- a/dynamic_links/testapp/ProjectSettings/ProjectSettings.asset
+++ b/dynamic_links/testapp/ProjectSettings/ProjectSettings.asset
@@ -229,7 +229,7 @@ PlayerSettings:
   macOSURLSchemes: []
   iOSBackgroundModes: 0
   iOSMetalForceHardShadows: 0
-  metalEditorSupport: 0
+  metalEditorSupport: 1
   metalAPIValidation: 1
   iOSRenderExtraFrameOnPause: 1
   iosCopyPluginsCodeInsteadOfSymlink: 0

--- a/functions/testapp/ProjectSettings/ProjectSettings.asset
+++ b/functions/testapp/ProjectSettings/ProjectSettings.asset
@@ -229,7 +229,7 @@ PlayerSettings:
   macOSURLSchemes: []
   iOSBackgroundModes: 0
   iOSMetalForceHardShadows: 0
-  metalEditorSupport: 0
+  metalEditorSupport: 1
   metalAPIValidation: 1
   iOSRenderExtraFrameOnPause: 1
   iosCopyPluginsCodeInsteadOfSymlink: 0

--- a/scripts/gha/integration_testing/MenuScene/Menu.unity
+++ b/scripts/gha/integration_testing/MenuScene/Menu.unity
@@ -43,7 +43,7 @@ RenderSettings:
 LightmapSettings:
   m_ObjectHideFlags: 0
   serializedVersion: 9
-  m_GIWorkflowMode: 0
+  m_GIWorkflowMode: 1
   m_GISettings:
     serializedVersion: 2
     m_BounceScale: 1


### PR DESCRIPTION
### Description
> Provide details of the change, and generalize the change in the PR title above.

After updating, the macOS GHA runners have been timing out when building the testapps, related to: https://issuetracker.unity3d.com/issues/unable-to-fall-back-to-cpu-lightmapper-dot-errors-in-the-console-when-opening-a-project-on-a-virtual-machine

Change the testapps to consistently not bake the lightmaps and support metal. Some of them already were.
***
### Testing
> Describe how you've tested these changes.

https://github.com/firebase/firebase-unity-sdk/actions/runs/15483427151
***

### Type of Change
Place an `x` the applicable box:
- [x] Bug fix. Add the issue # below if applicable.
- [ ] New feature. A non-breaking change which adds functionality.
- [ ] Other, such as a build process or documentation change.
***

