### PR TITLE
Fix Internal, Functions and FirebaseAI asmdefs to match supported platforms

### DIFF
--- a/app/src/internal/Firebase.App.Internal.asmdef
+++ b/app/src/internal/Firebase.App.Internal.asmdef
@@ -2,7 +2,16 @@
     "name": "Firebase.App.Internal",
     "rootNamespace": "Firebase.Internal",
     "references": [],
-    "includePlatforms": [],
+    "includePlatforms": [
+        "Editor",
+        "WindowsStandalone32",
+        "WindowsStandalone64",
+        "macOSStandalone",
+        "LinuxStandalone64",
+        "Android",
+        "iOS",
+        "tvOS"
+    ],
     "excludePlatforms": [],
     "allowUnsafeCode": false,
     "overrideReferences": true,

--- a/firebaseai/src/Firebase.FirebaseAI.asmdef
+++ b/firebaseai/src/Firebase.FirebaseAI.asmdef
@@ -4,7 +4,16 @@
     "references": [
         "Firebase.App.Internal"
     ],
-    "includePlatforms": [],
+    "includePlatforms": [
+        "Editor",
+        "WindowsStandalone32",
+        "WindowsStandalone64",
+        "macOSStandalone",
+        "LinuxStandalone64",
+        "Android",
+        "iOS",
+        "tvOS"
+    ],
     "excludePlatforms": [],
     "allowUnsafeCode": false,
     "overrideReferences": true,

--- a/functions/src/Firebase.Functions.asmdef
+++ b/functions/src/Firebase.Functions.asmdef
@@ -4,7 +4,16 @@
     "references": [
         "Firebase.App.Internal"
     ],
-    "includePlatforms": [],
+    "includePlatforms": [
+        "Editor",
+        "WindowsStandalone32",
+        "WindowsStandalone64",
+        "macOSStandalone",
+        "LinuxStandalone64",
+        "Android",
+        "iOS",
+        "tvOS"
+    ],
     "excludePlatforms": [],
     "allowUnsafeCode": false,
     "overrideReferences": true,


### PR DESCRIPTION
### Description
Firebase won't build on unsupported platforms such as Windows Store or platforms that are not supported by Firebase.App.dll.
Recent asmdefs for Internal, Functions and FirebaseAI do not specify included platforms and compile on all platforms. They should include the same platforms that Firebase.App.dll supports because Firebase.App.dll/Firebase.Platform.dll is referenced as **precompiledReferences** inside the asmdef. This will trigger a compile error CS0246 as it cannot reference Firebase.App.
***
### Testing
**Reproduction Steps**
Install Firebase 13.11.0 or newer. Prior versions not affected, introduced in #1439.

Build for Windows Store (UWP / WSAPlayer) and it will fail to compile when you make runtime builds. **Note:** it compiles in editor because Firebase.App.dll is included in Editor.

Once I made these changes to the package it compiled when building for Windows Store (UWP / WSAPlayer).
***
### Type of Change
- [x] Bug fix. Add the issue # below if applicable.
- [ ] New feature. A non-breaking change which adds functionality.
- [ ] Other, such as a build process or documentation change.
***

