### PR TITLE
Remove extra iOS targets from GHA tests

### DIFF
--- a/scripts/gha/print_matrix_configuration.py
+++ b/scripts/gha/print_matrix_configuration.py
@@ -122,29 +122,13 @@ TEST_DEVICES = {
   "emulator_target": {"platform": ANDROID, "type": "virtual", "image": "system-images;android-28;google_apis;x86_64"},
   "emulator_latest": {"platform": ANDROID, "type": "virtual", "image": "system-images;android-30;google_apis;x86_64"},
   "emulator_32bit": {"platform": ANDROID, "type": "virtual", "image": "system-images;android-30;google_apis;x86"},
-  "ios_min": {"platform": IOS, "type": "real",
-              "device": [
-                # Slightly different OS versions because of limited FTL selection.
-                "model=iphone8,version=14.7",
-                "model=iphone11pro,version=14.7",
-                "model=iphone12pro,version=14.8",
-              ]},
   "ios_target": {"platform": IOS, "type": "real",
                  "device": [
                    # Slightly different OS versions because of limited FTL selection.
-                   "model=iphone13pro,version=15.7",
-                   "model=iphone8,version=15.7",
-                 ]},
-  "ios_latest": {"platform": IOS, "type": "real",
-                 "device": [
                    "model=iphone14pro,version=16.6",
                    "model=iphone11pro,version=16.6",
-                   "model=iphone8,version=16.6",
-                   "model=ipad10,version=16.6",
                  ]},
-  "simulator_min": {"platform": IOS, "type": "virtual", "name": "iPhone 15 Pro Max", "version": "17.0.1"},
   "simulator_target": {"platform": IOS, "type": "virtual", "name": "iPhone 15 Pro Max", "version": "17.2"},
-  "simulator_latest": {"platform": IOS, "type": "virtual", "name": "iPhone 15 Plus", "version": "17.4"},
   "tvos_simulator": {"platform": TVOS, "type": "virtual", "name": "Apple TV", "version": "16.1"},
 }
 

--- a/scripts/gha/test_simulator.py
+++ b/scripts/gha/test_simulator.py
@@ -37,7 +37,7 @@ Example:
 iPhone 8, OS 12.0:
   --ios_name "iPhone 8" --ios_version "12.0"
 Alternatively, to set an iOS device, use the one of the values below:
-[simulator_min, simulator_target, simulator_latest]
+[simulator_target]
 Example:
   --ios_device "simulator_target"
 


### PR DESCRIPTION
### Description
> Provide details of the change, and generalize the change in the PR title above.

Reduce iOS testing targets to just ios_target and simulator_target, as the Firebase Test Lab is primarily only supporting one version anymore, making the others unnecessary. Also, update the iOS models and versions to align with the ones used by the Firebase C++ repo.
***
### Testing
> Describe how you've tested these changes.


[replace this line]: # (Describe your testing in detail.)
***

### Type of Change
Place an `x` the applicable box:
- [ ] Bug fix. Add the issue # below if applicable.
- [ ] New feature. A non-breaking change which adds functionality.
- [x] Other, such as a build process or documentation change.
***

