### PR TITLE
chore(tests): Increase FirebaseAI test timeout to 240 seconds

### DIFF
--- a/firebaseai/testapp/Assets/Firebase/Sample/FirebaseAI/UIHandlerAutomated.cs
+++ b/firebaseai/testapp/Assets/Firebase/Sample/FirebaseAI/UIHandlerAutomated.cs
@@ -218,7 +218,7 @@ namespace Firebase.Sample.FirebaseAI
       );
 
       // Some of the AI tests tend to take a bit longer, so increase the timeout.
-      testRunner.TestTimeoutSeconds = 120f;
+      testRunner.TestTimeoutSeconds = 240f;
 
       base.Start();
     }


### PR DESCRIPTION
Increase the timeout for FirebaseAI automated tests to prevent CI failures.

The automated AI tests have been timing out at the 120-second mark. Increasing this limit to 240 seconds allows slower-running tests to finish without triggering a timeout failure.

---
*PR created automatically by Jules for task [9103925748236399036](https://jules.google.com/task/9103925748236399036) started by @AustinBenoit*