### PR TITLE
[Messaging] Improve how the Notification is passed to C#

### DIFF
--- a/docs/readme.md
+++ b/docs/readme.md
@@ -112,6 +112,8 @@ Release Notes
 ### Upcoming
 -   Changes
     - Firebase AI: Add support for enabling the model to use Code Execution.
+    - Messaging: Fix crash when deleting a Message with a Notification.
+      ([#1334](https://github.com/firebase/firebase-unity-sdk/issues/1334)).
 
 ### 13.2.0
 -   Changes

--- a/messaging/src/swig/messaging.i
+++ b/messaging/src/swig/messaging.i
@@ -179,8 +179,20 @@ public:
     if (g_message_received_callback) {
       // Copy the message so that it can be owned and cleaned up by the C#
       // proxy object.
-      Message *copy = new Message();
-      *copy = *reinterpret_cast<Message*>(message);
+      Message* original = reinterpret_cast<Message*>(message);
+      Message* copy = new Message();
+      *copy = *original;
+      // If there is a notification, create a copy of that too
+      if (original->notification) {
+        copy->notification = new Notification();
+        *copy->notification = *original->notification;
+
+        // Then, if there is an AndroidNotificationParams, we need to copy that too
+        if (original->notification->android) {
+          copy->notification->android = new AndroidNotificationParams();
+          *copy->notification->android = *original->notification->android;
+        }
+      }
       // If the callback didn't take ownership of the message, delete it.
       if (!g_message_received_callback(copy)) {
         delete copy;


### PR DESCRIPTION
### Description
> Provide details of the change, and generalize the change in the PR title above.

When passing the Message object from C++ to C#, we need to make it a deep copy, to prevent using a pointer that will be deleted when the C++ version of the Message is deleted.

#1334
***
### Testing
> Describe how you've tested these changes.


[replace this line]: # (Describe your testing in detail.)
***

### Type of Change
Place an `x` the applicable box:
- [x] Bug fix. Add the issue # below if applicable.
- [ ] New feature. A non-breaking change which adds functionality.
- [ ] Other, such as a build process or documentation change.
***

