### PR TITLE
Fix the summary when we don't have the two parts of the comment

### DIFF
--- a/scripts/gha/it_workflow.py
+++ b/scripts/gha/it_workflow.py
@@ -185,7 +185,12 @@ def test_report(token, actor, commit, run_id):
   """
   issue_number = _get_issue_number(token, _REPORT_TITLE, _REPORT_LABEL)
   previous_comment = firebase_github.get_issue_body(token, issue_number)
-  [previous_prefix, previous_comment_test_result] = previous_comment.split(_COMMENT_HIDDEN_DIVIDER) # TODO add more content
+  parts = previous_comment.split(_COMMENT_HIDDEN_DIVIDER, 1) # TODO add more content
+  if len(parts) == 2:
+    previous_prefix, previous_comment_test_result = parts
+  else:
+    previous_prefix = previous_comment
+    previous_comment_test_result = ""
   logging.info("Previous prefix: %s", previous_prefix)
   prefix = ""
   # If there is a build dashboard, preserve it.


### PR DESCRIPTION
### Description
> Provide details of the change, and generalize the change in the PR title above.

Fix the nightly summary when we don't have the two parts of the comment. This seems to happen when there is not a comment for last time.

***
### Testing
> Describe how you've tested these changes.


Ran on the last few failed splits. It seems good now. 
***

### Type of Change
Place an `x` the applicable box:
- [ ] Bug fix. Add the issue # below if applicable.
- [ ] New feature. A non-breaking change which adds functionality.
- [X] Other, such as a build process or documentation change.
***

