### PR TITLE
Upgrade JUnit 4 to 4.13.2

### DIFF
--- a/scripts/gha/integration_testing/gameloop_android/app/build.gradle
+++ b/scripts/gha/integration_testing/gameloop_android/app/build.gradle
@@ -29,7 +29,9 @@ dependencies {
     implementation 'androidx.appcompat:appcompat:1.1.0'
     implementation 'androidx.constraintlayout:constraintlayout:1.1.3'
 
-    androidTestImplementation 'androidx.test.ext:junit:1.1.1'
+    // 1.1.5 is used instead of newer versions (e.g. 1.3.0) to maintain compatibility
+    // with the project's older Kotlin (1.3.72) and Gradle (7.4.2) versions.
+    androidTestImplementation 'androidx.test.ext:junit:1.1.5'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.2.0'
     androidTestImplementation 'androidx.test.uiautomator:uiautomator:2.2.0'
 }


### PR DESCRIPTION
### Description
> Provide details of the change, and generalize the change in the PR title above.

Upgrade JUnit 4 to 4.13.2 as it is a transitive dependency of androidx.test.ext:junit upgrading to 1.1.5 will upgrade junit to the required version
***
### Testing
> Describe how you've tested these changes.


Ran full integration tests
***

### Type of Change
Place an `x` the applicable box:
- [ ] Bug fix. Add the issue # below if applicable.
- [ ] New feature. A non-breaking change which adds functionality.
- [X] Other, such as a build process or documentation change.
***

