### PR TITLE
Update the node version used by GHA tests

### DIFF
--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -398,10 +398,10 @@ jobs:
           name: 'firebase_unity_sdk.zip'
           github-token: ${{ github.token }}
           run-id: ${{ github.event.inputs.packaged_sdk_run_id }} 
-      - name: Set up Node (18)
-        uses: actions/setup-node@v3
+      - name: Set up Node (22)
+        uses: actions/setup-node@v5
         with:
-          node-version: 18.x
+          node-version: 22
       - name: Setup java for Firestore emulator
         uses: actions/setup-java@v3
         with:
@@ -510,11 +510,11 @@ jobs:
         with:
           path: testapps
           name: ${{ steps.matrix_info.outputs.artifact_path }}
-      - name: Set up Node (18)
+      - name: Set up Node (22)
         if: ${{ matrix.test_device == 'github_runner'  }}
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v5
         with:
-          node-version: 18.x
+          node-version: 22
       - name: Setup java for Firestore emulator
         if: ${{ matrix.test_device == 'github_runner'  }}
         uses: actions/setup-java@v3


### PR DESCRIPTION
### Description
> Provide details of the change, and generalize the change in the PR title above.

Update the Node version to 22 for the Firestore tests
***
### Testing
> Describe how you've tested these changes.

https://github.com/firebase/firebase-unity-sdk/actions/runs/17653629869
***

### Type of Change
Place an `x` the applicable box:
- [ ] Bug fix. Add the issue # below if applicable.
- [ ] New feature. A non-breaking change which adds functionality.
- [x] Other, such as a build process or documentation change.
***

