### PR TITLE
Fix it_workflow.py crash when multiple dividers exist

### DIFF
--- a/scripts/gha/it_workflow.py
+++ b/scripts/gha/it_workflow.py
@@ -185,7 +185,7 @@ def test_report(token, actor, commit, run_id):
   """
   issue_number = _get_issue_number(token, _REPORT_TITLE, _REPORT_LABEL)
   previous_comment = firebase_github.get_issue_body(token, issue_number)
-  [previous_prefix, previous_comment_test_result] = previous_comment.split(_COMMENT_HIDDEN_DIVIDER) # TODO add more content
+  [previous_prefix, previous_comment_test_result] = previous_comment.split(_COMMENT_HIDDEN_DIVIDER, 1) # TODO add more content
   logging.info("Previous prefix: %s", previous_prefix)
   prefix = ""
   # If there is a build dashboard, preserve it.


### PR DESCRIPTION
In the `integration_tests.yml` workflow, the `summarize-results` job was failing with a `ValueError: too many values to unpack (expected 2)`.

This was caused by the `scripts/gha/it_workflow.py` script retrieving the `Nightly Integration Testing Report` GitHub issue body, and attempting to unpack `previous_comment.split(_COMMENT_HIDDEN_DIVIDER)`. If multiple test runs append this HTML divider over time, the string splits into more than 2 elements.

This PR fixes this by providing the `maxsplit=1` argument to ensure it always correctly unpacks `previous_prefix` and `previous_comment_test_result` without crashing.

---
*PR created automatically by Jules for task [8922391859756298172](https://jules.google.com/task/8922391859756298172) started by @AustinBenoit*