### PR TITLE
Strip debug symbols from the Apple libraries

### DIFF
--- a/cmake/build_shared.cmake
+++ b/cmake/build_shared.cmake
@@ -116,6 +116,15 @@ function(build_firebase_shared LIBRARY_NAME ARTIFACT_NAME OUTPUT_NAME)
       COMMENT "Strip debug symbols done on final binary. lib${OUTPUT_NAME}.so")
   endif()
   
+  if(APPLE AND NOT FIREBASE_IOS_BUILD)
+    target_link_options(${shared_target} PRIVATE "-Wl,-dead_strip")
+
+    add_custom_command(TARGET ${shared_target} POST_BUILD
+      COMMAND strip -x "$<TARGET_FILE:${shared_target}>"
+      COMMENT "Stripping symbols from Mac bundle"
+    )
+  endif()
+
   unity_pack_native(${shared_target})
 
   if(ANDROID)

--- a/cmake/build_shared.cmake
+++ b/cmake/build_shared.cmake
@@ -115,13 +115,22 @@ function(build_firebase_shared LIBRARY_NAME ARTIFACT_NAME OUTPUT_NAME)
       "lib${OUTPUT_NAME}.so"
       COMMENT "Strip debug symbols done on final binary. lib${OUTPUT_NAME}.so")
   endif()
-  
-  if(APPLE AND NOT FIREBASE_IOS_BUILD)
+
+  # Strip the debug symbols from the Mac build to reduce sizes
+  if(APPLE AND NOT FIREBASE_IOS_BUILD AND NOT CMAKE_BUILD_TYPE STREQUAL "Debug")
     target_link_options(${shared_target} PRIVATE "-Wl,-dead_strip")
 
     add_custom_command(TARGET ${shared_target} POST_BUILD
-      COMMAND strip -x "$<TARGET_FILE:${shared_target}>"
+      COMMAND "${CMAKE_STRIP}" -x "$<TARGET_FILE:${shared_target}>"
       COMMENT "Stripping symbols from Mac bundle"
+    )
+  endif()
+
+  # Strip the debug symbols from the Linux build to reduce size
+  if(UNIX AND NOT APPLE AND NOT ANDROID AND NOT CMAKE_BUILD_TYPE STREQUAL "Debug")
+    add_custom_command(TARGET ${shared_target} POST_BUILD
+      COMMAND "${CMAKE_STRIP}" --strip-unneeded "$<TARGET_FILE:${shared_target}>"
+      COMMENT "Stripping symbols from Linux shared object"
     )
   endif()
 

--- a/cmake/build_universal.cmake
+++ b/cmake/build_universal.cmake
@@ -96,12 +96,21 @@ function(build_uni TARGET_LINK_LIB_NAMES PROJECT_LIST_HEADER_VARIABLE)
       COMMENT "Strip debug symbols done on final binary. lib${FIREBASE_APP_UNI_VERSIONED}.so")
   endif()
 
-  if(APPLE AND NOT FIREBASE_IOS_BUILD)
+  # Strip the debug symbols from the Mac build to reduce size
+  if(APPLE AND NOT FIREBASE_IOS_BUILD AND NOT CMAKE_BUILD_TYPE STREQUAL "Debug")
     target_link_options(firebase_app_uni PRIVATE "-Wl,-dead_strip")
 
     add_custom_command(TARGET firebase_app_uni POST_BUILD
-      COMMAND strip -x "$<TARGET_FILE:firebase_app_uni>"
+      COMMAND "${CMAKE_STRIP}" -x "$<TARGET_FILE:firebase_app_uni>"
       COMMENT "Stripping symbols from Mac bundle"
+    )
+  endif()
+
+  # Strip the debug symbols from the Linux build to reduce size
+  if(UNIX AND NOT APPLE AND NOT ANDROID AND NOT CMAKE_BUILD_TYPE STREQUAL "Debug")
+    add_custom_command(TARGET firebase_app_uni POST_BUILD
+      COMMAND "${CMAKE_STRIP}" --strip-unneeded "$<TARGET_FILE:firebase_app_uni>"
+      COMMENT "Stripping symbols from Linux shared object"
     )
   endif()
 

--- a/cmake/build_universal.cmake
+++ b/cmake/build_universal.cmake
@@ -96,6 +96,15 @@ function(build_uni TARGET_LINK_LIB_NAMES PROJECT_LIST_HEADER_VARIABLE)
       COMMENT "Strip debug symbols done on final binary. lib${FIREBASE_APP_UNI_VERSIONED}.so")
   endif()
 
+  if(APPLE AND NOT FIREBASE_IOS_BUILD)
+    target_link_options(firebase_app_uni PRIVATE "-Wl,-dead_strip")
+
+    add_custom_command(TARGET firebase_app_uni POST_BUILD
+      COMMAND strip -x "$<TARGET_FILE:firebase_app_uni>"
+      COMMENT "Stripping symbols from Mac bundle"
+    )
+  endif()
+
   unity_pack_native(firebase_app_uni)
 
   set_property(TARGET firebase_app_uni

--- a/docs/readme.md
+++ b/docs/readme.md
@@ -111,6 +111,7 @@ Release Notes
 -------------
 ### Upcoming
 -   Changes
+    - General: Strip debug symbols from Mac and Linux libraries, to reduce library size.
     - General (iOS): Improve initialization to address intermittent crashes on iOS 26.
       ([#1436](https://github.com/firebase/firebase-unity-sdk/issues/1436)).
     - Firebase AI: Add support for Grounding with Google Maps.


### PR DESCRIPTION
### Description
> Provide details of the change, and generalize the change in the PR title above.

Reduce the size of the built Apple and Linux libraries by stripping unnecessary symbols from them.
***
### Testing
> Describe how you've tested these changes.

https://github.com/firebase/firebase-unity-sdk/actions/runs/25084056378
***

### Type of Change
Place an `x` the applicable box:
- [ ] Bug fix. Add the issue # below if applicable.
- [ ] New feature. A non-breaking change which adds functionality.
- [x] Other, such as a build process or documentation change.
***

