### PR TITLE
Add in in test retry for AI.

### DIFF
--- a/firebaseai/src/Internal/HttpHelpers.cs
+++ b/firebaseai/src/Internal/HttpHelpers.cs
@@ -16,6 +16,7 @@
 
 using System;
 using System.Net.Http;
+using System.Net;
 using System.Threading.Tasks;
 
 namespace Firebase.AI.Internal
@@ -106,12 +107,27 @@ namespace Firebase.AI.Internal
       }
 
       // Construct the exception with as much information as possible.
-      throw new HttpRequestException(
+      var ex = new HttpRequestException(
         $"HTTP request failed with status code: {(int)response.StatusCode} ({response.ReasonPhrase}).\n" +
         $"Error Content: {errorContent}",
-        null,
-        response.StatusCode
+        null
       );
+      ex.Data["StatusCode"] = response.StatusCode;
+
+      throw ex;
+    }
+  }
+
+  // Extension to get the StatusCode from the exception.
+  internal static class HttpRequestExceptionExtensions
+  {
+    internal static HttpStatusCode? GetStatusCode(this HttpRequestException exception)
+    {
+      if (exception.Data.Contains("StatusCode"))
+      {
+        return (HttpStatusCode)exception.Data["StatusCode"];
+      }
+      return null;
     }
   }
 }

--- a/firebaseai/testapp/Assets/Firebase/Sample/FirebaseAI/UIHandlerAutomated.cs
+++ b/firebaseai/testapp/Assets/Firebase/Sample/FirebaseAI/UIHandlerAutomated.cs
@@ -19,12 +19,14 @@ namespace Firebase.Sample.FirebaseAI
 {
   using Firebase;
   using Firebase.AI;
+  using Firebase.AI.Internal;
   using Firebase.Extensions;
   using System;
   using System.Collections;
   using System.Collections.Generic;
   using System.Linq;
   using System.Net.Http;
+  using System.Net;
   using System.Threading.Tasks;
   using Google.MiniJSON;
   using UnityEngine;
@@ -76,11 +78,13 @@ namespace Firebase.Sample.FirebaseAI
       }
 
       // Retry UNLESS it is a 429 and the quota is exhausted
-      if (ex is HttpRequestException httpEx && httpEx.StatusCode.HasValue)
+      var httpEx = ex as HttpRequestException;
+      if (httpEx != null)
       {
-        if (RetryableCodes.Contains(httpEx.StatusCode.Value))
+        var statusCode = httpEx.GetStatusCode();
+        if (statusCode.HasValue && RetryableCodes.Contains(statusCode.Value))
         {
-          return !(httpEx.StatusCode.Value == HttpStatusCode.TooManyRequests && IsQuotaExhausted(ex));
+          return !(statusCode.Value == HttpStatusCode.TooManyRequests && IsQuotaExhausted(ex));
         }
       }
       return false;
@@ -278,7 +282,7 @@ namespace Firebase.Sample.FirebaseAI
     }
 
     // The model name to use for the tests.
-    private readonly string TestModelName = "gemini-2.0-flash";
+    private readonly string TestModelName = "gemini-2.5-flash";
 
     private FirebaseAI GetFirebaseAI(Backend backend, string location = "us-central1")
     {


### PR DESCRIPTION
The github runners will retry but at whole sdk level. This means even if we encounter a retryable error in one test we must retry the whole product. This means we wasting our credits. In particular for our limited image generation ones. We can limit this by retrying in the test itself. The only con here is potenitaly retrying something that is doomed to fail. I have tried to put in some smarts to prevent this.

In the tests we can see a 429 resource exhausted that come in two flavours.

"code": 429,
    "message": "Resource exhausted. Please try again later. Please refer to https://cloud.google.com/vertex-ai/generative-ai/docs/error-code-429 for more details.",

and

"code": 429,
    "message": "You exceeded your current quota, please check your plan and billing details. For more information on this error, head to: https://ai.google.dev/gemini-api/docs/rate-limits. To monitor your current usage, head to: https://ai.dev/rate-limit. \n* Quota exceeded for metric: generativelanguage.googleapis.com/predict_requests_per_model_per_day_paid_tier_1, limit: 70, model: imagen-4.0-generate",

The exponential backoff should be helpful for  "Resource exhausted. Please try again later. " but no the quota exceded one.

### Description
> Provide details of the change, and generalize the change in the PR title above.

[replace this line]: # (Describe your changes in detail.)
***
### Testing
> Describe how you've tested these changes.

Tested this locally and saw some good recoveries that prevented the whole test run failing.

[replace this line]: # (Describe your testing in detail.)
***

### Type of Change
Place an `x` the applicable box:
- [ ] Bug fix. Add the issue # below if applicable.
- [ ] New feature. A non-breaking change which adds functionality.
- [X] Other, such as a build process or documentation change.
***

