### PR TITLE
[Firebase AI] Rename the GroundingChunk Maps

### DIFF
--- a/firebaseai/src/GenerateContentResponse.cs
+++ b/firebaseai/src/GenerateContentResponse.cs
@@ -407,12 +407,12 @@ namespace Firebase.AI
     /// <summary>
     /// Contains details if the grounding chunk is from a Google Maps source.
     /// </summary>
-    public GoogleMapsGroundingChunk? GoogleMaps { get; }
+    public GoogleMapsGroundingChunk? Maps { get; }
 
     private GroundingChunk(WebGroundingChunk? web, GoogleMapsGroundingChunk? googleMaps)
     {
       Web = web;
-      GoogleMaps = googleMaps;
+      Maps = googleMaps;
     }
 
     internal static GroundingChunk FromJson(Dictionary<string, object> jsonDict)

--- a/firebaseai/src/GenerateContentResponse.cs
+++ b/firebaseai/src/GenerateContentResponse.cs
@@ -409,10 +409,10 @@ namespace Firebase.AI
     /// </summary>
     public GoogleMapsGroundingChunk? Maps { get; }
 
-    private GroundingChunk(WebGroundingChunk? web, GoogleMapsGroundingChunk? googleMaps)
+    private GroundingChunk(WebGroundingChunk? web, GoogleMapsGroundingChunk? maps)
     {
       Web = web;
-      Maps = googleMaps;
+      Maps = maps;
     }
 
     internal static GroundingChunk FromJson(Dictionary<string, object> jsonDict)

--- a/firebaseai/testapp/Assets/Firebase/Sample/FirebaseAI/UIHandlerAutomated.cs
+++ b/firebaseai/testapp/Assets/Firebase/Sample/FirebaseAI/UIHandlerAutomated.cs
@@ -1216,7 +1216,7 @@ namespace Firebase.Sample.FirebaseAI
       var groundingMetadata = candidate.GroundingMetadata.Value;
 
       Assert("GroundingChunks should have Maps data.",
-          groundingMetadata.GroundingChunks.Any(gc => gc.GoogleMaps != null));
+          groundingMetadata.GroundingChunks.Any(gc => gc.Maps != null));
     }
 
     // Test providing a file from a GCS bucket (Firebase Storage) to the model.
@@ -1757,8 +1757,8 @@ namespace Firebase.Sample.FirebaseAI
 
       AssertEq("GroundingChunks count", grounding.GroundingChunks.Count(), 20);
       var chunk = grounding.GroundingChunks.First();
-      Assert("GroundingChunk.GoogleMaps should not be null", chunk.GoogleMaps.HasValue);
-      var mapsChunk = chunk.GoogleMaps.Value;
+      Assert("GroundingChunk.Maps should not be null", chunk.Maps.HasValue);
+      var mapsChunk = chunk.Maps.Value;
       AssertEq("GoogleMapsGroundingChunk.Title", mapsChunk.Title, "Joe’s Pizza");
       AssertEq("GoogleMapsGroundingChunk.Uri", mapsChunk.Uri, new Uri("https://maps.google.com/?cid=10332424901773702701"));
       AssertEq("GoogleMapsGroundingChunk.PlaceId", mapsChunk.PlaceId, "places/ChIJqdNaaBVbwokRLTafYrQlZI8");


### PR DESCRIPTION
### Description
> Provide details of the change, and generalize the change in the PR title above.

Rename the GroundingChunk property GoogleMaps to Maps, to align with the other Firebase AI Logic SDKs. Note, this hasn't gone out in a release yet, so it isn't a breaking change.
***
### Testing
> Describe how you've tested these changes.


[replace this line]: # (Describe your testing in detail.)
***

### Type of Change
Place an `x` the applicable box:
- [ ] Bug fix. Add the issue # below if applicable.
- [x] New feature. A non-breaking change which adds functionality.
- [ ] Other, such as a build process or documentation change.
***

