### PR TITLE
Handle if the Unity submodule is already installed

### DIFF
--- a/gha/unity/unity_installer.py
+++ b/gha/unity/unity_installer.py
@@ -395,7 +395,16 @@ def run(command, check=True, max_attempts=1):
       if result.stderr:
         logging.info("cmd stderr: %s", result.stderr.strip())
       if check and result.returncode != 0:
-        raise subprocess.CalledProcessError(result.returncode, command, output=result.stdout, stderr=result.stderr)
+        stdout_str = result.stdout or ""
+        stderr_str = result.stderr or ""
+        if "install-modules" in command and (
+            "already installed" in stdout_str.lower() or
+            "no modules found to install" in stdout_str.lower() or
+            "already installed" in stderr_str.lower() or
+            "no modules found to install" in stderr_str.lower()):
+          logging.info("Module already installed. Treating command as successful.")
+        else:
+          raise subprocess.CalledProcessError(result.returncode, command, output=result.stdout, stderr=result.stderr)
       break
     except subprocess.SubprocessError as e:
       logging.exception("run_with_retry: %s (attempt %s of %s) FAILED: %s", command, attempt_num, max_attempts, e)

--- a/gha/unity/unity_installer.py
+++ b/gha/unity/unity_installer.py
@@ -397,11 +397,10 @@ def run(command, check=True, max_attempts=1):
       if check and result.returncode != 0:
         stdout_str = result.stdout or ""
         stderr_str = result.stderr or ""
+        output = (stdout_str + stderr_str).lower()
         if "install-modules" in command and (
-            "already installed" in stdout_str.lower() or
-            "no modules found to install" in stdout_str.lower() or
-            "already installed" in stderr_str.lower() or
-            "no modules found to install" in stderr_str.lower()):
+            "already installed" in output or
+            "no modules found to install" in output):
           logging.info("Module already installed. Treating command as successful.")
         else:
           raise subprocess.CalledProcessError(result.returncode, command, output=result.stdout, stderr=result.stderr)


### PR DESCRIPTION
### Description
> Provide details of the change, and generalize the change in the PR title above.

Sometimes a Unity submodule is installed as part of an earlier step, which results in an error being thrown when trying to install it again. Check for that error, and treat it as success.
***
### Testing
> Describe how you've tested these changes.

See tvOS build here, where it triggered:
https://github.com/firebase/firebase-unity-sdk/actions/runs/25459242222/job/74696921620#step:9:397
***

### Type of Change
Place an `x` the applicable box:
- [x] Bug fix. Add the issue # below if applicable.
- [ ] New feature. A non-breaking change which adds functionality.
- [ ] Other, such as a build process or documentation change.
***

