### PR TITLE
Update the Unity Hub mac installer to arm64

### DIFF
--- a/gha/unity/unity_installer.py
+++ b/gha/unity/unity_installer.py
@@ -86,11 +86,13 @@ BUILD_OS = (WINDOWS, MACOS, LINUX)
 SUPPORTED_PLATFORMS = (ANDROID, IOS, TVOS, WINDOWS, MACOS, LINUX, PLAYMODE)
 UNITY_VERSION_PLACEHOLDER = "unity_version_placeholder"
 
+UNITY_HUB_URL_ARM_MAC = "https://public-cdn.cloud.unity3d.com/hub/prod/UnityHubSetup-arm64.dmg"
 SETTINGS = {
   # Used for downloading Unity Hub
   "unity_hub_url": {
     WINDOWS: "https://public-cdn.cloud.unity3d.com/hub/prod/UnityHubSetup.exe",
-    MACOS: "https://public-cdn.cloud.unity3d.com/hub/prod/UnityHubSetup-arm64.dmg",
+    # Note that this is for x86 architecture. UNITY_HUB_URL_ARM_MAC above is used for arm64
+    MACOS: "https://public-cdn.cloud.unity3d.com/hub/prod/UnityHubSetup.dmg",
     LINUX: "",
   },
   # Unity Hub will be installed at this location
@@ -276,6 +278,9 @@ def install_unity_hub():
   runner_os = get_os()
   unity_hub_url = SETTINGS["unity_hub_url"][runner_os]
   if unity_hub_url:
+    # Use the overriden version if running on a Mac arm64 machine
+    if platform.system() == 'Darwin' and 'arm' in platform.machine().lower():
+      unity_hub_url = UNITY_HUB_URL_ARM_MAC
     unity_hub_installer = path.basename(unity_hub_url)
     download_unity_hub(unity_hub_url, unity_hub_installer, max_attempts=MAX_ATTEMPTS)
   if runner_os == MACOS:

--- a/gha/unity/unity_installer.py
+++ b/gha/unity/unity_installer.py
@@ -90,7 +90,7 @@ SETTINGS = {
   # Used for downloading Unity Hub
   "unity_hub_url": {
     WINDOWS: "https://public-cdn.cloud.unity3d.com/hub/prod/UnityHubSetup.exe",
-    MACOS: "https://public-cdn.cloud.unity3d.com/hub/prod/UnityHubSetup.dmg",
+    MACOS: "https://public-cdn.cloud.unity3d.com/hub/prod/UnityHubSetup-arm64.dmg",
     LINUX: "",
   },
   # Unity Hub will be installed at this location


### PR DESCRIPTION
### Description
> Provide details of the change, and generalize the change in the PR title above.

The GitHub actions started failing to install Unity correctly on Mac, seems the likely problem is it needs to use the arm64 installer, so change it to that.
***
### Testing
> Describe how you've tested these changes.

https://github.com/firebase/firebase-unity-sdk/actions/runs/17745007883
https://github.com/firebase/firebase-unity-sdk/actions/runs/17747127860
***

### Type of Change
Place an `x` the applicable box:
- [ ] Bug fix. Add the issue # below if applicable.
- [ ] New feature. A non-breaking change which adds functionality.
- [x] Other, such as a build process or documentation change.
***

