### PR TITLE
[Firebase AI] Increase the test timeout

### DIFF
--- a/firebaseai/testapp/Assets/Firebase/Sample/FirebaseAI/UIHandlerAutomated.cs
+++ b/firebaseai/testapp/Assets/Firebase/Sample/FirebaseAI/UIHandlerAutomated.cs
@@ -120,6 +120,9 @@ namespace Firebase.Sample.FirebaseAI {
         logFunc: DebugLog
       );
 
+      // Some of the AI tests tend to take a bit longer, so increase the timeout.
+      testRunner.TestTimeoutSeconds = 120f;
+
       base.Start();
     }
 


### PR DESCRIPTION
### Description
> Provide details of the change, and generalize the change in the PR title above.

Some of the nightly tests are timing out because the youtube summary test is slow, so bump up the timeout.
***
### Testing
> Describe how you've tested these changes.

Running locally
***

### Type of Change
Place an `x` the applicable box:
- [ ] Bug fix. Add the issue # below if applicable.
- [ ] New feature. A non-breaking change which adds functionality.
- [x] Other, such as a build process or documentation change.
***

