### PR TITLE
Update Xcode versions to 26.2

### DIFF
--- a/.github/workflows/build_android.yml
+++ b/.github/workflows/build_android.yml
@@ -40,7 +40,7 @@ permissions: write-all
 jobs:
   build_android:
     name: build-android-unity${{ inputs.unity_version }}-CPP${{ inputs.firebase_cpp_sdk_version }}
-    runs-on: macos-14
+    runs-on: macos-15
     strategy:
       fail-fast: false
     env:

--- a/.github/workflows/build_ios.yml
+++ b/.github/workflows/build_ios.yml
@@ -40,12 +40,12 @@ permissions: write-all
 jobs:
   build_ios:
     name: build-ios-unity${{ inputs.unity_version }}-CPP${{ inputs.firebase_cpp_sdk_version }}
-    runs-on: macos-14
+    runs-on: macos-15
     strategy:
       fail-fast: false
 
     env:
-      xcodeVersion: "26.4"
+      xcodeVersion: "26.2"
   
     steps:
       - uses: lukka/get-cmake@latest

--- a/.github/workflows/build_ios.yml
+++ b/.github/workflows/build_ios.yml
@@ -45,7 +45,7 @@ jobs:
       fail-fast: false
 
     env:
-      xcodeVersion: "16.2"
+      xcodeVersion: "26.4"
   
     steps:
       - uses: lukka/get-cmake@latest

--- a/.github/workflows/build_macos.yml
+++ b/.github/workflows/build_macos.yml
@@ -40,7 +40,7 @@ permissions: write-all
 jobs:
   build_desktop:
     name: build-macOS-unity${{ inputs.unity_version}}-CPP${{ inputs.firebase_cpp_sdk_version }}
-    runs-on: macos-14
+    runs-on: macos-15
     strategy:
       fail-fast: false
 

--- a/.github/workflows/build_tvos.yml
+++ b/.github/workflows/build_tvos.yml
@@ -66,7 +66,7 @@ jobs:
       fail-fast: false
 
     env:
-      xcodeVersion: "16.2"
+      xcodeVersion: "26.4"
 
     steps:
       - uses: lukka/get-cmake@latest

--- a/.github/workflows/build_tvos.yml
+++ b/.github/workflows/build_tvos.yml
@@ -61,12 +61,12 @@ permissions: write-all
 jobs:
   build_tvos:
     name: build-tvos-unity${{ inputs.unity_version }}-CPP${{ inputs.firebase_cpp_sdk_version }}
-    runs-on: macos-14
+    runs-on: macos-15
     strategy:
       fail-fast: false
 
     env:
-      xcodeVersion: "26.4"
+      xcodeVersion: "26.2"
 
     steps:
       - uses: lukka/get-cmake@latest

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -191,7 +191,7 @@ jobs:
       fail-fast: false
       matrix: ${{ fromJson(needs.check_and_prepare.outputs.build_matrix) }}
     env:
-      xcodeVersion: "16.2"
+      xcodeVersion: "26.4"
     steps:
       - uses: lukka/get-cmake@latest
         with:
@@ -547,7 +547,7 @@ jobs:
       fail-fast: false
       matrix: ${{ fromJson(needs.check_and_prepare.outputs.test_matrix) }}
     env:
-      xcodeVersion: "16.2"
+      xcodeVersion: "26.4"
     steps:
       - id: matrix_info
         shell: bash

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -191,7 +191,7 @@ jobs:
       fail-fast: false
       matrix: ${{ fromJson(needs.check_and_prepare.outputs.build_matrix) }}
     env:
-      xcodeVersion: "26.4"
+      xcodeVersion: "26.2"
     steps:
       - uses: lukka/get-cmake@latest
         with:
@@ -547,7 +547,7 @@ jobs:
       fail-fast: false
       matrix: ${{ fromJson(needs.check_and_prepare.outputs.test_matrix) }}
     env:
-      xcodeVersion: "26.4"
+      xcodeVersion: "26.2"
     steps:
       - id: matrix_info
         shell: bash
@@ -836,7 +836,7 @@ jobs:
     # Our best guess is something to do with the MAC address all being the same across the Mac runners.
     # Therefore we wait for the builds to complete before returning the license.
     # Ensures that all the build and playmode tests complete before the license is returned from all the machines.
-    runs-on: macos-14
+    runs-on: macos-15
     # Wait for both build and playmode to finish before returning the license
     needs: [build_testapp, playmode_test]
     if: always()

--- a/docs/readme.md
+++ b/docs/readme.md
@@ -114,6 +114,7 @@ Release Notes
     - General: Update to Firebase C++ SDK version 13.7.0.
     - General (Android): Update to Firebase Android BoM version 34.13.0.
     - General (iOS): Update to Firebase Cocoapods version 12.13.0.
+    - General (iOS, tvOS, Desktop): iOS, tvOS, and macOS SDKs are now built using Xcode 26.2.
     - General: Strip debug symbols from Mac and Linux libraries, to reduce library size.
     - General: Enforce the Xcode CMake generator for iOS and tvOS SDKs.
     - General (iOS): Improve initialization to address intermittent crashes on iOS 26.

--- a/firebaseai/testapp/readme.md
+++ b/firebaseai/testapp/readme.md
@@ -9,7 +9,7 @@ inside the Unity Editor.
 ## Requirements
 
 * [Unity](http://unity3d.com/) The quickstart project requires 2021.3 or higher.
-* [Xcode](https://developer.apple.com/xcode/) 16.2 or higher
+* [Xcode](https://developer.apple.com/xcode/) 26.2 or higher
   (when developing for iOS).
 * [Android SDK](https://developer.android.com/studio/index.html#downloads)
   (when developing for Android).

--- a/scripts/gha/print_matrix_configuration.py
+++ b/scripts/gha/print_matrix_configuration.py
@@ -56,7 +56,7 @@ PLAYMODE = "Playmode"
 
 # GitHub Runner
 WINDOWS_RUNNER = "windows-latest"
-MACOS_RUNNER = "macos-14"
+MACOS_RUNNER = "macos-15"
 LINUX_RUNNER = "ubuntu-22.04"
 
 PARAMETERS = {

--- a/scripts/gha/print_matrix_configuration.py
+++ b/scripts/gha/print_matrix_configuration.py
@@ -124,8 +124,8 @@ TEST_DEVICES = {
                    "model=iphone14pro,version=16.6",
                    "model=iphone11pro,version=16.6",
                  ]},
-  "simulator_target": {"platform": IOS, "type": "virtual", "name": "iPhone 15 Pro Max", "version": "17.2"},
-  "tvos_simulator": {"platform": TVOS, "type": "virtual", "name": "Apple TV", "version": "16.1"},
+  "simulator_target": {"platform": IOS, "type": "virtual", "name": "iPhone 16 Pro Max", "version": "26.2"},
+  "tvos_simulator": {"platform": TVOS, "type": "virtual", "name": "Apple TV", "version": "26.2"},
 }
 
 


### PR DESCRIPTION
### Description
> Provide details of the change, and generalize the change in the PR title above.

The underlying iOS SDKs have updated their minimum Xcode version to 26.2, so do similarly for Unity. Note this also involves bumping the macos version of the runners, to a version that has that version of Xcode available.
***
### Testing
> Describe how you've tested these changes.

https://github.com/firebase/firebase-unity-sdk/actions/runs/26115690906
***

### Type of Change
Place an `x` the applicable box:
- [ ] Bug fix. Add the issue # below if applicable.
- [ ] New feature. A non-breaking change which adds functionality.
- [x] Other, such as a build process or documentation change.
***

