### PR TITLE
Fix `xcodes` installation conflict in `test_simulator.py`

### DIFF
--- a/scripts/gha/test_simulator.py
+++ b/scripts/gha/test_simulator.py
@@ -79,6 +79,7 @@ Returns:
 import json
 import os
 import pathlib
+import shutil
 import subprocess
 import time
 import glob
@@ -400,14 +401,17 @@ def _create_and_boot_simulator(apple_platform, device_name, device_os):
 
   if not device_id:
     # download and create device
-    args = ["brew", "install", "xcodesorg/made/xcodes"]
-    logging.info("Download xcodes: %s", " ".join(args))
-    subprocess.run(args=args, check=True)
+    if not shutil.which("xcodes"):
+      args = ["brew", "install", "xcodes"]
+      logging.info("Download xcodes: %s", " ".join(args))
+      subprocess.run(args=args, check=True)
+    else:
+      logging.info("xcodes is already installed.")
 
     # Get the set of available versions for the given Apple platform
     args = ["xcodes", "runtimes"]
     runtimes = subprocess.run(args=args, capture_output=True, text=True, check=True)
-    available_versions = re.findall('{0} ([\d|.]+)'.format(apple_platform), runtimes.stdout.strip())
+    available_versions = re.findall(r'{0} ([\d|.]+)'.format(apple_platform), runtimes.stdout.strip())
     logging.info("Found available versions for %s: %s", apple_platform, ", ".join(available_versions))
 
     # If the requested version is available, use it, otherwise default to the latest


### PR DESCRIPTION
Fixes an issue where `test_simulator.py` fails on CI because of a tap conflict when attempting to install `xcodesorg/made/xcodes`, while `homebrew-core` already provides it natively on new runner images. Now it dynamically checks if `xcodes` is installed and uses the core tap otherwise.

---
*PR created automatically by Jules for task [9750456139968716017](https://jules.google.com/task/9750456139968716017) started by @AustinBenoit*