### PR TITLE
[App] Add link.xml to preserve Auth types for reflection

### DIFF
--- a/app/src/internal/link.xml
+++ b/app/src/internal/link.xml
@@ -3,4 +3,7 @@
     <type fullname="Firebase.Auth.FirebaseAuth" preserve="all"/>
     <type fullname="Firebase.Auth.FirebaseUser" preserve="all"/>
   </assembly>
+  <assembly fullname="Firebase.AppCheck">
+    <type fullname="Firebase.AppCheck.FirebaseAppCheck" preserve="all"/>
+  </assembly>
 </linker>

--- a/app/src/internal/link.xml
+++ b/app/src/internal/link.xml
@@ -1,0 +1,6 @@
+<linker>
+  <assembly fullname="Firebase.Auth">
+    <type fullname="Firebase.Auth.FirebaseAuth" preserve="all"/>
+    <type fullname="Firebase.Auth.FirebaseUser" preserve="all"/>
+  </assembly>
+</linker>

--- a/app/src/internal/link.xml.meta
+++ b/app/src/internal/link.xml.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 178c4b1924574f9c95f7a7f28adfd218
+labels:
+- gvh
+- gvh_version-13.10.0
+- gvhp_exportpath-Firebase/FirebaseApp/Internal/link.xml
+timeCreated: 1480838400
+DefaultImporter:
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/app/src/internal/link.xml.meta
+++ b/app/src/internal/link.xml.meta
@@ -1,9 +1,5 @@
 fileFormatVersion: 2
 guid: 178c4b1924574f9c95f7a7f28adfd218
-labels:
-- gvh
-- gvh_version-13.10.0
-- gvhp_exportpath-Firebase/FirebaseApp/Internal/link.xml
 timeCreated: 1480838400
 DefaultImporter:
   userData:


### PR DESCRIPTION
### Description
> Provide details of the change, and generalize the change in the PR title above.
Add a `link.xml` file to the core `App` module in `app/src/internal/`. This file prevents Unity's IL2CPP compiler from aggressively stripping `Firebase.Auth` types (`FirebaseAuth` and `FirebaseUser`) when they are accessed via reflection by other modules like `Functions` or `Firebase AI` (via `FirebaseInterops.cs`).
This resolves runtime `INTERNAL` errors on iOS/tvOS where the `Functions` SDK failed to retrieve Auth tokens due to missing symbols, resulting in backend assertion failures.
***
### Testing
> Describe how you've tested these changes.
*   Verified that the `tokenTest` in the Functions integration test app passes on the iOS simulator after adding `link.xml`.
*   Verified that `link.xml` is correctly bundled in both `.unitypackage` and UPM (`.tgz`) generated artifacts via the build scripts.
*  Full run of tests verifying that they all pass
***
### Type of Change
Place an `x` the applicable box:
- [x] Bug fix. Add the issue # below if applicable.
- [ ] New feature. A non-breaking change which adds functionality.
- [ ] Other, such as a build process or documentation change.
***