### PR TITLE
Fix report build script

### DIFF
--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -743,6 +743,8 @@ jobs:
           path: test_results
           pattern: build_and_test_results-*
           merge-multiple: true
+      # Upload the combined log artifacts so report_build_status.py can download and parse
+      # the JSON results directly, which is much faster and more reliable than scraping the GitHub text logs.
       - name: Upload combined log artifacts
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -743,6 +743,12 @@ jobs:
           path: test_results
           pattern: build_and_test_results-*
           merge-multiple: true
+      - name: Upload combined log artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: build_and_test_results
+          path: test_results/*
+          retention-days: ${{ env.artifactRetentionDays }}
       # Use a different token to remove the "in-progress" label,
       # to allow the removal to trigger the "Check Labels" workflow.
       - name: Generate token for GitHub API

--- a/scripts/gha/report_build_status.py
+++ b/scripts/gha/report_build_status.py
@@ -514,13 +514,13 @@ def main(argv):
                 logging.info("Integration test %s results (via log): %s", run['id'], run['log_results'])
               else:
                 if run.get('conclusion') == 'success':
-                  run['log_success'] = True
-                  run['log_results'] = ''
+                  logging.info("Integration test %s results (via log): Success (no failure block found)", run['id'])
                 else:
                   # If we didn't find the error text we're looking for, then we must assume it failed.
                   # It was either flakiness, build failure, or no failures were reported due to missing artifacts.
                   run['log_success'] = False
                   run['log_results'] = "[BUILD] [ERROR] Unknown Error. Could not find summarize-results log failure string."
+                  logging.info("Integration test %s results (via log): %s", run['id'], run['log_results'])
         bar.next()
 
     _cache['all_days'] = all_days

--- a/scripts/gha/report_build_status.py
+++ b/scripts/gha/report_build_status.py
@@ -513,10 +513,14 @@ def main(argv):
                   run['log_results'] = m.group(1)
                 logging.info("Integration test %s results (via log): %s", run['id'], run['log_results'])
               else:
-                # If we didn't find the error text we're looking for, then we must assume it failed.
-                # It was either flakiness, build failure, or no failures were reported due to missing artifacts.
-                run['log_success'] = False
-                run['log_results'] = "[BUILD] [ERROR] Unknown Error. Could not find summarize-results log failure string."
+                if run.get('conclusion') == 'success':
+                  run['log_success'] = True
+                  run['log_results'] = ''
+                else:
+                  # If we didn't find the error text we're looking for, then we must assume it failed.
+                  # It was either flakiness, build failure, or no failures were reported due to missing artifacts.
+                  run['log_success'] = False
+                  run['log_results'] = "[BUILD] [ERROR] Unknown Error. Could not find summarize-results log failure string."
         bar.next()
 
     _cache['all_days'] = all_days


### PR DESCRIPTION
### Description
> Provide details of the change, and generalize the change in the PR title above.

Problem: The nightly integration test reporting script (report_build_status.py) was incorrectly marking successful test runs (specifically the "Test Build" and "Firestore Test Build" columns) as failures.

This happened due to a combination of two issues:

Missing Combined Artifact: The summarize-results job in integration_tests.yml downloaded and merged all the fragmented build_and_test_results-* artifacts, but it never uploaded the final combined build_and_test_results artifact. As a result, the reporting script could never find the artifact and was forced to parse the raw GitHub text logs instead.
Aggressive Fallback Logic: When parsing the raw logs of a fully successful run, the INTEGRATION TEST FAILURES block is naturally absent. Instead of recognizing the run as successful, the fallback logic incorrectly assumed the summary string was missing and injected a generic [BUILD] [ERROR] Unknown Error string, which was then parsed as a hard failure.
Solution:

integration_tests.yml: Added an actions/upload-artifact step to upload the combined build_and_test_results artifact at the end of the summarize-results job. This allows the reporting script to bypass text log scraping and parse the structured JSON directly (which is significantly faster and more reliable).
report_build_status.py: Updated the fallback logic to check if the workflow run's conclusion is
***
### Testing
> Describe how you've tested these changes.


Ran test to make sure they don't break
***

### Type of Change
Place an `x` the applicable box:
- [ ] Bug fix. Add the issue # below if applicable.
- [ ] New feature. A non-breaking change which adds functionality.
- [X] Other, such as a build process or documentation change.
***

