### PR TITLE
Fix Analytics DoubleCall test

### DIFF
--- a/analytics/testapp/Assets/Firebase/Sample/Analytics/UIHandlerAutomated.cs
+++ b/analytics/testapp/Assets/Firebase/Sample/Analytics/UIHandlerAutomated.cs
@@ -147,9 +147,10 @@ namespace Firebase.Sample.Analytics {
         }
       };
       List<Task> tasks = new List<Task>();
-      tasks.Add(Firebase.FirebaseApp.CheckAndFixDependenciesAsync()
-        .ContinueWithOnMainThread(taskHandler));
       try {
+        // Put both calls in a try catch, since either can throw
+        tasks.Add(Firebase.FirebaseApp.CheckAndFixDependenciesAsync()
+          .ContinueWithOnMainThread(taskHandler));
         tasks.Add(Firebase.FirebaseApp.CheckAndFixDependenciesAsync()
           .ContinueWithOnMainThread(taskHandler));
       } catch (System.InvalidOperationException) {


### PR DESCRIPTION
### Description
> Provide details of the change, and generalize the change in the PR title above.

The Analytics test TestCheckAndFixDependenciesDoubleCall can sometimes fail because the first call throws the exception. Move both calls inside the try catch to handle that case.

Example of error: https://github.com/firebase/firebase-unity-sdk/actions/runs/21047713877/job/60533907213#step:13:327
***
### Testing
> Describe how you've tested these changes.


***

### Type of Change
Place an `x` the applicable box:
- [x] Bug fix. Add the issue # below if applicable.
- [ ] New feature. A non-breaking change which adds functionality.
- [ ] Other, such as a build process or documentation change.
***

