### PR TITLE
Update the python version used by GHA runners

### DIFF
--- a/.github/workflows/build-report.yml
+++ b/.github/workflows/build-report.yml
@@ -34,7 +34,7 @@ jobs:
     - name: Setup python
       uses: actions/setup-python@v4
       with:
-        python-version: '3.8'
+        python-version: '3.9'
 
     - name: Install prerequisites
       shell: bash

--- a/.github/workflows/build_android.yml
+++ b/.github/workflows/build_android.yml
@@ -69,7 +69,7 @@ jobs:
       - name: Setup python
         uses: actions/setup-python@v4
         with:
-          python-version: '3.8'
+          python-version: '3.9'
 
       - name: Cache NDK
         id: cache_ndk

--- a/.github/workflows/build_ios.yml
+++ b/.github/workflows/build_ios.yml
@@ -70,7 +70,7 @@ jobs:
       - name: Setup python
         uses: actions/setup-python@v4
         with:
-          python-version: '3.8'
+          python-version: '3.9'
 
       - name: setup Xcode version
         run: sudo xcode-select -s /Applications/Xcode_${{ env.xcodeVersion }}.app/Contents/Developer

--- a/.github/workflows/build_linux.yml
+++ b/.github/workflows/build_linux.yml
@@ -65,7 +65,7 @@ jobs:
       - name: Setup python
         uses: actions/setup-python@v4
         with:
-          python-version: '3.8'
+          python-version: '3.9'
 
       - name: Install prerequisites
         shell: bash

--- a/.github/workflows/build_macos.yml
+++ b/.github/workflows/build_macos.yml
@@ -73,7 +73,7 @@ jobs:
       - name: Setup python
         uses: actions/setup-python@v4
         with:
-          python-version: '3.8'
+          python-version: '3.9'
 
       - name: Add msbuild to PATH (windows)
         if: startsWith(matrix.os, 'windows')

--- a/.github/workflows/build_starter.yml
+++ b/.github/workflows/build_starter.yml
@@ -58,7 +58,7 @@ on:
 permissions: write-all
 
 env:
-  pythonVersion: '3.8'
+  pythonVersion: '3.9'
 
 jobs:
   check_and_prepare:

--- a/.github/workflows/build_tvos.yml
+++ b/.github/workflows/build_tvos.yml
@@ -91,7 +91,7 @@ jobs:
       - name: Setup python
         uses: actions/setup-python@v4
         with:
-          python-version: '3.8'
+          python-version: '3.9'
 
       - name: setup Xcode version
         run: sudo xcode-select -s /Applications/Xcode_${{ env.xcodeVersion }}.app/Contents/Developer

--- a/.github/workflows/build_windows.yml
+++ b/.github/workflows/build_windows.yml
@@ -68,7 +68,7 @@ jobs:
       - name: Setup python
         uses: actions/setup-python@v4
         with:
-          python-version: '3.8'
+          python-version: '3.9'
 
       - name: Add msbuild to PATH (windows)
         uses: microsoft/setup-msbuild@v1.1

--- a/.github/workflows/generate_swig.yml
+++ b/.github/workflows/generate_swig.yml
@@ -53,7 +53,7 @@ jobs:
       - name: Setup python
         uses: actions/setup-python@v4
         with:
-          python-version: '3.8'
+          python-version: '3.9'
 
       - name: Install prerequisites
         shell: bash

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -37,7 +37,7 @@ env:
   triggerLabelPrefix: "tests-requested: "
   triggerLabelFull: "tests-requested: full"
   triggerLabelQuick: "tests-requested: quick"
-  pythonVersion: '3.8'
+  pythonVersion: '3.9'
   artifactRetentionDays: 2
 
 jobs:
@@ -190,7 +190,7 @@ jobs:
       - name: Setup python
         uses: actions/setup-python@v4
         with:
-          python-version: '3.8'
+          python-version: '3.9'
       - name: Install python deps
         timeout-minutes: 10
         shell: bash
@@ -371,7 +371,7 @@ jobs:
       - name: Setup python
         uses: actions/setup-python@v4
         with:
-          python-version: '3.8'
+          python-version: '3.9'
       - name: Install python deps
         timeout-minutes: 10
         shell: bash
@@ -497,7 +497,7 @@ jobs:
       - name: Setup python
         uses: actions/setup-python@v4
         with:
-          python-version: '3.8'
+          python-version: '3.9'
       - name: Install python deps
         timeout-minutes: 10
         shell: bash

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -94,7 +94,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v4
         with:
-          python-version: 3.8
+          python-version: 3.9
 
       - name: Install python deps
         shell: bash
@@ -277,7 +277,7 @@ jobs:
     - name: Setup python
       uses: actions/setup-python@v4
       with:
-        python-version: 3.8
+        python-version: 3.9
     - name: Generate token for GitHub API
       # This step is necessary because the existing GITHUB_TOKEN cannot be used inside one workflow to trigger another.
       # 

--- a/.github/workflows/retry-test-failures.yml
+++ b/.github/workflows/retry-test-failures.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Setup python
         uses: actions/setup-python@v4
         with:
-          python-version: 3.8
+          python-version: 3.9
 
       - uses: actions/checkout@v3
         with:

--- a/.github/workflows/update_versions.yml
+++ b/.github/workflows/update_versions.yml
@@ -112,7 +112,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v4
         with:
-          python-version: 3.8
+          python-version: 3.9
 
       - name: Install python deps
         shell: bash

--- a/editor/app/src/PythonExecutor.cs
+++ b/editor/app/src/PythonExecutor.cs
@@ -116,7 +116,7 @@ namespace Firebase.Editor {
 
         // Just 'python' might prompt the user for input, so try that last
         private static readonly string[] PYTHON_INTERPRETERS = {
-          "python3", "python3.8","python3.7", "python2.7", "python2", "python"
+          "python3", "python3.9", "python3.8","python3.7", "python2.7", "python2", "python"
         };
 
         private static string s_pythonInterpreter = null;


### PR DESCRIPTION
### Description
> Provide details of the change, and generalize the change in the PR title above.

Update the GHA runners to use Python 3.9.  This is partially because of gcloud no longer working with 3.8
***
### Testing
> Describe how you've tested these changes.

https://github.com/firebase/firebase-unity-sdk/actions/runs/18728093413
***

### Type of Change
Place an `x` the applicable box:
- [ ] Bug fix. Add the issue # below if applicable.
- [ ] New feature. A non-breaking change which adds functionality.
- [x] Other, such as a build process or documentation change.
***

