### PR TITLE
Chore: Pin windows runners to 2022

### DIFF
--- a/.github/workflows/build_windows.yml
+++ b/.github/workflows/build_windows.yml
@@ -40,7 +40,7 @@ permissions: write-all
 jobs:
   build_desktop:
     name: build-windows-unity${{inputs.unity_version}}-CPP${{ inputs.firebase_cpp_sdk_version }}
-    runs-on: windows-latest
+    runs-on: windows-2022
     strategy:
       fail-fast: false
  

--- a/scripts/gha/print_matrix_configuration.py
+++ b/scripts/gha/print_matrix_configuration.py
@@ -55,7 +55,7 @@ TVOS = "tvOS"
 PLAYMODE = "Playmode"
 
 # GitHub Runner
-WINDOWS_RUNNER = "windows-latest"
+WINDOWS_RUNNER = "windows-2022"
 MACOS_RUNNER = "macos-15"
 LINUX_RUNNER = "ubuntu-22.04"
 


### PR DESCRIPTION
### Description
> Provide details of the change, and generalize the change in the PR title above.

The latest windows github runner windows 2026 comes with visual studio 18. Which need an updated version of Cmake (4.2+) to work. The generators concept introduced does not work with older version of cmake. Firestore still depend on Cmake 3.x feature so we cannot update Cmake While we wait for firestore updates pin windows to 2022 version.

See https://github.com/actions/runner-images/issues/14017 for more details
***
### Testing
> Describe how you've tested these changes.


Run the github actions
***

### Type of Change
Place an `x` the applicable box:
- [ ] Bug fix. Add the issue # below if applicable.
- [ ] New feature. A non-breaking change which adds functionality.
- [X] Other, such as a build process or documentation change.
***

