### PR TITLE
Fix: remove the Vector SetDefaultEventParameters from being included

### DIFF
--- a/analytics/src/swig/analytics.i
+++ b/analytics/src/swig/analytics.i
@@ -125,7 +125,7 @@ void SetConsentWithInts(const std::map<int, int>& settings) {
 // Ignore the SetDefaultEventParameters that takes a Parameter array, as we
 // handle it with a custom version instead.
 %ignore firebase::analytics::SetDefaultEventParameters(const Parameter*, size_t);
-// Ignore the SetDefaulteventparameters that takes int the vector, as we
+// Ignore the SetDefaultEventParameters that takes a Parameter vector, as we
 // handle it with a custom version instead.
 %ignore firebase::analytics::SetDefaultEventParameters(const std::vector<Parameter>&);
 // Ignore SetConsent, in order to convert the types with our own function.


### PR DESCRIPTION
The documentation is referencing the C++ vector version and it should be removed.

### Description
> Provide details of the change, and generalize the change in the PR title above.

Ignoring the vector implementation of the SetDefaultEventParameters and the the LogEvent. This should prevent the autogenerate docs from including the random vector types that are not helpful for end SDK users.
***
### Testing
> Describe how you've tested these changes.


[replace this line]: # (Describe your testing in detail.)
***

### Type of Change
Place an `x` the applicable box:
- [x] Bug fix. Add the issue # below if applicable.
- [ ] New feature. A non-breaking change which adds functionality.
- [ ] Other, such as a build process or documentation change.
***

