### PR TITLE
Fix for FTL test result flag redefinition

### DIFF
--- a/scripts/gha/read_ftl_test_result.py
+++ b/scripts/gha/read_ftl_test_result.py
@@ -44,8 +44,12 @@ from integration_testing import gcs
 
 
 FLAGS = flags.FLAGS
-flags.DEFINE_string("test_result", None, "FTL test result in JSON format.")
-flags.DEFINE_string("output_path", None, "Log will be write into this path.")
+# This script can be loaded by multiple threads at once, which can cause problems with
+# the flags, as they are defined globally, so make sure they are only defined once.
+if "test_result" not in FLAGS:
+  flags.DEFINE_string("test_result", None, "FTL test result in JSON format.")
+if "output_path" not in FLAGS:
+  flags.DEFINE_string("output_path", None, "Log will be write into this path.")
 
 @attr.s(frozen=False, eq=False)
 class Test(object):


### PR DESCRIPTION
### Description
> Provide details of the change, and generalize the change in the PR title above.

FTL runs the tests in parallel, which can cause issues with the python absl Flags, as those are defined globally. Add some basic checking, to avoid flag duplication.
***
### Testing
> Describe how you've tested these changes.

https://github.com/firebase/firebase-unity-sdk/actions/runs/26915597291
***

### Type of Change
Place an `x` the applicable box:
- [ ] Bug fix. Add the issue # below if applicable.
- [ ] New feature. A non-breaking change which adds functionality.
- [x] Other, such as a build process or documentation change.
***

