### PR TITLE
[FirebaseAI] Add support for Grounding with Google Search

### DIFF
--- a/firebaseai/src/Candidate.cs
+++ b/firebaseai/src/Candidate.cs
@@ -100,13 +100,20 @@ public readonly struct Candidate {
   /// </summary>
   public CitationMetadata? CitationMetadata { get; }
 
+  /// <summary>
+  /// Grounding metadata for the response, if any.
+  /// </summary>
+  public GroundingMetadata? GroundingMetadata { get; }
+
   // Hidden constructor, users don't need to make this.
   private Candidate(ModelContent content, List<SafetyRating> safetyRatings,
-      FinishReason? finishReason, CitationMetadata? citationMetadata) {
+      FinishReason? finishReason, CitationMetadata? citationMetadata,
+      GroundingMetadata? groundingMetadata) {
     Content = content;
     _safetyRatings = new ReadOnlyCollection<SafetyRating>(safetyRatings ?? new List<SafetyRating>());
     FinishReason = finishReason;
     CitationMetadata = citationMetadata;
+    GroundingMetadata = groundingMetadata;
   }
 
   private static FinishReason ParseFinishReason(string str) {
@@ -135,7 +142,9 @@ public readonly struct Candidate {
       jsonDict.ParseObjectList("safetyRatings", SafetyRating.FromJson),
       jsonDict.ParseNullableEnum("finishReason", ParseFinishReason),
       jsonDict.ParseNullableObject("citationMetadata",
-          (d) => Firebase.AI.CitationMetadata.FromJson(d, backend)));
+          (d) => Firebase.AI.CitationMetadata.FromJson(d, backend)),
+      jsonDict.ParseNullableObject("groundingMetadata",
+          Firebase.AI.GroundingMetadata.FromJson));
   }
 }
 

--- a/firebaseai/src/GenerateContentResponse.cs
+++ b/firebaseai/src/GenerateContentResponse.cs
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Linq;
@@ -179,6 +180,251 @@ public readonly struct PromptFeedback {
       jsonDict.ParseObjectList("safetyRatings", SafetyRating.FromJson));
   }
 }
+
+/// <summary>
+/// Metadata returned to the client when grounding is enabled.
+///
+/// > Important: If using Grounding with Google Search, you are required to comply with the
+/// "Grounding with Google Search" usage requirements for your chosen API provider:
+/// [Gemini Developer API](https://ai.google.dev/gemini-api/terms#grounding-with-google-search)
+/// or Vertex AI Gemini API (see [Service Terms](https://cloud.google.com/terms/service-terms)
+/// section within the Service Specific Terms).
+/// </summary>
+public readonly struct GroundingMetadata {
+  private readonly ReadOnlyCollection<string> _webSearchQueries;
+  private readonly ReadOnlyCollection<GroundingChunk> _groundingChunks;
+  private readonly ReadOnlyCollection<GroundingSupport> _groundingSupports;
+
+  /// <summary>
+  /// A list of web search queries that the model performed to gather the grounding information.
+  /// These can be used to allow users to explore the search results themselves.
+  /// </summary>
+  public IEnumerable<string> WebSearchQueries {
+    get {
+      return _webSearchQueries ?? new ReadOnlyCollection<string>(new List<string>());
+    }
+  }
+
+  /// <summary>
+  /// A list of `GroundingChunk` structs. Each chunk represents a piece of retrieved content
+  /// (e.g., from a web page) that the model used to ground its response.
+  /// </summary>
+  public IEnumerable<GroundingChunk> GroundingChunks {
+    get {
+      return _groundingChunks ?? new ReadOnlyCollection<GroundingChunk>(new List<GroundingChunk>());
+    }
+  }
+
+  /// <summary>
+  /// A list of `GroundingSupport` structs. Each object details how specific segments of the
+  /// model's response are supported by the `groundingChunks`.
+  /// </summary>
+  public IEnumerable<GroundingSupport> GroundingSupports {
+    get {
+      return _groundingSupports ?? new ReadOnlyCollection<GroundingSupport>(new List<GroundingSupport>());
+    }
+  }
+
+  /// <summary>
+  /// Google Search entry point for web searches.
+  /// This contains an HTML/CSS snippet that **must** be embedded in an app to display a Google
+  /// Search entry point for follow-up web searches related to the model's "Grounded Response".
+  /// </summary>
+  public SearchEntryPoint? SearchEntryPoint { get; }
+
+  private GroundingMetadata(List<string> webSearchQueries, List<GroundingChunk> groundingChunks,
+                            List<GroundingSupport> groundingSupports, SearchEntryPoint? searchEntryPoint) {
+    _webSearchQueries = new ReadOnlyCollection<string>(webSearchQueries ?? new List<string>());
+    _groundingChunks = new ReadOnlyCollection<GroundingChunk>(groundingChunks ?? new List<GroundingChunk>());
+    _groundingSupports = new ReadOnlyCollection<GroundingSupport>(groundingSupports ?? new List<GroundingSupport>());
+    SearchEntryPoint = searchEntryPoint;
+  }
+
+  internal static GroundingMetadata FromJson(Dictionary<string, object> jsonDict) {
+    List<GroundingSupport> supports = null;
+    if (jsonDict.TryParseValue("groundingSupports", out List<object> supportListRaw))
+    {
+      supports = supportListRaw
+          .OfType<Dictionary<string, object>>()
+          .Where(d => d.ContainsKey("segment")) // Filter out if segment is missing
+          .Select(GroundingSupport.FromJson)
+          .ToList();
+    }
+
+    return new GroundingMetadata(
+      jsonDict.ParseStringList("webSearchQueries"),
+      jsonDict.ParseObjectList("groundingChunks", GroundingChunk.FromJson),
+      supports,
+      jsonDict.ParseNullableObject("searchEntryPoint", Firebase.AI.SearchEntryPoint.FromJson)
+    );
+  }
+}
+
+/// <summary>
+/// A struct representing the Google Search entry point.
+/// </summary>
+public readonly struct SearchEntryPoint {
+  /// <summary>
+  /// An HTML/CSS snippet that can be embedded in your app.
+  ///
+  /// To ensure proper rendering, it's recommended to display this content within a web view component.
+  /// </summary>
+  public string RenderedContent { get; }
+
+  private SearchEntryPoint(string renderedContent) {
+    RenderedContent = renderedContent;
+  }
+
+  internal static SearchEntryPoint FromJson(Dictionary<string, object> jsonDict) {
+    return new SearchEntryPoint(
+      jsonDict.ParseValue<string>("renderedContent", JsonParseOptions.ThrowEverything)
+    );
+  }
+}
+
+/// <summary>
+/// Represents a chunk of retrieved data that supports a claim in the model's response. This is
+/// part of the grounding information provided when grounding is enabled.
+/// </summary>
+public readonly struct GroundingChunk {
+  /// <summary>
+  /// Contains details if the grounding chunk is from a web source.
+  /// </summary>
+  public WebGroundingChunk? Web { get; }
+
+  private GroundingChunk(WebGroundingChunk? web) {
+    Web = web;
+  }
+
+  internal static GroundingChunk FromJson(Dictionary<string, object> jsonDict) {
+    return new GroundingChunk(
+      jsonDict.ParseNullableObject("web", WebGroundingChunk.FromJson)
+    );
+  }
+}
+
+/// <summary>
+/// A grounding chunk sourced from the web.
+/// </summary>
+public readonly struct WebGroundingChunk {
+  /// <summary>
+  /// The URI of the retrieved web page.
+  /// </summary>
+  public string Uri { get; }
+  /// <summary>
+  /// The title of the retrieved web page.
+  /// </summary>
+  public string Title { get; }
+  /// <summary>
+  /// The domain of the original URI from which the content was retrieved.
+  ///
+  /// This field is only populated when using the Vertex AI Gemini API.
+  /// </summary>
+  public string Domain { get; }
+
+  private WebGroundingChunk(string uri, string title, string domain) {
+    Uri = uri;
+    Title = title;
+    Domain = domain;
+  }
+
+  internal static WebGroundingChunk FromJson(Dictionary<string, object> jsonDict) {
+    return new WebGroundingChunk(
+      jsonDict.ParseValue<string>("uri"),
+      jsonDict.ParseValue<string>("title"),
+      jsonDict.ParseValue<string>("domain")
+    );
+  }
+}
+
+/// <summary>
+/// Provides information about how a specific segment of the model's response is supported by the
+/// retrieved grounding chunks.
+/// </summary>
+public readonly struct GroundingSupport {
+  private readonly ReadOnlyCollection<int> _groundingChunkIndices;
+
+  /// <summary>
+  /// Specifies the segment of the model's response content that this grounding support pertains
+  /// to.
+  /// </summary>
+  public Segment Segment { get; }
+
+  /// <summary>
+  /// A list of indices that refer to specific `GroundingChunk` structs within the
+  /// `GroundingMetadata.GroundingChunks` array. These referenced chunks are the sources that
+  /// support the claim made in the associated `segment` of the response. For example, an array
+  /// `[1, 3, 4]`
+  /// means that `groundingChunks[1]`, `groundingChunks[3]`, `groundingChunks[4]` are the
+  /// retrieved content supporting this part of the response.
+  /// </summary>
+  public IEnumerable<int> GroundingChunkIndices {
+    get {
+      return _groundingChunkIndices ?? new ReadOnlyCollection<int>(new List<int>());
+    }
+  }
+
+  private GroundingSupport(Segment segment, List<int> groundingChunkIndices) {
+    Segment = segment;
+    _groundingChunkIndices = new ReadOnlyCollection<int>(groundingChunkIndices ?? new List<int>());
+  }
+
+  internal static GroundingSupport FromJson(Dictionary<string, object> jsonDict) {
+    List<int> indices = new List<int>();
+    if (jsonDict.TryParseValue("groundingChunkIndices", out List<object> indicesRaw)) {
+      indices = indicesRaw.OfType<long>().Select(l => (int)l).ToList();
+    }
+
+    return new GroundingSupport(
+      jsonDict.ParseObject("segment", Segment.FromJson, JsonParseOptions.ThrowEverything),
+      indices
+    );
+  }
+}
+
+/// <summary>
+/// Represents a specific segment within a `ModelContent` struct, often used to pinpoint the
+/// exact location of text or data that grounding information refers to.
+/// </summary>
+public readonly struct Segment {
+  /// <summary>
+  /// The zero-based index of the `Part` object within the `parts` array of its parent
+  /// `ModelContent` object. This identifies which part of the content the segment belongs to.
+  /// </summary>
+  public int PartIndex { get; }
+  /// <summary>
+  /// The zero-based start index of the segment within the specified `Part`, measured in UTF-8
+  /// bytes. This offset is inclusive, starting from 0 at the beginning of the part's content.
+  /// </summary>
+  public int StartIndex { get; }
+  /// <summary>
+  /// The zero-based end index of the segment within the specified `Part`, measured in UTF-8
+  /// bytes. This offset is exclusive, meaning the character at this index is not included in the
+  /// segment.
+  /// </summary>
+  public int EndIndex { get; }
+  /// <summary>
+  /// The text corresponding to the segment from the response.
+  /// </summary>
+  public string Text { get; }
+
+  private Segment(int partIndex, int startIndex, int endIndex, string text) {
+    PartIndex = partIndex;
+    StartIndex = startIndex;
+    EndIndex = endIndex;
+    Text = text;
+  }
+
+  internal static Segment FromJson(Dictionary<string, object> jsonDict) {
+    return new Segment(
+      jsonDict.ParseValue<int>("partIndex"),
+      jsonDict.ParseValue<int>("startIndex"),
+      jsonDict.ParseValue<int>("endIndex"),
+      jsonDict.ParseValue<string>("text")
+    );
+  }
+}
+
 
 /// <summary>
 /// Token usage metadata for processing the generate content request.

--- a/firebaseai/testapp/Assets/Firebase/Sample/FirebaseAI/UIHandlerAutomated.cs
+++ b/firebaseai/testapp/Assets/Firebase/Sample/FirebaseAI/UIHandlerAutomated.cs
@@ -63,6 +63,7 @@ namespace Firebase.Sample.FirebaseAI {
         TestFunctionCallingNone,
         TestEnumSchemaResponse,
         TestAnyOfSchemaResponse,
+        TestSearchGrounding,
         TestChatBasicTextNoHistory,
         TestChatBasicTextPriorHistory,
         TestChatFunctionCalling,
@@ -82,6 +83,11 @@ namespace Firebase.Sample.FirebaseAI {
         InternalTestFinishReasonSafetyNoContent,
         InternalTestUnknownEnumSafetyRatings,
         InternalTestFunctionCallWithArguments,
+        InternalTestVertexAIGrounding,
+        InternalTestGoogleAIGrounding,
+        InternalTestGoogleAIGroundingEmptyChunks,
+        InternalTestGroundingMetadata_Empty,
+        InternalTestSegment_Empty,
         InternalTestCountTokenResponse,
         InternalTestBasicResponseLongUsageMetadata,
         InternalTestGoogleAIBasicReplyShort,
@@ -443,7 +449,7 @@ namespace Firebase.Sample.FirebaseAI {
         generationConfig: new GenerationConfig(
           responseMimeType: "text/x.enum",
           responseSchema: Schema.Enum(new string[] { enumValue })));
-
+      
       var response = await model.GenerateContentAsync(
         "Hello, I am testing setting the response schema to an enum.");
 
@@ -465,6 +471,43 @@ namespace Firebase.Sample.FirebaseAI {
 
       // There isn't much guarantee on what this will respond with. We just want non-empty.
       Assert("Response was empty.", !string.IsNullOrWhiteSpace(response.Text));
+    }
+
+    // Test grounding with Google Search.
+    async Task TestSearchGrounding(Backend backend) {
+      // Use a model that supports grounding.
+      var model = GetFirebaseAI(backend).GetGenerativeModel(TestModelName,
+        tools: new Tool[] { new Tool(new GoogleSearch()) }
+      );
+
+      // A prompt that requires recent information.
+      GenerateContentResponse response = await model.GenerateContentAsync("What's the current weather in Toronto?");
+
+      Assert("Response missing candidates.", response.Candidates.Any());
+
+      string result = response.Text;
+      Assert("Response text was missing", !string.IsNullOrWhiteSpace(result));
+
+      var candidate = response.Candidates.First();
+      Assert("GroundingMetadata should not be null when GoogleSearch tool is used.",
+          candidate.GroundingMetadata.HasValue);
+
+      var groundingMetadata = candidate.GroundingMetadata.Value;
+
+      Assert("WebSearchQueries should not be empty.",
+          groundingMetadata.WebSearchQueries.Any());
+
+      Assert("GroundingChunks should not be empty.",
+          groundingMetadata.GroundingChunks.Any());
+
+      Assert("GroundingSupports should not be empty.",
+          groundingMetadata.GroundingSupports.Any());
+
+      Assert("SearchEntryPoint should not be null.",
+          groundingMetadata.SearchEntryPoint.HasValue);
+
+      Assert("SearchEntryPoint.RenderedContent should not be empty.",
+          !string.IsNullOrWhiteSpace(groundingMetadata.SearchEntryPoint?.RenderedContent));
     }
 
     // Test if when using Chat the model will get the previous messages.
@@ -732,7 +775,7 @@ namespace Firebase.Sample.FirebaseAI {
 
     // The url prefix to use when fetching test data to use from the separate GitHub repo.
     readonly string testDataUrl =
-        "https://raw.githubusercontent.com/FirebaseExtended/vertexai-sdk-test-data/47becf9101d11ea3c568bf60b12f1c8ed9fb684e/mock-responses/";
+        "https://raw.githubusercontent.com/FirebaseExtended/vertexai-sdk-test-data/548c2d5ae4555ca6f57d8621903e2b591bec7b05/mock-responses/";
     readonly HttpClient httpClient = new();
 
     private Task<string> LoadStreamingAsset(string fullPath) {
@@ -1026,6 +1069,113 @@ namespace Firebase.Sample.FirebaseAI {
       AssertEq("FunctionCall args[x] wrong value", fcPart.Args["x"], 4L);
     }
 
+    // Test that parsing a Vertex AI response with GroundingMetadata works.
+    // https://github.com/FirebaseExtended/vertexai-sdk-test-data/blob/main/mock-responses/vertexai/unary-success-google-search-grounding.json
+    async Task InternalTestVertexAIGrounding() {
+      Dictionary<string, object> json = await GetVertexJsonTestData("unary-success-google-search-grounding.json");
+
+      GenerateContentResponse response = GenerateContentResponse.FromJson(json, FirebaseAI.Backend.InternalProvider.VertexAI);
+
+      Assert("Response missing candidates.", response.Candidates.Any());
+      var candidate = response.Candidates.First();
+      Assert("Candidate should have GroundingMetadata", candidate.GroundingMetadata.HasValue);
+
+      var grounding = candidate.GroundingMetadata.Value;
+
+      Assert("WebSearchQueries should not be null", grounding.WebSearchQueries != null);
+      Assert("SearchEntryPoint should not be null", grounding.SearchEntryPoint.HasValue);
+      Assert("GroundingChunks should not be null", grounding.GroundingChunks != null);
+      var chunk = grounding.GroundingChunks.First();
+      Assert("GroundingChunk.Web should not be null", chunk.Web.HasValue);
+      Assert("GroundingSupports should not be null", grounding.GroundingSupports != null);
+      var support = grounding.GroundingSupports.First();
+      Assert("GroundingChunkIndices should not be null", support.GroundingChunkIndices != null);
+    }
+
+    // Test that parsing a Google AI response with GroundingMetadata works.
+    // https://github.com/FirebaseExtended/vertexai-sdk-test-data/blob/main/mock-responses/googleai/unary-success-google-search-grounding.json
+    async Task InternalTestGoogleAIGrounding() {
+      Dictionary<string, object> json = await GetGoogleAIJsonTestData("unary-success-google-search-grounding.json");
+      GenerateContentResponse response = GenerateContentResponse.FromJson(json, FirebaseAI.Backend.InternalProvider.GoogleAI);
+
+      Assert("Response missing candidates.", response.Candidates.Any());
+      var candidate = response.Candidates.First();
+      Assert("Candidate should have GroundingMetadata", candidate.GroundingMetadata.HasValue);
+
+      var grounding = candidate.GroundingMetadata.Value;
+
+      AssertEq("WebSearchQueries count", grounding.WebSearchQueries.Count(), 1);
+      AssertEq("WebSearchQueries content", grounding.WebSearchQueries.First(),
+          "current weather in London");
+
+      Assert("SearchEntryPoint should not be null", grounding.SearchEntryPoint.HasValue);
+      Assert("SearchEntryPoint content should not be empty", !string.IsNullOrEmpty(grounding.SearchEntryPoint.Value.RenderedContent));
+
+      AssertEq("GroundingChunks count", grounding.GroundingChunks.Count(), 2);
+      var firstChunk = grounding.GroundingChunks.First();
+      Assert("GroundingChunk.Web should not be null", firstChunk.Web.HasValue);
+      var webChunk = firstChunk.Web.Value;
+      AssertEq("WebGroundingChunk.Title", webChunk.Title, "accuweather.com");
+      Assert("WebGroundingChunk.Uri should not be null", webChunk.Uri != null);
+      Assert("WebGroundingChunk.Domain should be null or empty", string.IsNullOrEmpty(webChunk.Domain));
+
+      AssertEq("GroundingSupports count", grounding.GroundingSupports.Count(), 3);
+      var firstSupport = grounding.GroundingSupports.First();
+      var segment = firstSupport.Segment;
+      AssertEq("Segment.Text", segment.Text, "The current weather in London, United Kingdom is cloudy.");
+      AssertEq("Segment.StartIndex", segment.StartIndex, 0);
+      AssertEq("Segment.PartIndex", segment.PartIndex, 0);
+      AssertEq("Segment.EndIndex", segment.EndIndex, 56);
+      AssertEq("GroundingChunkIndices count", firstSupport.GroundingChunkIndices.Count(), 1);
+      AssertEq("GroundingChunkIndices content", firstSupport.GroundingChunkIndices.First(), 0);
+    }
+
+    // Test that parsing a Google AI response with empty GroundingChunks works.
+    // https://github.com/FirebaseExtended/vertexai-sdk-test-data/blob/main/mock-responses/googleai/unary-success-google-search-grounding-empty-grounding-chunks.json
+    async Task InternalTestGoogleAIGroundingEmptyChunks() {
+      Dictionary<string, object> json = await GetGoogleAIJsonTestData("unary-success-google-search-grounding-empty-grounding-chunks.json");
+      GenerateContentResponse response = GenerateContentResponse.FromJson(json, FirebaseAI.Backend.InternalProvider.GoogleAI);
+
+      Assert("Response missing candidates.", response.Candidates.Any());
+      var candidate = response.Candidates.First();
+      Assert("Candidate should have GroundingMetadata", candidate.GroundingMetadata.HasValue);
+
+      var grounding = candidate.GroundingMetadata.Value;
+      AssertEq("WebSearchQueries count", grounding.WebSearchQueries.Count(), 1);
+      AssertEq("GroundingChunks count", grounding.GroundingChunks.Count(), 2);
+      Assert("First GroundingChunk.Web should be null", !grounding.GroundingChunks.ElementAt(0).Web.HasValue);
+      Assert("Second GroundingChunk.Web should be null", !grounding.GroundingChunks.ElementAt(1).Web.HasValue);
+
+      AssertEq("GroundingSupports count", grounding.GroundingSupports.Count(), 1);
+      var support = grounding.GroundingSupports.First();
+      AssertEq(
+          "Segment.Text",
+          support.Segment.Text,
+          "There is a 0% chance of rain and the humidity is around 41%.");
+    }
+
+    // Test parsing an empty GroundingMetadata object.
+    async Task InternalTestGroundingMetadata_Empty() {
+      var json = new Dictionary<string, object>();
+      var grounding = GroundingMetadata.FromJson(json);
+
+      Assert("WebSearchQueries should be empty", !grounding.WebSearchQueries.Any());
+      Assert("GroundingChunks should be empty", !grounding.GroundingChunks.Any());
+      Assert("GroundingSupports should be empty", !grounding.GroundingSupports.Any());
+      Assert("SearchEntryPoint should be null", !grounding.SearchEntryPoint.HasValue);
+    }
+    
+    // Test parsing an empty Segment object.
+    async Task InternalTestSegment_Empty() {
+      var json = new Dictionary<string, object>();
+      var segment = Segment.FromJson(json);
+
+      AssertEq("PartIndex should default to 0", segment.PartIndex, 0);
+      AssertEq("StartIndex should default to 0", segment.StartIndex, 0);
+      AssertEq("EndIndex should default to 0", segment.EndIndex, 0);
+      Assert("Text should be empty", string.IsNullOrEmpty(segment.Text));
+    }
+
     // Test that parsing a count token response works.
     async Task InternalTestCountTokenResponse() {
       Dictionary<string, object> json = await GetVertexJsonTestData("unary-success-detailed-token-response.json");
@@ -1101,7 +1251,7 @@ namespace Firebase.Sample.FirebaseAI {
 
       // Validate Text Part (check start and end)
       string expectedStart = "Okay, let's break down quantum mechanics.";
-      string expectedEnd = "area of physics!";
+      string expectedEnd = "It's a challenging but fascinating area of physics!";
       Assert("Candidate count", response.Candidates.Count() == 1);
       Candidate candidate = response.Candidates.First();
       AssertEq("Content role", candidate.Content.Role, "model");


### PR DESCRIPTION
### Description

Adds support for Grounding with Google Search. This includes adding a new `GoogleSearch` tool to include in the generation config, and the `GroundingMetadata` which is populated for grounded results.

Stray changes:
 - updated the commit we pull the mock responses from to get the latest grounding mock responses. I had to make a stray change to a citations test to fix a failure caused by a change in a mock response
 - Renamed `Functions` in `Tool` to `FunctionsDeclarations`- I think it's more clear.

API proposal: [go/fal-grounding-api](https://goto.google.com/fal-grounding-api) (internal)

### Testing

Added new tests in the sample app, including an integration test and unit tests against the mock responses.

### Type of Change
- [ ] Bug fix. Add the issue # below if applicable.
- [x] New feature. A non-breaking change which adds functionality.
- [ ] Other, such as a build process or documentation change.
***

