### PR TITLE
[Firebase AI] Add support for Thinking budget

### DIFF
--- a/docs/readme.md
+++ b/docs/readme.md
@@ -117,6 +117,7 @@ Release Notes
     - Auth: Removed deprecated `FirebaseUser.UpdateEmailAsync`.
     - Firebase AI: Add support for image generation via Imagen. For more info, see
       https://firebase.google.com/docs/ai-logic/generate-images-imagen
+    - Firebase AI: Add support for Grounding with Google Search, and Thinking budget.
     - Firebase AI: Deprecated `CountTokensResponse.TotalBillableCharacters`, use
       `CountTokensResponse.TotalTokens` instead.
     - Messaging: Removed deprecated `FirebaseMessage.Dispose`,

--- a/docs/readme.md
+++ b/docs/readme.md
@@ -117,7 +117,8 @@ Release Notes
     - Auth: Removed deprecated `FirebaseUser.UpdateEmailAsync`.
     - Firebase AI: Add support for image generation via Imagen. For more info, see
       https://firebase.google.com/docs/ai-logic/generate-images-imagen
-    - Firebase AI: Add support for Grounding with Google Search, and Thinking budget.
+    - Firebase AI: Add support for Grounding with Google Search.
+    - Firebase AI: Add support for defining a Thinking budget.
     - Firebase AI: Deprecated `CountTokensResponse.TotalBillableCharacters`, use
       `CountTokensResponse.TotalTokens` instead.
     - Messaging: Removed deprecated `FirebaseMessage.Dispose`,

--- a/firebaseai/src/GenerateContentResponse.cs
+++ b/firebaseai/src/GenerateContentResponse.cs
@@ -193,6 +193,17 @@ public readonly struct UsageMetadata {
   /// </summary>
   public int CandidatesTokenCount { get; }
   /// <summary>
+  /// The number of tokens used by the model's internal "thinking" process.
+  ///
+  /// For models that support thinking (like Gemini 2.5 Pro and Flash), this represents the actual
+  /// number of tokens consumed for reasoning before the model generated a response. For models
+  /// that do not support thinking, this value will be `0`.
+  ///
+  /// When thinking is used, this count will be less than or equal to the `thinkingBudget` set in
+  /// the `ThinkingConfig`.
+  /// </summary>
+  public int ThoughtsTokenCount { get; }
+  /// <summary>
   /// The total number of tokens in both the request and response.
   /// </summary>
   public int TotalTokenCount { get; }
@@ -212,10 +223,11 @@ public readonly struct UsageMetadata {
   }
 
   // Hidden constructor, users don't need to make this.
-  private UsageMetadata(int promptTC, int candidatesTC, int totalTC,
+  private UsageMetadata(int promptTC, int candidatesTC, int thoughtsTC, int totalTC,
                         List<ModalityTokenCount> promptDetails, List<ModalityTokenCount> candidateDetails) {
     PromptTokenCount = promptTC;
     CandidatesTokenCount = candidatesTC;
+    ThoughtsTokenCount = thoughtsTC;
     TotalTokenCount = totalTC;
     _promptTokensDetails =
         new ReadOnlyCollection<ModalityTokenCount>(promptDetails ?? new List<ModalityTokenCount>());
@@ -232,6 +244,7 @@ public readonly struct UsageMetadata {
     return new UsageMetadata(
       jsonDict.ParseValue<int>("promptTokenCount"),
       jsonDict.ParseValue<int>("candidatesTokenCount"),
+      jsonDict.ParseValue<int>("thoughtsTokenCount"),
       jsonDict.ParseValue<int>("totalTokenCount"),
       jsonDict.ParseObjectList("promptTokensDetails", ModalityTokenCount.FromJson),
       jsonDict.ParseObjectList("candidatesTokensDetails", ModalityTokenCount.FromJson));

--- a/firebaseai/src/GenerationConfig.cs
+++ b/firebaseai/src/GenerationConfig.cs
@@ -21,173 +21,223 @@ using Firebase.AI.Internal;
 
 namespace Firebase.AI {
 
-/// <summary>
-/// A struct defining model parameters to be used when sending generative AI
-/// requests to the backend model.
-/// </summary>
-public readonly struct GenerationConfig {
-  private readonly float? _temperature;
-  private readonly float? _topP;
-  private readonly float? _topK;
-  private readonly int? _candidateCount;
-  private readonly int? _maxOutputTokens;
-  private readonly float? _presencePenalty;
-  private readonly float? _frequencyPenalty;
-  private readonly string[] _stopSequences;
-  private readonly string _responseMimeType;
-  private readonly Schema _responseSchema;
-  private readonly List<ResponseModality> _responseModalities;
-
   /// <summary>
-  /// Creates a new `GenerationConfig` value.
-  ///
-  /// See the
-  /// [Configure model parameters](https://firebase.google.com/docs/vertex-ai/model-parameters)
-  /// guide and the
-  /// [Cloud documentation](https://cloud.google.com/vertex-ai/generative-ai/docs/model-reference/inference#generationconfig)
-  /// for more details.
+  /// A struct defining model parameters to be used when sending generative AI
+  /// requests to the backend model.
   /// </summary>
-  /// 
-  /// <param name="temperature">Controls the randomness of the language model's output. Higher values (for
-  /// example, 1.0) make the text more random and creative, while lower values (for example,
-  /// 0.1) make it more focused and deterministic.
-  ///
-  /// > Note: A temperature of 0 means that the highest probability tokens are always selected.
-  /// > In this case, responses for a given prompt are mostly deterministic, but a small amount
-  /// > of variation is still possible.
-  ///
-  /// > Important: The range of supported temperature values depends on the model; see the
-  /// > [Cloud documentation](https://cloud.google.com/vertex-ai/generative-ai/docs/model-reference/inference#generationconfig)
-  /// > for more details.</param>
-  /// 
-  /// <param name="topP">Controls diversity of generated text. Higher values (e.g., 0.9) produce more diverse
-  /// text, while lower values (e.g., 0.5) make the output more focused.
-  ///
-  /// The supported range is 0.0 to 1.0.
-  ///
-  /// > Important: The default `topP` value depends on the model; see the
-  /// [Cloud documentation](https://cloud.google.com/vertex-ai/generative-ai/docs/model-reference/inference#generationconfig)
-  /// for more details.</param>
-  /// 
-  /// <param name="topK">Limits the number of highest probability words the model considers when generating
-  /// text. For example, a topK of 40 means only the 40 most likely words are considered for the
-  /// next token. A higher value increases diversity, while a lower value makes the output more
-  /// deterministic.
-  ///
-  /// The supported range is 1 to 40.
-  ///
-  /// > Important: Support for `topK` and the default value depends on the model; see the
-  /// [Cloud documentation](https://cloud.google.com/vertex-ai/generative-ai/docs/model-reference/inference#generationconfig)
-  /// for more details.</param>
-  /// 
-  /// <param name="candidateCount">The number of response variations to return; defaults to 1 if not set.
-  /// Support for multiple candidates depends on the model; see the
-  /// [Cloud documentation](https://cloud.google.com/vertex-ai/generative-ai/docs/model-reference/inference#generationconfig)
-  /// for more details.</param>
-  /// 
-  /// <param name="maxOutputTokens">Maximum number of tokens that can be generated in the response.
-  /// See the configure model parameters [documentation](https://firebase.google.com/docs/vertex-ai/model-parameters?platform=ios#max-output-tokens)
-  /// for more details.</param>
-  /// 
-  /// <param name="presencePenalty">Controls the likelihood of repeating the same words or phrases already
-  /// generated in the text. Higher values increase the penalty of repetition, resulting in more
-  /// diverse output.
-  ///
-  /// > Note: While both `presencePenalty` and `frequencyPenalty` discourage repetition,
-  /// > `presencePenalty` applies the same penalty regardless of how many times the word/phrase
-  /// > has already appeared, whereas `frequencyPenalty` increases the penalty for *each*
-  /// > repetition of a word/phrase.
-  ///
-  /// > Important: The range of supported `presencePenalty` values depends on the model; see the
-  /// > [Cloud documentation](https://cloud.google.com/vertex-ai/generative-ai/docs/model-reference/inference#generationconfig)
-  /// > for more details.</param>
-  /// 
-  /// <param name="frequencyPenalty">Controls the likelihood of repeating words or phrases, with the penalty
-  /// increasing for each repetition. Higher values increase the penalty of repetition,
-  /// resulting in more diverse output.
-  ///
-  /// > Note: While both `frequencyPenalty` and `presencePenalty` discourage repetition,
-  /// > `frequencyPenalty` increases the penalty for *each* repetition of a word/phrase, whereas
-  /// > `presencePenalty` applies the same penalty regardless of how many times the word/phrase
-  /// > has already appeared.
-  ///
-  /// > Important: The range of supported `frequencyPenalty` values depends on the model; see
-  /// > the
-  /// > [Cloud documentation](https://cloud.google.com/vertex-ai/generative-ai/docs/model-reference/inference#generationconfig)
-  /// > for more details.</param>
-  /// 
-  /// <param name="stopSequences">A set of up to 5 `String`s that will stop output generation. If specified,
-  /// the API will stop at the first appearance of a stop sequence. The stop sequence will not
-  /// be included as part of the response. See the
-  /// [Cloud documentation](https://cloud.google.com/vertex-ai/generative-ai/docs/model-reference/inference#generationconfig)
-  /// for more details.</param>
-  /// 
-  /// <param name="responseMimeType">Output response MIME type of the generated candidate text.
-  ///
-  /// Supported MIME types:
-  /// - `text/plain`: Text output; the default behavior if unspecified.
-  /// - `application/json`: JSON response in the candidates.
-  /// - `text/x.enum`: For classification tasks, output an enum value as defined in the
-  /// `responseSchema`.</param>
-  /// 
-  /// <param name="responseSchema">Output schema of the generated candidate text. If set, a compatible
-  /// `responseMimeType` must also be set.
-  ///
-  /// Compatible MIME types:
-  /// - `application/json`: Schema for JSON response.
-  ///
-  /// Refer to the
-  /// [Control generated output](https://cloud.google.com/vertex-ai/generative-ai/docs/multimodal/control-generated-output)
-  /// guide for more details.</param>
-  public GenerationConfig(
-      float? temperature = null,
-      float? topP = null,
-      float? topK = null,
-      int? candidateCount = null,
-      int? maxOutputTokens = null,
-      float? presencePenalty = null,
-      float? frequencyPenalty = null,
-      string[] stopSequences = null,
-      string responseMimeType = null,
-      Schema responseSchema = null,
-      IEnumerable<ResponseModality> responseModalities = null) {
-    _temperature = temperature;
-    _topP = topP;
-    _topK = topK;
-    _candidateCount = candidateCount;
-    _maxOutputTokens = maxOutputTokens;
-    _presencePenalty = presencePenalty;
-    _frequencyPenalty = frequencyPenalty;
-    _stopSequences = stopSequences;
-    _responseMimeType = responseMimeType;
-    _responseSchema = responseSchema;
-    _responseModalities = responseModalities != null ?
-        new List<ResponseModality>(responseModalities) : null;
-  }
+  public readonly struct GenerationConfig {
+    private readonly float? _temperature;
+    private readonly float? _topP;
+    private readonly float? _topK;
+    private readonly int? _candidateCount;
+    private readonly int? _maxOutputTokens;
+    private readonly float? _presencePenalty;
+    private readonly float? _frequencyPenalty;
+    private readonly string[] _stopSequences;
+    private readonly string _responseMimeType;
+    private readonly Schema _responseSchema;
+    private readonly List<ResponseModality> _responseModalities;
+    private readonly ThinkingConfig? _thinkingConfig;
 
-  /// <summary>
-  /// Intended for internal use only.
-  /// This method is used for serializing the object to JSON for the API request.
-  /// </summary>
-  internal Dictionary<string, object> ToJson() {
-    Dictionary<string, object> jsonDict = new();
-    if (_temperature.HasValue) jsonDict["temperature"] = _temperature.Value;
-    if (_topP.HasValue) jsonDict["topP"] = _topP.Value;
-    if (_topK.HasValue) jsonDict["topK"] = _topK.Value;
-    if (_candidateCount.HasValue) jsonDict["candidateCount"] = _candidateCount.Value;
-    if (_maxOutputTokens.HasValue) jsonDict["maxOutputTokens"] = _maxOutputTokens.Value;
-    if (_presencePenalty.HasValue) jsonDict["presencePenalty"] = _presencePenalty.Value;
-    if (_frequencyPenalty.HasValue) jsonDict["frequencyPenalty"] = _frequencyPenalty.Value;
-    if (_stopSequences != null && _stopSequences.Length > 0) jsonDict["stopSequences"] = _stopSequences;
-    if (!string.IsNullOrWhiteSpace(_responseMimeType)) jsonDict["responseMimeType"] = _responseMimeType;
-    if (_responseSchema != null) jsonDict["responseSchema"] = _responseSchema.ToJson();
-    if (_responseModalities != null && _responseModalities.Count > 0) {
-      jsonDict["responseModalities"] =
-          _responseModalities.Select(EnumConverters.ResponseModalityToString).ToList();
+    /// <summary>
+    /// Creates a new `GenerationConfig` value.
+    ///
+    /// See the
+    /// [Configure model parameters](https://firebase.google.com/docs/vertex-ai/model-parameters)
+    /// guide and the
+    /// [Cloud documentation](https://cloud.google.com/vertex-ai/generative-ai/docs/model-reference/inference#generationconfig)
+    /// for more details.
+    /// </summary>
+    /// 
+    /// <param name="temperature">Controls the randomness of the language model's output. Higher values (for
+    /// example, 1.0) make the text more random and creative, while lower values (for example,
+    /// 0.1) make it more focused and deterministic.
+    ///
+    /// > Note: A temperature of 0 means that the highest probability tokens are always selected.
+    /// > In this case, responses for a given prompt are mostly deterministic, but a small amount
+    /// > of variation is still possible.
+    ///
+    /// > Important: The range of supported temperature values depends on the model; see the
+    /// > [Cloud documentation](https://cloud.google.com/vertex-ai/generative-ai/docs/model-reference/inference#generationconfig)
+    /// > for more details.</param>
+    /// 
+    /// <param name="topP">Controls diversity of generated text. Higher values (e.g., 0.9) produce more diverse
+    /// text, while lower values (e.g., 0.5) make the output more focused.
+    ///
+    /// The supported range is 0.0 to 1.0.
+    ///
+    /// > Important: The default `topP` value depends on the model; see the
+    /// [Cloud documentation](https://cloud.google.com/vertex-ai/generative-ai/docs/model-reference/inference#generationconfig)
+    /// for more details.</param>
+    /// 
+    /// <param name="topK">Limits the number of highest probability words the model considers when generating
+    /// text. For example, a topK of 40 means only the 40 most likely words are considered for the
+    /// next token. A higher value increases diversity, while a lower value makes the output more
+    /// deterministic.
+    ///
+    /// The supported range is 1 to 40.
+    ///
+    /// > Important: Support for `topK` and the default value depends on the model; see the
+    /// [Cloud documentation](https://cloud.google.com/vertex-ai/generative-ai/docs/model-reference/inference#generationconfig)
+    /// for more details.</param>
+    /// 
+    /// <param name="candidateCount">The number of response variations to return; defaults to 1 if not set.
+    /// Support for multiple candidates depends on the model; see the
+    /// [Cloud documentation](https://cloud.google.com/vertex-ai/generative-ai/docs/model-reference/inference#generationconfig)
+    /// for more details.</param>
+    /// 
+    /// <param name="maxOutputTokens">Maximum number of tokens that can be generated in the response.
+    /// See the configure model parameters [documentation](https://firebase.google.com/docs/vertex-ai/model-parameters?platform=ios#max-output-tokens)
+    /// for more details.</param>
+    /// 
+    /// <param name="presencePenalty">Controls the likelihood of repeating the same words or phrases already
+    /// generated in the text. Higher values increase the penalty of repetition, resulting in more
+    /// diverse output.
+    ///
+    /// > Note: While both `presencePenalty` and `frequencyPenalty` discourage repetition,
+    /// > `presencePenalty` applies the same penalty regardless of how many times the word/phrase
+    /// > has already appeared, whereas `frequencyPenalty` increases the penalty for *each*
+    /// > repetition of a word/phrase.
+    ///
+    /// > Important: The range of supported `presencePenalty` values depends on the model; see the
+    /// > [Cloud documentation](https://cloud.google.com/vertex-ai/generative-ai/docs/model-reference/inference#generationconfig)
+    /// > for more details.</param>
+    /// 
+    /// <param name="frequencyPenalty">Controls the likelihood of repeating words or phrases, with the penalty
+    /// increasing for each repetition. Higher values increase the penalty of repetition,
+    /// resulting in more diverse output.
+    ///
+    /// > Note: While both `frequencyPenalty` and `presencePenalty` discourage repetition,
+    /// > `frequencyPenalty` increases the penalty for *each* repetition of a word/phrase, whereas
+    /// > `presencePenalty` applies the same penalty regardless of how many times the word/phrase
+    /// > has already appeared.
+    ///
+    /// > Important: The range of supported `frequencyPenalty` values depends on the model; see
+    /// > the
+    /// > [Cloud documentation](https://cloud.google.com/vertex-ai/generative-ai/docs/model-reference/inference#generationconfig)
+    /// > for more details.</param>
+    /// 
+    /// <param name="stopSequences">A set of up to 5 `String`s that will stop output generation. If specified,
+    /// the API will stop at the first appearance of a stop sequence. The stop sequence will not
+    /// be included as part of the response. See the
+    /// [Cloud documentation](https://cloud.google.com/vertex-ai/generative-ai/docs/model-reference/inference#generationconfig)
+    /// for more details.</param>
+    /// 
+    /// <param name="responseMimeType">Output response MIME type of the generated candidate text.
+    ///
+    /// Supported MIME types:
+    /// - `text/plain`: Text output; the default behavior if unspecified.
+    /// - `application/json`: JSON response in the candidates.
+    /// - `text/x.enum`: For classification tasks, output an enum value as defined in the
+    /// `responseSchema`.</param>
+    /// 
+    /// <param name="responseSchema">Output schema of the generated candidate text. If set, a compatible
+    /// `responseMimeType` must also be set.
+    ///
+    /// Compatible MIME types:
+    /// - `application/json`: Schema for JSON response.
+    ///
+    /// Refer to the
+    /// [Control generated output](https://cloud.google.com/vertex-ai/generative-ai/docs/multimodal/control-generated-output)
+    /// guide for more details.</param>
+    /// 
+    /// <param name="responseModalities">
+    /// The data types (modalities) that may be returned in model responses.
+    ///
+    /// See the [multimodal
+    /// responses](https://cloud.google.com/vertex-ai/generative-ai/docs/multimodal-response-generation)
+    /// documentation for more details.
+    /// </param>
+    /// 
+    /// <param name="thinkingConfig">
+    /// Configuration for controlling the "thinking" behavior of compatible Gemini
+    /// models; see `ThinkingConfig` for more details.
+    ///
+    /// An error will be returned if this field is set for models that don't
+    /// support thinking.
+    /// </param>
+    public GenerationConfig(
+        float? temperature = null,
+        float? topP = null,
+        float? topK = null,
+        int? candidateCount = null,
+        int? maxOutputTokens = null,
+        float? presencePenalty = null,
+        float? frequencyPenalty = null,
+        string[] stopSequences = null,
+        string responseMimeType = null,
+        Schema responseSchema = null,
+        IEnumerable<ResponseModality> responseModalities = null,
+        ThinkingConfig? thinkingConfig = null) {
+      _temperature = temperature;
+      _topP = topP;
+      _topK = topK;
+      _candidateCount = candidateCount;
+      _maxOutputTokens = maxOutputTokens;
+      _presencePenalty = presencePenalty;
+      _frequencyPenalty = frequencyPenalty;
+      _stopSequences = stopSequences;
+      _responseMimeType = responseMimeType;
+      _responseSchema = responseSchema;
+      _responseModalities = responseModalities != null ?
+          new List<ResponseModality>(responseModalities) : null;
+      _thinkingConfig = thinkingConfig;
     }
 
-    return jsonDict;
+    /// <summary>
+    /// Intended for internal use only.
+    /// This method is used for serializing the object to JSON for the API request.
+    /// </summary>
+    internal Dictionary<string, object> ToJson() {
+      Dictionary<string, object> jsonDict = new();
+      if (_temperature.HasValue) jsonDict["temperature"] = _temperature.Value;
+      if (_topP.HasValue) jsonDict["topP"] = _topP.Value;
+      if (_topK.HasValue) jsonDict["topK"] = _topK.Value;
+      if (_candidateCount.HasValue) jsonDict["candidateCount"] = _candidateCount.Value;
+      if (_maxOutputTokens.HasValue) jsonDict["maxOutputTokens"] = _maxOutputTokens.Value;
+      if (_presencePenalty.HasValue) jsonDict["presencePenalty"] = _presencePenalty.Value;
+      if (_frequencyPenalty.HasValue) jsonDict["frequencyPenalty"] = _frequencyPenalty.Value;
+      if (_stopSequences != null && _stopSequences.Length > 0) jsonDict["stopSequences"] = _stopSequences;
+      if (!string.IsNullOrWhiteSpace(_responseMimeType)) jsonDict["responseMimeType"] = _responseMimeType;
+      if (_responseSchema != null) jsonDict["responseSchema"] = _responseSchema.ToJson();
+      if (_responseModalities != null && _responseModalities.Count > 0) {
+        jsonDict["responseModalities"] =
+            _responseModalities.Select(EnumConverters.ResponseModalityToString).ToList();
+      }
+      if (_thinkingConfig != null) jsonDict["thinkingConfig"] = _thinkingConfig?.ToJson();
+
+      return jsonDict;
+    }
   }
-}
+
+  /// <summary>
+  /// Configuration options for Thinking features.
+  /// </summary>
+  public readonly struct ThinkingConfig {
+#if !DOXYGEN
+    public readonly int? ThinkingBudget { get; }
+#endif
+
+    /// <summary>
+    /// Initializates configuration options for Thinking features.
+    /// </summary>
+    /// <param name="thinkingBudget">Number of tokens present in thoughts output.</param>
+    public ThinkingConfig(int? thinkingBudget = null) {
+      ThinkingBudget = thinkingBudget;
+    }
+
+    /// <summary>
+    /// Intended for internal use only.
+    /// This method is used for serializing the object to JSON for the API request.
+    /// </summary>
+    internal Dictionary<string, object> ToJson() {
+      Dictionary<string, object> jsonDict = new();
+      if (ThinkingBudget.HasValue) {
+        jsonDict["thinkingBudget"] = ThinkingBudget.Value;
+      }
+      return jsonDict;
+    }
+  }
+
 
 }

--- a/firebaseai/src/GenerationConfig.cs
+++ b/firebaseai/src/GenerationConfig.cs
@@ -219,9 +219,9 @@ namespace Firebase.AI {
 #endif
 
     /// <summary>
-    /// Initializates configuration options for Thinking features.
+    /// Initializes configuration options for Thinking features.
     /// </summary>
-    /// <param name="thinkingBudget">Number of tokens present in thoughts output.</param>
+    /// <param name="thinkingBudget">The token budget for the model's thinking process.</param>
     public ThinkingConfig(int? thinkingBudget = null) {
       ThinkingBudget = thinkingBudget;
     }

--- a/firebaseai/src/Imagen/ImagenConfig.cs
+++ b/firebaseai/src/Imagen/ImagenConfig.cs
@@ -196,7 +196,7 @@ namespace Firebase.AI {
         jsonDict["outputOptions"] = ImageFormat?.ToJson();
       }
       if (AddWatermark != null) {
-        jsonDict["addWatermark"] = AddWatermark;
+        jsonDict["addWatermark"] = AddWatermark.Value;
       }
 
       return jsonDict;


### PR DESCRIPTION
### Description
> Provide details of the change, and generalize the change in the PR title above.

Add support for defining a thinking budget, and getting a thought token count back as part of the results. Note that only newer models support this feature.
***
### Testing
> Describe how you've tested these changes.

Running the tests locally
***

### Type of Change
Place an `x` the applicable box:
- [ ] Bug fix. Add the issue # below if applicable.
- [x] New feature. A non-breaking change which adds functionality.
- [ ] Other, such as a build process or documentation change.
***

