### PR TITLE
[FirebaseAI] Remove unnecessary ternary operators

### DIFF
--- a/firebaseai/src/GenerateContentResponse.cs
+++ b/firebaseai/src/GenerateContentResponse.cs
@@ -102,7 +102,7 @@ namespace Firebase.AI
     {
       get
       {
-        var parts = Candidates.FirstOrDefault().Content.Parts ?? Enumerable.Empty<ModelContent.Part>();
+        var parts = Candidates.FirstOrDefault().Content.Parts;
         return parts
             .OfType<ModelContent.InlineDataPart>()
             .Where(part => part.MimeType != null && part.MimeType.StartsWith("audio/"))

--- a/firebaseai/src/GenerateContentResponse.cs
+++ b/firebaseai/src/GenerateContentResponse.cs
@@ -102,7 +102,7 @@ namespace Firebase.AI
     {
       get
       {
-        var parts = Candidates.FirstOrDefault()?.Content?.Parts ?? Enumerable.Empty<ModelContent.Part>();
+        var parts = Candidates.FirstOrDefault().Content.Parts ?? Enumerable.Empty<ModelContent.Part>();
         return parts
             .OfType<ModelContent.InlineDataPart>()
             .Where(part => part.MimeType != null && part.MimeType.StartsWith("audio/"))


### PR DESCRIPTION
### Description
> Provide details of the change, and generalize the change in the PR title above.

Since Candidate and ModelContent are structs, they can't be null, so the ?. operator is unnecessary and can cause errors.
***
### Testing
> Describe how you've tested these changes.


***

### Type of Change
Place an `x` the applicable box:
- [x] Bug fix. Add the issue # below if applicable.
- [ ] New feature. A non-breaking change which adds functionality.
- [ ] Other, such as a build process or documentation change.
***

