### PR TITLE
[Functions][FirebaseAI] Safely cache AppVersion on main thread (#1506)

### DIFF
--- a/app/platform/Mono/PlatformInformation.cs
+++ b/app/platform/Mono/PlatformInformation.cs
@@ -80,6 +80,13 @@ internal static class PlatformInformation {
       return "unknown";
     }
   }
+
+  // Get the application version.
+  internal static string AppVersion {
+    get {
+      return "";
+    }
+  }
 }
 
 }  // namespace Firebase.Platform

--- a/app/platform/Unity/AssemblyInfo.cs
+++ b/app/platform/Unity/AssemblyInfo.cs
@@ -31,6 +31,7 @@ using System.Runtime.CompilerServices;
 
 [assembly: InternalsVisibleTo("Firebase.Analytics")]
 [assembly: InternalsVisibleTo("Firebase.App")]
+[assembly: InternalsVisibleTo("Firebase.App.Internal")]
 [assembly: InternalsVisibleTo("Firebase.AppCheck")]
 [assembly: InternalsVisibleTo("Firebase.Auth")]
 [assembly: InternalsVisibleTo("Firebase.Crashlytics")]

--- a/app/platform/Unity/FirebaseHandler.cs
+++ b/app/platform/Unity/FirebaseHandler.cs
@@ -187,6 +187,9 @@ internal sealed class FirebaseHandler {
         }
 
         firebaseHandler = new FirebaseHandler();
+
+        // Warm the Application.version cache on the main thread.
+        _ = PlatformInformation.AppVersion;
       }
     });
   }

--- a/app/platform/Unity/PlatformInformation.cs
+++ b/app/platform/Unity/PlatformInformation.cs
@@ -77,6 +77,21 @@ internal static class PlatformInformation {
         return runtimeVersion;
       }
   }
+
+  private static string appVersion;
+
+  // Get the application version.
+  // This should be called from the main thread after FirebaseHandler is initialized.
+  internal static string AppVersion {
+      get {
+        if (appVersion == null) {
+          appVersion = FirebaseHandler.RunOnMainThread(() => {
+              return UnityEngine.Application.version;
+          });
+        }
+        return appVersion;
+      }
+  }
 }
 
 }  // namespace Firebase

--- a/app/src/internal/FirebaseInterops.cs
+++ b/app/src/internal/FirebaseInterops.cs
@@ -149,24 +149,23 @@ namespace Firebase.Internal
       return _sdkVersionFetcher.Value;
     }
 
-    private static string _appVersion = null;
+    private static readonly Lazy<string> _appVersionFetcher = new(() =>
+    {
+      try
+      {
+        return Firebase.Platform.PlatformInformation.AppVersion ?? "";
+      }
+      catch (Exception e)
+      {
+        LogError($"Error accessing AppVersion: {e}");
+        return "";
+      }
+    });
 
     // Gets the application version from PlatformInformation.
     internal static string GetApplicationVersion()
     {
-      if (_appVersion == null)
-      {
-        try
-        {
-          _appVersion = Firebase.Platform.PlatformInformation.AppVersion;
-        }
-        catch (Exception e)
-        {
-          LogError($"Error accessing AppVersion: {e}");
-          _appVersion = "";
-        }
-      }
-      return _appVersion ?? "";
+      return _appVersionFetcher.Value;
     }
 
     // Cache the various types and methods needed for AppCheck token retrieval.

--- a/app/src/internal/FirebaseInterops.cs
+++ b/app/src/internal/FirebaseInterops.cs
@@ -149,6 +149,26 @@ namespace Firebase.Internal
       return _sdkVersionFetcher.Value;
     }
 
+    private static string _appVersion = null;
+
+    // Gets the application version from PlatformInformation.
+    internal static string GetApplicationVersion()
+    {
+      if (_appVersion == null)
+      {
+        try
+        {
+          _appVersion = Firebase.Platform.PlatformInformation.AppVersion;
+        }
+        catch (Exception e)
+        {
+          LogError($"Error accessing AppVersion: {e}");
+          _appVersion = "";
+        }
+      }
+      return _appVersion ?? "";
+    }
+
     // Cache the various types and methods needed for AppCheck token retrieval.
     private static void InitializeAppCheckReflection()
     {

--- a/app/src/internal/HttpHelpers.cs
+++ b/app/src/internal/HttpHelpers.cs
@@ -32,7 +32,7 @@ namespace Firebase.Internal
       if (FirebaseInterops.GetIsDataCollectionDefaultEnabled(firebaseApp))
       {
         request.Headers.Add("X-Firebase-AppId", firebaseApp.Options.AppId);
-        request.Headers.Add("X-Firebase-AppVersion", UnityEngine.Application.version);
+        request.Headers.Add("X-Firebase-AppVersion", FirebaseInterops.GetApplicationVersion());
       }
       // Add additional Firebase tokens to the header.
       await FirebaseInterops.AddFirebaseTokensAsync(request, firebaseApp, authPrefix, limitedUseAppCheckTokens);

--- a/docs/readme.md
+++ b/docs/readme.md
@@ -124,6 +124,9 @@ Release Notes
     - Messaging: Added new Registration methods using Installation Ids.
       Deprecated old Token based methods.
     - Remote Config: Add support for setting Custom Signals.
+    - Functions / Firebase AI: Fixed a `UnityException` thrown when invoking Cloud Functions
+      or connecting to Live Generative Models from background threads
+      ([#1506](https://github.com/firebase/firebase-unity-sdk/issues/1506)).
 
 ### 13.15.0
 -   Changes

--- a/firebaseai/src/LiveGenerativeModel.cs
+++ b/firebaseai/src/LiveGenerativeModel.cs
@@ -128,7 +128,7 @@ namespace Firebase.AI
       if (Firebase.Internal.FirebaseInterops.GetIsDataCollectionDefaultEnabled(_firebaseApp))
       {
         clientWebSocket.Options.SetRequestHeader("X-Firebase-AppId", _firebaseApp.Options.AppId);
-        clientWebSocket.Options.SetRequestHeader("X-Firebase-AppVersion", UnityEngine.Application.version);
+        clientWebSocket.Options.SetRequestHeader("X-Firebase-AppVersion", Firebase.Internal.FirebaseInterops.GetApplicationVersion());
       }
       // Add additional Firebase tokens to the header.
       await Firebase.Internal.FirebaseInterops.AddFirebaseTokensAsync(clientWebSocket, _firebaseApp, limitedUseAppCheckTokens: _useLimitedUseAppCheckTokens);

--- a/proxy/AssemblyInfoApp.cs
+++ b/proxy/AssemblyInfoApp.cs
@@ -32,6 +32,7 @@ using System.Runtime.CompilerServices;
 // Firebase App contains internals that need to be visibly to the other
 // Firebase Unity projects, so mark them as friends.
 [assembly: InternalsVisibleTo("Firebase.Analytics")]
+[assembly: InternalsVisibleTo("Firebase.App.Internal")]
 [assembly: InternalsVisibleTo("Firebase.AppCheck")]
 [assembly: InternalsVisibleTo("Firebase.Auth")]
 [assembly: InternalsVisibleTo("Firebase.Crash")]

--- a/testapp/PlatformInformation.cs
+++ b/testapp/PlatformInformation.cs
@@ -31,6 +31,10 @@ internal static class PlatformInformation {
   internal static float RealtimeSinceStartup {
     get { return 0.0f; }
   }
+
+  internal static string AppVersion {
+    get { return ""; }
+  }
 }
 
 }  // namespace Firebase


### PR DESCRIPTION
### Description
> Provide details of the change, and generalize the change in the PR title above.

Fixes #1506.

`UnityEngine.Application.version` is a main-thread-only Unity API. Accessing it directly from background threads in `HttpHelpers.cs` and `LiveGenerativeModel.cs` throws a `UnityException`, breaking Cloud Functions invocations and Live generative model connections that occur outside the main thread.

This change:
1. Adds `PlatformInformation.AppVersion` which queries `UnityEngine.Application.version` via `FirebaseHandler.RunOnMainThread(...)` and caches the result.
2. Pre-warms `PlatformInformation.AppVersion` on the main thread during `FirebaseHandler` startup (`CreatePartialOnMainThread`).
3. Adds `FirebaseInterops.GetApplicationVersion()` with safe exception fallback.
4. Uses `FirebaseInterops.GetApplicationVersion()` in `HttpHelpers.cs` and `LiveGenerativeModel.cs`.

***
### Testing
> Describe how you've tested these changes.

GitHub integration tests

***
### Type of Change
Place an `x` the applicable box:
- [x] Bug fix. Add the issue # below if applicable.
- [ ] New feature. A non-breaking change which adds functionality.
- [ ] Other, such as a build process or documentation change.
***