### PR TITLE
Improve initialization lookup to address iOS crash

### DIFF
--- a/app/src/swig/app.i
+++ b/app/src/swig/app.i
@@ -887,15 +887,12 @@ static firebase::AppOptions* AppOptionsLoadFromJsonConfig(const char* config) {
         try {
           // FirebaseAI doesn't depend on the other platforms, so the heartbeat
           // logic needs to check for it here, using reflection.
-          const string firebaseAIClassName = "Firebase.AI.FirebaseAI";
-          // Iterate over the loaded assemblies, since we don't have a known DLL name.
-          foreach (var assembly in System.AppDomain.CurrentDomain.GetAssemblies()) {
-            System.Type foundType = assembly.GetType(firebaseAIClassName, throwOnError: false, ignoreCase: false);
-            if (foundType != null) {
-              // Found the class, add the FirebaseAI heartbeat to the user agent.
-              userAgentMap["fire-vertex"] = Firebase.VersionInfo.SdkVersion;
-              break;
-            }
+          // From the asmdef file, the type should be located in the Firebase.FirebaseAI assembly.
+          System.Type foundType =
+              System.Type.GetType("Firebase.AI.FirebaseAI, Firebase.FirebaseAI", false, false);
+          if (foundType != null) {
+            // Found the class, add the FirebaseAI heartbeat to the user agent.
+            userAgentMap["fire-vertex"] = Firebase.VersionInfo.SdkVersion;
           }
         } catch {
           // Don't actually want to do anything if it fails

--- a/docs/readme.md
+++ b/docs/readme.md
@@ -111,6 +111,8 @@ Release Notes
 -------------
 ### Upcoming
 -   Changes
+    - General (iOS): Improve initialization to address intermittent crashes on iOS 26.
+      ([#1436](https://github.com/firebase/firebase-unity-sdk/issues/1436)).
     - Firebase AI: Add support for Grounding with Google Maps.
     - Storage: Added `ListAsync` API to list items and prefixes under a reference.
     - Functions: Fixed tgz export, added missing asmdef for functions. Fixes issue where Functions were not being exported correctly in the tgz build.


### PR DESCRIPTION
### Description
> Provide details of the change, and generalize the change in the PR title above.

When searching for AI Logic for heartbeat, look for the specific assembly, instead of iterating over them. This to to both improve the speed, but also because on iOS 26 this seems to be causing a rare race condition crash.
Fixes #1436
***
### Testing
> Describe how you've tested these changes.

Running locally, but wasn't able to reproduce the crash beforehand
***

### Type of Change
Place an `x` the applicable box:
- [x] Bug fix. Add the issue # below if applicable.
- [ ] New feature. A non-breaking change which adds functionality.
- [ ] Other, such as a build process or documentation change.
***

